### PR TITLE
feat(context-eval): open benchmark for context-selection tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,24 @@ task: "add rate limiting to auth"
 
 Every step is deterministic. Same input, same output. No embeddings, no random chunking.
 
+## Benchmark: context-eval
+
+Selection quality is measured, not claimed. [`context-eval/`](context-eval/)
+is an open benchmark for context-selection tools: tasks come from real git
+commits, ground truth is the files each commit actually modified, and every
+tool packs the same token budget. Current results (33 tasks, 24k budget):
+
+| Tool | Mean coverage | Tokens / coverage point |
+|------|--------------:|------------------------:|
+| `redcon` | **43.8%** | **306.8** |
+| `keyword-topk` (baseline) | 29.8% | 538.9 |
+| `aider-repomap` (real aider) | 15.3% | 533.3 |
+| `pagerank` (baseline) | 11.4% | 720.0 |
+
+Rerun it on any repo: `python context-eval/run.py --repo /path/to/repo`.
+Methodology, limitations, and how to add your own tool:
+[context-eval/README.md](context-eval/README.md).
+
 ## MCP Integration (Pull Model)
 
 Instead of pushing a 30k-token blob to your agent, Redcon exposes 6 MCP tools the agent calls on demand:

--- a/context-eval/README.md
+++ b/context-eval/README.md
@@ -1,0 +1,101 @@
+# context-eval
+
+**An open, reproducible benchmark for context-selection tools.**
+
+Every AI coding agent has to answer the same question before it calls the
+model: *which part of this repository does the current task actually need?*
+Tools that answer it (redcon, aider's repo map, embedding retrievers,
+full-repo dumpers) all claim to be good at it. None of them could be
+compared, because there was no common measurement. context-eval is that
+measurement.
+
+## How it works
+
+1. **Tasks come from real git history.** A commit is a task: the commit
+   subject is the task description an agent would receive, and the source
+   files the commit modified are the ground truth a selection tool should
+   surface. Only `feat`/`fix`/`perf`/`refactor` commits qualify - their
+   subjects describe code, not process.
+2. **No leakage.** Every tool sees the repository checked out at the
+   commit's *parent*, so nothing about the change itself is visible.
+   Newly added files are excluded from ground truth (no tool could have
+   selected a file that did not exist yet).
+3. **Same budget for everyone.** Each tool returns a ranking; the harness
+   greedily packs full file contents in that order into a fixed token
+   budget (default 24,000 tokens, chars/4 estimator for every tool).
+4. **Two metrics.**
+   - **Coverage** - share of ground-truth files inside the packed budget.
+   - **Tokens per coverage point** - `tokens_used / coverage`; what a
+     point of useful context costs. Lower is cheaper evidence.
+
+## Current results
+
+Repository: this repo (335 source files) | Budget: 24,000 tokens |
+Tasks: 33 real commits | Full table: [`results/results.md`](results/results.md)
+
+| Tool | Mean coverage | Median | Tokens / coverage point |
+|------|--------------:|-------:|------------------------:|
+| `redcon` | **43.8%** | 50.0% | **306.8** |
+| `keyword-topk` | 29.8% | 0.0% | 538.9 |
+| `aider-repomap` | 15.3% | 0.0% | 533.3 |
+| `pagerank` | 11.4% | 0.0% | 720.0 |
+| `random` | 5.8% | 0.0% | 690.0 |
+| `full-dump` | 0.0% | 0.0% | n/a |
+
+Reading of the table: task-keyword matching alone reaches ~30%, structural
+centrality alone (aider's repo map, plain PageRank) reaches 11-15%, and
+redcon's hybrid of both reaches ~44% at the lowest cost per point. Full-repo
+dumping scores zero here because under a fixed budget alphabetical packing
+exhausts tokens before reaching the relevant modules - which is exactly the
+failure mode budgets exist to expose.
+
+## Compared approaches
+
+| Adapter | What it is |
+|---------|------------|
+| `redcon` | Task-aware hybrid: keyword relevance + import-graph propagation, via the public `RedconEngine.plan()` API |
+| `aider-repomap` | The real `aider` package's `RepoMap` ranking (PageRank over tree-sitter tags), with task identifiers passed the same way aider receives them from a chat |
+| `keyword-topk` | Task-keyword matching only (path hits weighted over content hits) |
+| `pagerank` | Task-agnostic PageRank over a regex-built import graph |
+| `full-dump` | Everything in path order until the budget runs out (repomix-style) |
+| `random` | Seeded random order - the floor any real tool must clear |
+
+## Run it yourself
+
+```bash
+pip install git+https://github.com/natiixnt/ContextBudget
+pip install aider-chat   # optional, enables the aider-repomap adapter
+
+python context-eval/run.py --repo /path/to/any/git/repo --budget 24000
+python context-eval/run.py --tools redcon,keyword-topk,random   # subset
+```
+
+Any git repository with a descriptive commit history works. Results land
+in `results/results.json` and `results/results.md`.
+
+## Adding a tool
+
+An adapter is one function in
+[`contexteval/adapters.py`](contexteval/adapters.py):
+
+```python
+def my_tool_rank(task: str, root: Path, files: list[str]) -> list[str]:
+    """Return candidate files, best first. The harness handles the budget."""
+```
+
+Register it in `ADAPTERS` and it appears in every table. PRs adding tools
+or task sets are welcome - the point of this benchmark is that nobody,
+including redcon, gets to grade their own homework in private.
+
+## Honest limitations
+
+- Ground truth is "files the real commit touched". A tool that selects a
+  *better* set than the human author gets penalised; over many tasks this
+  noise averages out but individual tasks are only proxies.
+- Packing uses full file contents for every tool. redcon's symbol-level
+  compression would fit more files per budget in production, so this
+  measures pure *selection* quality, deliberately ignoring compression.
+- One repository so far. The harness runs on any git repo; results on
+  more repositories (and more tools) are the roadmap.
+- Single-commit tasks have binary coverage (0% or 100%), which is why
+  medians are coarse; means over 33 tasks are the headline metric.

--- a/context-eval/contexteval/__init__.py
+++ b/context-eval/contexteval/__init__.py
@@ -1,0 +1,20 @@
+"""context-eval: an open, reproducible benchmark for context-selection tools.
+
+Given a repository and a natural-language task, a context-selection tool
+decides which files an AI coding agent should see. context-eval measures
+how good that decision is:
+
+- tasks come from the repository's own git history (a commit is a task,
+  the files that commit modified are the ground truth),
+- every tool is evaluated at the same token budget,
+- coverage = how much of the ground truth landed in the selected context,
+- tokens per coverage point = what each point of coverage costs.
+
+The harness is tool-agnostic: adapters wrap redcon, aider's repo map,
+and simple baselines, and new adapters are a single function.
+"""
+
+from contexteval.runner import evaluate
+from contexteval.tasks import Task, extract_tasks
+
+__all__ = ["Task", "extract_tasks", "evaluate"]

--- a/context-eval/contexteval/adapters.py
+++ b/context-eval/contexteval/adapters.py
@@ -1,0 +1,240 @@
+"""Tool adapters.
+
+An adapter is a callable ``(task_description, repo_root, files) -> ranking``
+where *files* is the selection universe (repo-relative paths) and the
+returned ranking is an ordered subset of it, best candidates first. The
+runner packs files in ranking order until the token budget is exhausted,
+so adapters only decide the order, never the budget.
+
+Adapters must not look at git state newer than the checked-out tree: the
+runner hands them a worktree pinned to the task's parent commit.
+"""
+
+from __future__ import annotations
+
+import random
+import re
+from collections.abc import Callable, Iterable
+from pathlib import Path
+
+Ranking = list[str]
+Adapter = Callable[[str, Path, list[str]], Ranking]
+
+_STOPWORDS = {
+    "the",
+    "and",
+    "for",
+    "with",
+    "from",
+    "into",
+    "that",
+    "this",
+    "when",
+    "add",
+    "adds",
+    "fix",
+    "fixes",
+    "make",
+    "use",
+    "uses",
+    "via",
+    "per",
+    "all",
+    "new",
+    "now",
+    "not",
+    "are",
+    "was",
+}
+
+_WORD = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]{2,}")
+
+
+def _read(root: Path, rel: str, cap: int = 200_000) -> str:
+    try:
+        return (root / rel).read_text(encoding="utf-8", errors="replace")[:cap]
+    except OSError:
+        return ""
+
+
+def _keywords(task: str) -> list[str]:
+    words = [w.lower() for w in _WORD.findall(task)]
+    return [w for w in words if w not in _STOPWORDS]
+
+
+# ---------------------------------------------------------------------------
+# redcon
+# ---------------------------------------------------------------------------
+
+
+def redcon_rank(task: str, root: Path, files: list[str]) -> Ranking:
+    """redcon's task-aware ranking via the public engine API."""
+    from redcon.engine import RedconEngine
+
+    plan = RedconEngine().plan(task=task, repo=str(root), top_files=200)
+    universe = set(files)
+    ranking = [
+        entry["path"] for entry in plan.get("ranked_files", []) if entry.get("path") in universe
+    ]
+    return ranking
+
+
+# ---------------------------------------------------------------------------
+# aider repo map (the real thing, not a reimplementation)
+# ---------------------------------------------------------------------------
+
+
+def aider_repomap_rank(task: str, root: Path, files: list[str]) -> Ranking:
+    """File ranking from aider's RepoMap (PageRank over tree-sitter tags).
+
+    The task's identifiers are passed as ``mentioned_idents`` - the same
+    signal aider extracts from a chat conversation - so the comparison is
+    fair: both tools see the identical task text.
+    """
+    from aider.models import Model
+    from aider.repomap import RepoMap
+
+    class _SilentIO:
+        def tool_output(self, *args, **kwargs):
+            pass
+
+        def tool_warning(self, *args, **kwargs):
+            pass
+
+        def tool_error(self, *args, **kwargs):
+            pass
+
+        def read_text(self, fname):
+            try:
+                return Path(fname).read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                return ""
+
+    repo_map = RepoMap(
+        map_tokens=8192,
+        root=str(root),
+        main_model=Model("gpt-4o"),
+        io=_SilentIO(),
+        verbose=False,
+    )
+    abs_files = [str(root / f) for f in files]
+    ranked_tags = repo_map.get_ranked_tags(
+        chat_fnames=[],
+        other_fnames=abs_files,
+        mentioned_fnames=set(),
+        mentioned_idents=set(_keywords(task)),
+    )
+
+    universe = set(files)
+    ranking: Ranking = []
+    seen: set[str] = set()
+    for tag in ranked_tags:
+        rel = getattr(tag, "rel_fname", None) or (tag[0] if tag else None)
+        if isinstance(rel, str) and rel in universe and rel not in seen:
+            seen.add(rel)
+            ranking.append(rel)
+    return ranking
+
+
+# ---------------------------------------------------------------------------
+# Baselines
+# ---------------------------------------------------------------------------
+
+
+def keyword_rank(task: str, root: Path, files: list[str]) -> Ranking:
+    """Task-keyword matching only: path hits weigh more than content hits."""
+    keywords = _keywords(task)
+    scored: list[tuple[float, str]] = []
+    for rel in files:
+        path_l = rel.lower()
+        content_l = _read(root, rel).lower()
+        score = 0.0
+        for kw in keywords:
+            score += 4.0 * path_l.count(kw)
+            score += min(content_l.count(kw), 25)
+        scored.append((score, rel))
+    scored.sort(key=lambda pair: (-pair[0], pair[1]))
+    return [rel for score, rel in scored if score > 0]
+
+
+_PY_IMPORT = re.compile(r"^\s*(?:from|import)\s+([\w.]+)", re.M)
+_JS_IMPORT = re.compile(r"""(?:from\s+|require\()\s*['"]([^'"]+)['"]""")
+
+
+def pagerank_rank(task: str, root: Path, files: list[str]) -> Ranking:
+    """Task-agnostic PageRank over a regex-built import graph.
+
+    This is the structural-centrality family of approaches (what a repo map
+    gives you with no task signal). Included so the delta between
+    "task-aware" and "structure-only" is visible in one table.
+    """
+    universe = set(files)
+    by_suffix: dict[str, list[str]] = {}
+    for rel in files:
+        parts = rel.split("/")
+        for i in range(len(parts)):
+            by_suffix.setdefault("/".join(parts[i:]), []).append(rel)
+
+    def resolve_py(module: str) -> Iterable[str]:
+        base = module.replace(".", "/")
+        for cand in (f"{base}.py", f"{base}/__init__.py"):
+            yield from by_suffix.get(cand, [])
+
+    def resolve_js(spec: str, importer: str) -> Iterable[str]:
+        if not spec.startswith("."):
+            return
+        base = (Path(importer).parent / spec).as_posix()
+        base = re.sub(r"^\./", "", base).replace("../", "")
+        for ext in ("", ".ts", ".tsx", ".js", ".jsx", "/index.ts", "/index.js"):
+            cand = base + ext
+            if cand in universe:
+                yield cand
+
+    edges: dict[str, set[str]] = {rel: set() for rel in files}
+    for rel in files:
+        content = _read(root, rel)
+        if rel.endswith(".py"):
+            for module in _PY_IMPORT.findall(content):
+                edges[rel].update(t for t in resolve_py(module) if t != rel)
+        elif rel.endswith((".ts", ".tsx", ".js", ".jsx")):
+            for spec in _JS_IMPORT.findall(content):
+                edges[rel].update(t for t in resolve_js(spec, rel) if t != rel)
+
+    damping = 0.85
+    rank = dict.fromkeys(files, 1.0 / len(files))
+    for _ in range(40):
+        nxt = dict.fromkeys(files, (1.0 - damping) / len(files))
+        for src, targets in edges.items():
+            if targets:
+                share = damping * rank[src] / len(targets)
+                for dst in targets:
+                    nxt[dst] += share
+            else:
+                leak = damping * rank[src] / len(files)
+                for dst in files:
+                    nxt[dst] += leak
+        rank = nxt
+    return sorted(files, key=lambda rel: (-rank[rel], rel))
+
+
+def full_dump_rank(task: str, root: Path, files: list[str]) -> Ranking:
+    """Everything in path order until the budget runs out (repomix-style)."""
+    return sorted(files)
+
+
+def random_rank(task: str, root: Path, files: list[str]) -> Ranking:
+    """Seeded random order - the floor any real tool must clear."""
+    rng = random.Random(hash(task) & 0xFFFFFFFF)
+    shuffled = list(files)
+    rng.shuffle(shuffled)
+    return shuffled
+
+
+ADAPTERS: dict[str, Adapter] = {
+    "redcon": redcon_rank,
+    "aider-repomap": aider_repomap_rank,
+    "keyword-topk": keyword_rank,
+    "pagerank": pagerank_rank,
+    "full-dump": full_dump_rank,
+    "random": random_rank,
+}

--- a/context-eval/contexteval/report.py
+++ b/context-eval/contexteval/report.py
@@ -1,0 +1,103 @@
+"""Result aggregation and Markdown rendering."""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import asdict
+
+from contexteval.runner import TaskResult
+
+
+def aggregate(results: list[TaskResult]) -> dict:
+    tools = sorted({name for r in results for name in r.tools})
+    summary: dict[str, dict] = {}
+    for name in tools:
+        coverages = [r.tools[name].coverage_pct for r in results if name in r.tools]
+        per_point = [
+            r.tools[name].tokens_per_point
+            for r in results
+            if name in r.tools and r.tools[name].tokens_per_point is not None
+        ]
+        tokens = [r.tools[name].tokens_used for r in results if name in r.tools]
+        errors = sum(1 for r in results if name in r.tools and r.tools[name].error)
+        summary[name] = {
+            "tasks": len(coverages),
+            "mean_coverage_pct": round(statistics.fmean(coverages), 1) if coverages else 0.0,
+            "median_coverage_pct": round(statistics.median(coverages), 1) if coverages else 0.0,
+            "mean_tokens_used": int(statistics.fmean(tokens)) if tokens else 0,
+            "mean_tokens_per_coverage_point": (
+                round(statistics.fmean(per_point), 1) if per_point else None
+            ),
+            "errors": errors,
+        }
+    return summary
+
+
+def as_dict(results: list[TaskResult], *, budget: int, repo: str) -> dict:
+    return {
+        "budget_tokens": budget,
+        "repo": repo,
+        "task_count": len(results),
+        "aggregate": aggregate(results),
+        "tasks": [
+            {
+                "commit": r.task.commit[:10],
+                "description": r.task.description,
+                "ground_truth": list(r.ground_truth),
+                "universe_size": r.universe_size,
+                "tools": {name: asdict(tool) for name, tool in r.tools.items()},
+            }
+            for r in results
+        ],
+    }
+
+
+def render_markdown(results: list[TaskResult], *, budget: int, repo: str, generated: str) -> str:
+    summary = aggregate(results)
+    ordered = sorted(summary.items(), key=lambda kv: -kv[1]["mean_coverage_pct"])
+
+    lines = [
+        "# context-eval results",
+        "",
+        f"Repository: `{repo}` | Token budget: {budget:,} | "
+        f"Tasks: {len(results)} (from real git history) | Generated: {generated}",
+        "",
+        "## Aggregate",
+        "",
+        "| Tool | Mean coverage | Median coverage | Mean tokens used | Tokens / coverage point |",
+        "|------|--------------:|----------------:|-----------------:|------------------------:|",
+    ]
+    for name, row in ordered:
+        per_point = row["mean_tokens_per_coverage_point"]
+        per_point_str = f"{per_point:,.1f}" if per_point is not None else "n/a"
+        lines.append(
+            f"| `{name}` | **{row['mean_coverage_pct']:.1f}%** "
+            f"| {row['median_coverage_pct']:.1f}% "
+            f"| {row['mean_tokens_used']:,} "
+            f"| {per_point_str} |"
+        )
+
+    lines += [
+        "",
+        "Coverage: share of the files the task's real commit modified that "
+        "the tool placed inside the budget. Tokens per coverage point: mean "
+        "of per-task `tokens_used / coverage`; lower is cheaper evidence.",
+        "",
+        "## Per-task coverage",
+        "",
+    ]
+    tools = [name for name, _ in ordered]
+    header = "| Task | GT files | " + " | ".join(f"`{t}`" for t in tools) + " |"
+    sep = "|------|---------:|" + "|".join(["---:"] * len(tools)) + "|"
+    lines += [header, sep]
+    for r in results:
+        cells = []
+        for t in tools:
+            tool = r.tools.get(t)
+            cells.append(f"{tool.coverage_pct:.0f}%" if tool else "-")
+        desc = r.task.description
+        if len(desc) > 60:
+            desc = desc[:57] + "..."
+        lines.append(f"| {desc} | {len(r.ground_truth)} | " + " | ".join(cells) + " |")
+    lines.append("")
+    return "\n".join(lines)

--- a/context-eval/contexteval/runner.py
+++ b/context-eval/contexteval/runner.py
@@ -1,0 +1,144 @@
+"""Evaluation loop: worktrees, greedy packing, coverage scoring."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import traceback
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from contexteval.adapters import Adapter
+from contexteval.tasks import Task, is_source_path
+
+
+# One shared estimator for every tool keeps the comparison fair; chars/4 is
+# the same heuristic redcon documents (within ~15% of tiktoken).
+def estimate_tokens(text: str) -> int:
+    return max(1, len(text) // 4)
+
+
+@dataclass
+class ToolResult:
+    tool: str
+    coverage_pct: float
+    tokens_used: int
+    files_included: int
+    hits: int
+    error: str | None = None
+
+    @property
+    def tokens_per_point(self) -> float | None:
+        if self.coverage_pct <= 0:
+            return None
+        return self.tokens_used / self.coverage_pct
+
+
+@dataclass
+class TaskResult:
+    task: Task
+    universe_size: int
+    ground_truth: tuple[str, ...]
+    tools: dict[str, ToolResult] = field(default_factory=dict)
+
+
+def _list_universe(root: Path) -> list[str]:
+    skip_dirs = {".git", "node_modules", ".venv", "__pycache__", "dist", "build"}
+    universe: list[str] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(root).as_posix()
+        if any(part in skip_dirs for part in rel.split("/")):
+            continue
+        if is_source_path(rel):
+            universe.append(rel)
+    return universe
+
+
+def _pack(root: Path, ranking: list[str], budget: int) -> tuple[list[str], int]:
+    """Greedy fill: take files in ranking order while they fit the budget."""
+    included: list[str] = []
+    used = 0
+    for rel in ranking:
+        try:
+            cost = estimate_tokens((root / rel).read_text(encoding="utf-8", errors="replace"))
+        except OSError:
+            continue
+        if used + cost > budget:
+            continue
+        included.append(rel)
+        used += cost
+    return included, used
+
+
+def evaluate(
+    repo: Path,
+    tasks: list[Task],
+    adapters: dict[str, Adapter],
+    *,
+    budget: int = 16_000,
+    log=print,
+) -> list[TaskResult]:
+    results: list[TaskResult] = []
+    for index, task in enumerate(tasks, start=1):
+        with tempfile.TemporaryDirectory(prefix="ctxeval-") as tmp:
+            worktree = Path(tmp) / "wt"
+            subprocess.run(
+                ["git", "-C", str(repo), "worktree", "add", "--detach", str(worktree), task.parent],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            try:
+                universe = _list_universe(worktree)
+                universe_set = set(universe)
+                ground_truth = tuple(f for f in task.ground_truth if f in universe_set)
+                if not ground_truth:
+                    log(f"[{index}/{len(tasks)}] skip (ground truth empty): {task.description}")
+                    continue
+
+                task_result = TaskResult(
+                    task=task, universe_size=len(universe), ground_truth=ground_truth
+                )
+                log(
+                    f"[{index}/{len(tasks)}] {task.description}  "
+                    f"(gt={len(ground_truth)}, universe={len(universe)})"
+                )
+
+                for name, adapter in adapters.items():
+                    try:
+                        ranking = adapter(task.description, worktree, list(universe))
+                        included, used = _pack(worktree, ranking, budget)
+                        hits = sum(1 for f in ground_truth if f in set(included))
+                        coverage = 100.0 * hits / len(ground_truth)
+                        task_result.tools[name] = ToolResult(
+                            tool=name,
+                            coverage_pct=coverage,
+                            tokens_used=used,
+                            files_included=len(included),
+                            hits=hits,
+                        )
+                        log(
+                            f"    {name:<14} coverage={coverage:5.1f}%  "
+                            f"tokens={used:>6,}  files={len(included)}"
+                        )
+                    except Exception:
+                        task_result.tools[name] = ToolResult(
+                            tool=name,
+                            coverage_pct=0.0,
+                            tokens_used=0,
+                            files_included=0,
+                            hits=0,
+                            error=traceback.format_exc(limit=2),
+                        )
+                        log(f"    {name:<14} ERROR (see results.json)")
+                results.append(task_result)
+            finally:
+                subprocess.run(
+                    ["git", "-C", str(repo), "worktree", "remove", "--force", str(worktree)],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+    return results

--- a/context-eval/contexteval/tasks.py
+++ b/context-eval/contexteval/tasks.py
@@ -1,0 +1,146 @@
+"""Task extraction from git history.
+
+A benchmark task is a real commit: the commit subject is the task
+description an agent would receive, and the set of source files the commit
+modified is the ground truth a context-selection tool should surface.
+Tools are evaluated against the repository state at the commit's parent,
+so nothing about the change itself can leak into the selection.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+# File types that count as selectable source context. Ground-truth filtering
+# and the selection universe use the same set so coverage is well defined.
+SOURCE_EXTS = {
+    ".py",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".rs",
+    ".go",
+    ".java",
+    ".rb",
+    ".c",
+    ".cc",
+    ".cpp",
+    ".h",
+    ".hpp",
+    ".toml",
+    ".yml",
+    ".yaml",
+    ".sh",
+    ".sql",
+}
+
+# Directories excluded from both the universe and ground truth: generated
+# reports, prose, and the harness itself must not influence results.
+EXCLUDED_PREFIXES = (
+    "research/",
+    "docs/",
+    "examples/sample-outputs/",
+    ".github/wiki/",
+    "context-eval/",
+)
+
+_CONVENTIONAL_PREFIX = re.compile(r"^([a-z]+)(\([^)]*\))?!?:\s*")
+
+# Commit types whose subject meaningfully describes the files they touch.
+# docs/style/chore/ci subjects ("clear lint debt", "regen reports") name a
+# process, not code, so coverage against them would measure noise.
+_TASKLIKE_TYPES = {"feat", "fix", "perf", "refactor"}
+
+
+@dataclass(frozen=True)
+class Task:
+    """One benchmark task derived from a single commit."""
+
+    commit: str
+    parent: str
+    description: str
+    ground_truth: tuple[str, ...]
+
+
+def _git(repo: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout
+
+
+def is_source_path(path: str) -> bool:
+    if any(path.startswith(prefix) for prefix in EXCLUDED_PREFIXES):
+        return False
+    # Hidden directories (.github, .vscode, ...) are excluded on both sides:
+    # most context tools skip them by convention, so counting them would
+    # penalise convention-followers rather than measure selection quality.
+    if any(part.startswith(".") for part in path.split("/")[:-1]):
+        return False
+    return Path(path).suffix.lower() in SOURCE_EXTS
+
+
+def extract_tasks(
+    repo: Path,
+    *,
+    rev: str = "HEAD",
+    max_tasks: int = 20,
+    min_files: int = 1,
+    max_files: int = 8,
+) -> list[Task]:
+    """Walk the history of *rev* and turn suitable commits into tasks.
+
+    A commit qualifies when its subject is descriptive enough to act as a
+    task and it modified between *min_files* and *max_files* source files.
+    Only modified/renamed/deleted paths count as ground truth: files the
+    commit newly added did not exist at the parent state, so no selection
+    tool could have picked them.
+    """
+    tasks: list[Task] = []
+    log = _git(repo, "log", rev, "--no-merges", "--format=%H|%s")
+    for line in log.splitlines():
+        sha, _, subject = line.partition("|")
+        match = _CONVENTIONAL_PREFIX.match(subject)
+        if match and match.group(1) not in _TASKLIKE_TYPES:
+            continue
+        description = _CONVENTIONAL_PREFIX.sub("", subject).strip()
+        if len(description) < 15:
+            continue  # subjects like "wip" make meaningless tasks
+
+        name_status = _git(repo, "show", "--name-status", "--format=", sha)
+        ground_truth: set[str] = set()
+        for row in name_status.splitlines():
+            parts = row.split("\t")
+            if len(parts) < 2:
+                continue
+            status = parts[0]
+            # Renames report old and new path; the old path existed at the
+            # parent state, so that is the one a tool could have selected.
+            if status.startswith(("M", "D", "R")):
+                path = parts[1]
+            else:
+                continue  # A (added) and friends did not exist at parent
+            if is_source_path(path):
+                ground_truth.add(path)
+
+        if not (min_files <= len(ground_truth) <= max_files):
+            continue
+
+        tasks.append(
+            Task(
+                commit=sha,
+                parent=f"{sha}^",
+                description=description,
+                ground_truth=tuple(sorted(ground_truth)),
+            )
+        )
+        if len(tasks) >= max_tasks:
+            break
+    return tasks

--- a/context-eval/results/results.json
+++ b/context-eval/results/results.json
@@ -1,0 +1,2008 @@
+{
+  "budget_tokens": 24000,
+  "repo": "ContextBudget",
+  "task_count": 33,
+  "aggregate": {
+    "aider-repomap": {
+      "tasks": 33,
+      "mean_coverage_pct": 15.3,
+      "median_coverage_pct": 0.0,
+      "mean_tokens_used": 23999,
+      "mean_tokens_per_coverage_point": 533.3,
+      "errors": 0
+    },
+    "full-dump": {
+      "tasks": 33,
+      "mean_coverage_pct": 0.0,
+      "median_coverage_pct": 0.0,
+      "mean_tokens_used": 23999,
+      "mean_tokens_per_coverage_point": null,
+      "errors": 0
+    },
+    "keyword-topk": {
+      "tasks": 33,
+      "mean_coverage_pct": 29.8,
+      "median_coverage_pct": 0.0,
+      "mean_tokens_used": 23941,
+      "mean_tokens_per_coverage_point": 538.9,
+      "errors": 0
+    },
+    "pagerank": {
+      "tasks": 33,
+      "mean_coverage_pct": 11.4,
+      "median_coverage_pct": 0.0,
+      "mean_tokens_used": 23998,
+      "mean_tokens_per_coverage_point": 720.0,
+      "errors": 0
+    },
+    "random": {
+      "tasks": 33,
+      "mean_coverage_pct": 5.8,
+      "median_coverage_pct": 0.0,
+      "mean_tokens_used": 23999,
+      "mean_tokens_per_coverage_point": 690.0,
+      "errors": 0
+    },
+    "redcon": {
+      "tasks": 33,
+      "mean_coverage_pct": 43.8,
+      "median_coverage_pct": 50.0,
+      "mean_tokens_used": 23978,
+      "mean_tokens_per_coverage_point": 306.8,
+      "errors": 0
+    }
+  },
+  "tasks": [
+    {
+      "commit": "f4da3fe052",
+      "description": "repair pre-existing test_repo_map_respects_budget flake",
+      "ground_truth": [
+        "tests/test_repo_map.py"
+      ],
+      "universe_size": 335,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 0.0,
+          "tokens_used": 23953,
+          "files_included": 13,
+          "hits": 0,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 17,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 0.0,
+          "tokens_used": 23993,
+          "files_included": 12,
+          "hits": 0,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 16,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 25,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "df19ba01a8",
+      "description": "re-measure sessions with V41+V43+V49 cross-call layers enabled",
+      "ground_truth": [
+        "benchmarks/measure_sessions.py"
+      ],
+      "universe_size": 335,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 100.0,
+          "tokens_used": 23928,
+          "files_included": 14,
+          "hits": 1,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 17,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 100.0,
+          "tokens_used": 23996,
+          "files_included": 8,
+          "hits": 1,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 16,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 23998,
+          "files_included": 23,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "b945ad38b0",
+      "description": "V49 session-scoped symbol aliaser",
+      "ground_truth": [
+        "redcon/cmd/aliasing.py",
+        "redcon/cmd/pipeline.py"
+      ],
+      "universe_size": 335,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 0.0,
+          "tokens_used": 23995,
+          "files_included": 12,
+          "hits": 0,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 19,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 0.0,
+          "tokens_used": 23912,
+          "files_included": 9,
+          "hits": 0,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 16,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 23998,
+          "files_included": 24,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "c7d443b9d6",
+      "description": "V43 session-scoped content reference ledger",
+      "ground_truth": [
+        "redcon/cmd/aliasing.py",
+        "redcon/cmd/pipeline.py"
+      ],
+      "universe_size": 335,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 50.0,
+          "tokens_used": 23982,
+          "files_included": 13,
+          "hits": 1,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 19,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 0.0,
+          "tokens_used": 23987,
+          "files_included": 7,
+          "hits": 0,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 16,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 17,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "39d3a755d7",
+      "description": "pre-compile remaining inline regex patterns (V78 follow-up)",
+      "ground_truth": [
+        "redcon/cmd/compressors/sql_explain_compressor.py",
+        "redcon/compressors/symbols.py",
+        "redcon/symbols/tree_sitter.py"
+      ],
+      "universe_size": 334,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 0.0,
+          "tokens_used": 23971,
+          "files_included": 15,
+          "hits": 0,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 17,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 33.333333333333336,
+          "tokens_used": 23991,
+          "files_included": 10,
+          "hits": 1,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 16,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 23997,
+          "files_included": 16,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "b9b3dc66e4",
+      "description": "extract skeleton-clustering helper to _skeletons module",
+      "ground_truth": [
+        "redcon/cmd/compressors/test_format.py"
+      ],
+      "universe_size": 333,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 9,
+          "hits": 0,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 16,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 0.0,
+          "tokens_used": 23990,
+          "files_included": 19,
+          "hits": 0,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 16,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 23998,
+          "files_included": 19,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "29d9345754",
+      "description": "bundle stats compressor for webpack/esbuild (V63)",
+      "ground_truth": [
+        "redcon/cmd/registry.py",
+        "redcon/cmd/runner.py",
+        "redcon/cmd/types.py",
+        "tests/test_cmd_quality.py"
+      ],
+      "universe_size": 332,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 0.0,
+          "tokens_used": 23984,
+          "files_included": 14,
+          "hits": 0,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 22,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 25.0,
+          "tokens_used": 23898,
+          "files_included": 10,
+          "hits": 1,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 25.0,
+          "tokens_used": 24000,
+          "files_included": 15,
+          "hits": 1,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 23997,
+          "files_included": 21,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "d5a2c8e320",
+      "description": "lint rule-pivot COMPACT layout with min-gate (V62)",
+      "ground_truth": [
+        "redcon/cmd/compressors/lint_compressor.py"
+      ],
+      "universe_size": 332,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 100.0,
+          "tokens_used": 23941,
+          "files_included": 17,
+          "hits": 1,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 22,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 100.0,
+          "tokens_used": 23991,
+          "files_included": 11,
+          "hits": 1,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 15,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 24,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "a7ff13f241",
+      "description": "stratified file sampling for >30 test failures (V51)",
+      "ground_truth": [
+        "redcon/cmd/compressors/test_format.py"
+      ],
+      "universe_size": 332,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 100.0,
+          "tokens_used": 23998,
+          "files_included": 14,
+          "hits": 1,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 16,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 0.0,
+          "tokens_used": 23995,
+          "files_included": 10,
+          "hits": 0,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 15,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 23998,
+          "files_included": 18,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "1e55b093e9",
+      "description": "close V85 residuals on 4 schemas, enable full ENFORCE",
+      "ground_truth": [
+        "redcon/cmd/compressors/git_diff.py",
+        "redcon/cmd/compressors/git_log.py",
+        "redcon/cmd/compressors/git_status.py",
+        "redcon/cmd/compressors/json_log_compressor.py",
+        "tests/test_cmd_quality_adversarial.py"
+      ],
+      "universe_size": 332,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 0.0,
+          "tokens_used": 23998,
+          "files_included": 10,
+          "hits": 0,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 23998,
+          "files_included": 19,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 20.0,
+          "tokens_used": 23970,
+          "files_included": 7,
+          "hits": 1,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 15,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 40.0,
+          "tokens_used": 24000,
+          "files_included": 16,
+          "hits": 2,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "ceb890cbbc",
+      "description": "make V85 fuzzer per-test seed deterministic across runs",
+      "ground_truth": [
+        "tests/test_cmd_quality_adversarial.py"
+      ],
+      "universe_size": 332,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 100.0,
+          "tokens_used": 23935,
+          "files_included": 17,
+          "hits": 1,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 23998,
+          "files_included": 18,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 100.0,
+          "tokens_used": 23948,
+          "files_included": 9,
+          "hits": 1,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 15,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 17,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "32f485c255",
+      "description": "coverage delta renderer for V47 dispatcher (#114)",
+      "ground_truth": [
+        "redcon/cmd/compressors/coverage_compressor.py",
+        "redcon/cmd/delta.py",
+        "tests/test_cmd_snapshot_delta.py"
+      ],
+      "universe_size": 332,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 100.0,
+          "tokens_used": 23997,
+          "files_included": 11,
+          "hits": 3,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 33.333333333333336,
+          "tokens_used": 24000,
+          "files_included": 16,
+          "hits": 1,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 100.0,
+          "tokens_used": 23926,
+          "files_included": 9,
+          "hits": 3,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 15,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 24,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "d47ed38f41",
+      "description": "SQL EXPLAIN ANALYZE compressor (V61)",
+      "ground_truth": [
+        "redcon/cmd/registry.py",
+        "redcon/cmd/runner.py",
+        "redcon/cmd/types.py",
+        "tests/test_cmd_quality.py"
+      ],
+      "universe_size": 331,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 0.0,
+          "tokens_used": 23981,
+          "files_included": 12,
+          "hits": 0,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 50.0,
+          "tokens_used": 24000,
+          "files_included": 17,
+          "hits": 2,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 25.0,
+          "tokens_used": 23990,
+          "files_included": 11,
+          "hits": 1,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 25.0,
+          "tokens_used": 23999,
+          "files_included": 23,
+          "hits": 1,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 25.0,
+          "tokens_used": 24000,
+          "files_included": 23,
+          "hits": 1,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "d874a9a5b1",
+      "description": "coverage report compressor (V69)",
+      "ground_truth": [
+        "redcon/cmd/registry.py",
+        "redcon/cmd/runner.py",
+        "redcon/cmd/types.py",
+        "tests/test_cmd_quality.py"
+      ],
+      "universe_size": 330,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 0.0,
+          "tokens_used": 23996,
+          "files_included": 12,
+          "hits": 0,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 50.0,
+          "tokens_used": 23999,
+          "files_included": 17,
+          "hits": 2,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 0.0,
+          "tokens_used": 23961,
+          "files_included": 10,
+          "hits": 0,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 25.0,
+          "tokens_used": 23997,
+          "files_included": 18,
+          "hits": 1,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 25.0,
+          "tokens_used": 23998,
+          "files_included": 27,
+          "hits": 1,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "2051330c6a",
+      "description": "NDJSON log compressor with schema-mining (V65)",
+      "ground_truth": [
+        "redcon/cmd/registry.py",
+        "redcon/cmd/runner.py",
+        "redcon/cmd/types.py",
+        "tests/test_cmd_quality.py"
+      ],
+      "universe_size": 329,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 0.0,
+          "tokens_used": 23941,
+          "files_included": 9,
+          "hits": 0,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 50.0,
+          "tokens_used": 24000,
+          "files_included": 18,
+          "hits": 2,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 25.0,
+          "tokens_used": 23980,
+          "files_included": 13,
+          "hits": 1,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 25.0,
+          "tokens_used": 24000,
+          "files_included": 19,
+          "hits": 1,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 23997,
+          "files_included": 24,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "4731960e96",
+      "description": "profiler collapsed-stack compressor (V70)",
+      "ground_truth": [
+        "redcon/cmd/registry.py",
+        "redcon/cmd/runner.py",
+        "redcon/cmd/types.py",
+        "tests/test_cmd_quality.py"
+      ],
+      "universe_size": 328,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 0.0,
+          "tokens_used": 23960,
+          "files_included": 10,
+          "hits": 0,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 24,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 50.0,
+          "tokens_used": 23973,
+          "files_included": 10,
+          "hits": 2,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 25.0,
+          "tokens_used": 24000,
+          "files_included": 22,
+          "hits": 1,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 23,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "f99acb163f",
+      "description": "schema-aware V47 deltas for pytest + git_diff",
+      "ground_truth": [
+        "redcon/cmd/compressors/git_diff.py",
+        "redcon/cmd/compressors/pytest_compressor.py",
+        "redcon/cmd/delta.py",
+        "redcon/cmd/pipeline.py",
+        "tests/test_cmd_snapshot_delta.py"
+      ],
+      "universe_size": 328,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 80.0,
+          "tokens_used": 23997,
+          "files_included": 14,
+          "hits": 4,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 20.0,
+          "tokens_used": 24000,
+          "files_included": 20,
+          "hits": 1,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 40.0,
+          "tokens_used": 23999,
+          "files_included": 11,
+          "hits": 2,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 23997,
+          "files_included": 20,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 18,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "6730c48c47",
+      "description": "git_status header inflation fallback (V85 finding 3)",
+      "ground_truth": [
+        "redcon/cmd/compressors/git_status.py"
+      ],
+      "universe_size": 328,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 100.0,
+          "tokens_used": 23981,
+          "files_included": 20,
+          "hits": 1,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 100.0,
+          "tokens_used": 23997,
+          "files_included": 24,
+          "hits": 1,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 0.0,
+          "tokens_used": 23928,
+          "files_included": 7,
+          "hits": 0,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 23997,
+          "files_included": 20,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 23,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "b0a41836e2",
+      "description": "align ls/tree/find must-preserve patterns with formatter (V85 finding 2)",
+      "ground_truth": [
+        "redcon/cmd/compressors/listing_compressor.py"
+      ],
+      "universe_size": 328,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 100.0,
+          "tokens_used": 23994,
+          "files_included": 13,
+          "hits": 1,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 18,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 100.0,
+          "tokens_used": 23966,
+          "files_included": 8,
+          "hits": 1,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 23997,
+          "files_included": 20,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 21,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "add62c11ae",
+      "description": "align git_log parser+regex+formatter (V85 finding 1)",
+      "ground_truth": [
+        "redcon/cmd/compressors/git_log.py"
+      ],
+      "universe_size": 328,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 100.0,
+          "tokens_used": 23991,
+          "files_included": 15,
+          "hits": 1,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 100.0,
+          "tokens_used": 23999,
+          "files_included": 23,
+          "hits": 1,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 0.0,
+          "tokens_used": 23839,
+          "files_included": 4,
+          "hits": 0,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 23997,
+          "files_included": 20,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "e2fd08bb4f",
+      "description": "snapshot-delta framework + git_status hookup (V47)",
+      "ground_truth": [
+        "redcon/cmd/pipeline.py"
+      ],
+      "universe_size": 325,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 14,
+          "hits": 0,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 20,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 0.0,
+          "tokens_used": 23974,
+          "files_included": 6,
+          "hits": 0,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 23997,
+          "files_included": 20,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 100.0,
+          "tokens_used": 23994,
+          "files_included": 31,
+          "hits": 1,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "c3ea8fa0a7",
+      "description": "session-scoped path aliases at egress (V41)",
+      "ground_truth": [
+        "redcon/cmd/pipeline.py"
+      ],
+      "universe_size": 324,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 0.0,
+          "tokens_used": 23983,
+          "files_included": 12,
+          "hits": 0,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 21,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 0.0,
+          "tokens_used": 23997,
+          "files_included": 9,
+          "hits": 0,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 23997,
+          "files_included": 20,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 22,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "a88abf1c73",
+      "description": "cluster duplicate test failures with min-gate (V64)",
+      "ground_truth": [
+        "redcon/cmd/compressors/test_format.py"
+      ],
+      "universe_size": 324,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 100.0,
+          "tokens_used": 23956,
+          "files_included": 19,
+          "hits": 1,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 22,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 0.0,
+          "tokens_used": 23988,
+          "files_included": 10,
+          "hits": 0,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 23997,
+          "files_included": 20,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 19,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "e593cbc1b8",
+      "description": "specialise kubectl events compressor",
+      "ground_truth": [
+        "redcon/cmd/compressors/kubectl_compressor.py",
+        "redcon/cmd/types.py"
+      ],
+      "universe_size": 324,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 50.0,
+          "tokens_used": 23995,
+          "files_included": 10,
+          "hits": 1,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 50.0,
+          "tokens_used": 24000,
+          "files_included": 20,
+          "hits": 1,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 50.0,
+          "tokens_used": 23893,
+          "files_included": 11,
+          "hits": 1,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 50.0,
+          "tokens_used": 23996,
+          "files_included": 21,
+          "hits": 1,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 14,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "0b4319ead0",
+      "description": "stamp invariant-cert sha prefix on compact/verbose",
+      "ground_truth": [
+        "redcon/cmd/compressors/base.py",
+        "redcon/cmd/pipeline.py"
+      ],
+      "universe_size": 324,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 50.0,
+          "tokens_used": 23989,
+          "files_included": 15,
+          "hits": 1,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 18,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 0.0,
+          "tokens_used": 23952,
+          "files_included": 11,
+          "hits": 0,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 50.0,
+          "tokens_used": 23997,
+          "files_included": 16,
+          "hits": 1,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 20,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "b0b25ce75c",
+      "description": "inject NO_COLOR + strip ANSI escapes pre-compress",
+      "ground_truth": [
+        "redcon/cmd/pipeline.py",
+        "redcon/cmd/runner.py"
+      ],
+      "universe_size": 324,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 0.0,
+          "tokens_used": 23963,
+          "files_included": 14,
+          "hits": 0,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 18,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 9,
+          "hits": 0,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 23997,
+          "files_included": 16,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 32,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "ffa8842e01",
+      "description": "tokenizer-aware substitution table for compact/ultra",
+      "ground_truth": [
+        "redcon/cmd/pipeline.py"
+      ],
+      "universe_size": 323,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 0.0,
+          "tokens_used": 23979,
+          "files_included": 16,
+          "hits": 0,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 18,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 0.0,
+          "tokens_used": 23896,
+          "files_included": 11,
+          "hits": 0,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 23997,
+          "files_included": 16,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 15,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "b234f3b040",
+      "description": "tighten ', ' and ': ' whitespace post-normalise",
+      "ground_truth": [
+        "redcon/cmd/pipeline.py"
+      ],
+      "universe_size": 323,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 100.0,
+          "tokens_used": 23964,
+          "files_included": 19,
+          "hits": 1,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 21,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 0.0,
+          "tokens_used": 23889,
+          "files_included": 14,
+          "hits": 0,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 23997,
+          "files_included": 16,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 22,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "16d2ef776e",
+      "description": "memoise compiled regex in verify_must_preserve",
+      "ground_truth": [
+        "redcon/cmd/compressors/base.py"
+      ],
+      "universe_size": 323,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 100.0,
+          "tokens_used": 23998,
+          "files_included": 17,
+          "hits": 1,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 21,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 100.0,
+          "tokens_used": 23533,
+          "files_included": 11,
+          "hits": 1,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 100.0,
+          "tokens_used": 24000,
+          "files_included": 11,
+          "hits": 1,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 23,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "bf860c186c",
+      "description": "--baseline gating for cmd-bench + bundled cmd_baseline.json (T4.B)",
+      "ground_truth": [
+        "redcon/cli.py",
+        "redcon/cmd/benchmark.py"
+      ],
+      "universe_size": 322,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 50.0,
+          "tokens_used": 23961,
+          "files_included": 12,
+          "hits": 1,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 25,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 50.0,
+          "tokens_used": 23996,
+          "files_included": 9,
+          "hits": 1,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 11,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 17,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "dbe5c3bf5e",
+      "description": "blend PageRank with engine ranker (T4.A3)",
+      "ground_truth": [
+        "redcon/repo_map.py"
+      ],
+      "universe_size": 322,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 0.0,
+          "tokens_used": 23986,
+          "files_included": 8,
+          "hits": 0,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 19,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 0.0,
+          "tokens_used": 23991,
+          "files_included": 6,
+          "hits": 0,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 11,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 23998,
+          "files_included": 19,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "a601fd33fd",
+      "description": "extract_imports() across Python/TS/JS/Rust/Go/Java/Ruby/C/C++",
+      "ground_truth": [
+        "redcon/symbols/__init__.py",
+        "redcon/symbols/tree_sitter.py",
+        "tests/test_symbols_tree_sitter.py"
+      ],
+      "universe_size": 320,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 66.66666666666667,
+          "tokens_used": 24000,
+          "files_included": 12,
+          "hits": 2,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 17,
+          "hits": 0,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 66.66666666666667,
+          "tokens_used": 23879,
+          "files_included": 7,
+          "hits": 2,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 11,
+          "hits": 0,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 23,
+          "hits": 0,
+          "error": null
+        }
+      }
+    },
+    {
+      "commit": "2da94108b5",
+      "description": "LLMLingua-2 opt-in semantic fallback (T3.D)",
+      "ground_truth": [
+        "redcon/cmd/budget.py",
+        "redcon/cmd/pipeline.py"
+      ],
+      "universe_size": 318,
+      "tools": {
+        "redcon": {
+          "tool": "redcon",
+          "coverage_pct": 0.0,
+          "tokens_used": 23990,
+          "files_included": 20,
+          "hits": 0,
+          "error": null
+        },
+        "aider-repomap": {
+          "tool": "aider-repomap",
+          "coverage_pct": 50.0,
+          "tokens_used": 24000,
+          "files_included": 17,
+          "hits": 1,
+          "error": null
+        },
+        "keyword-topk": {
+          "tool": "keyword-topk",
+          "coverage_pct": 0.0,
+          "tokens_used": 23864,
+          "files_included": 5,
+          "hits": 0,
+          "error": null
+        },
+        "pagerank": {
+          "tool": "pagerank",
+          "coverage_pct": 50.0,
+          "tokens_used": 23997,
+          "files_included": 16,
+          "hits": 1,
+          "error": null
+        },
+        "full-dump": {
+          "tool": "full-dump",
+          "coverage_pct": 0.0,
+          "tokens_used": 23999,
+          "files_included": 27,
+          "hits": 0,
+          "error": null
+        },
+        "random": {
+          "tool": "random",
+          "coverage_pct": 0.0,
+          "tokens_used": 24000,
+          "files_included": 17,
+          "hits": 0,
+          "error": null
+        }
+      }
+    }
+  ],
+  "generated": "2026-07-07"
+}

--- a/context-eval/results/results.md
+++ b/context-eval/results/results.md
@@ -1,0 +1,54 @@
+# context-eval results
+
+Repository: `ContextBudget` | Token budget: 24,000 | Tasks: 33 (from real git history) | Generated: 2026-07-07
+
+## Aggregate
+
+| Tool | Mean coverage | Median coverage | Mean tokens used | Tokens / coverage point |
+|------|--------------:|----------------:|-----------------:|------------------------:|
+| `redcon` | **43.8%** | 50.0% | 23,978 | 306.8 |
+| `keyword-topk` | **29.8%** | 0.0% | 23,941 | 538.9 |
+| `aider-repomap` | **15.3%** | 0.0% | 23,999 | 533.3 |
+| `pagerank` | **11.4%** | 0.0% | 23,998 | 720.0 |
+| `random` | **5.8%** | 0.0% | 23,999 | 690.0 |
+| `full-dump` | **0.0%** | 0.0% | 23,999 | n/a |
+
+Coverage: share of the files the task's real commit modified that the tool placed inside the budget. Tokens per coverage point: mean of per-task `tokens_used / coverage`; lower is cheaper evidence.
+
+## Per-task coverage
+
+| Task | GT files | `redcon` | `keyword-topk` | `aider-repomap` | `pagerank` | `random` | `full-dump` |
+|------|---------:|---:|---:|---:|---:|---:|---:|
+| repair pre-existing test_repo_map_respects_budget flake | 1 | 0% | 0% | 0% | 0% | 0% | 0% |
+| re-measure sessions with V41+V43+V49 cross-call layers en... | 1 | 100% | 100% | 0% | 0% | 0% | 0% |
+| V49 session-scoped symbol aliaser | 2 | 0% | 0% | 0% | 0% | 0% | 0% |
+| V43 session-scoped content reference ledger | 2 | 50% | 0% | 0% | 0% | 0% | 0% |
+| pre-compile remaining inline regex patterns (V78 follow-up) | 3 | 0% | 33% | 0% | 0% | 0% | 0% |
+| extract skeleton-clustering helper to _skeletons module | 1 | 0% | 0% | 0% | 0% | 0% | 0% |
+| bundle stats compressor for webpack/esbuild (V63) | 4 | 0% | 25% | 0% | 25% | 0% | 0% |
+| lint rule-pivot COMPACT layout with min-gate (V62) | 1 | 100% | 100% | 0% | 0% | 0% | 0% |
+| stratified file sampling for >30 test failures (V51) | 1 | 100% | 0% | 0% | 0% | 0% | 0% |
+| close V85 residuals on 4 schemas, enable full ENFORCE | 5 | 0% | 20% | 0% | 0% | 40% | 0% |
+| make V85 fuzzer per-test seed deterministic across runs | 1 | 100% | 100% | 0% | 0% | 0% | 0% |
+| coverage delta renderer for V47 dispatcher (#114) | 3 | 100% | 100% | 33% | 0% | 0% | 0% |
+| SQL EXPLAIN ANALYZE compressor (V61) | 4 | 0% | 25% | 50% | 25% | 25% | 0% |
+| coverage report compressor (V69) | 4 | 0% | 0% | 50% | 25% | 25% | 0% |
+| NDJSON log compressor with schema-mining (V65) | 4 | 0% | 25% | 50% | 25% | 0% | 0% |
+| profiler collapsed-stack compressor (V70) | 4 | 0% | 50% | 0% | 25% | 0% | 0% |
+| schema-aware V47 deltas for pytest + git_diff | 5 | 80% | 40% | 20% | 0% | 0% | 0% |
+| git_status header inflation fallback (V85 finding 3) | 1 | 100% | 0% | 100% | 0% | 0% | 0% |
+| align ls/tree/find must-preserve patterns with formatter ... | 1 | 100% | 100% | 0% | 0% | 0% | 0% |
+| align git_log parser+regex+formatter (V85 finding 1) | 1 | 100% | 0% | 100% | 0% | 0% | 0% |
+| snapshot-delta framework + git_status hookup (V47) | 1 | 0% | 0% | 0% | 0% | 100% | 0% |
+| session-scoped path aliases at egress (V41) | 1 | 0% | 0% | 0% | 0% | 0% | 0% |
+| cluster duplicate test failures with min-gate (V64) | 1 | 100% | 0% | 0% | 0% | 0% | 0% |
+| specialise kubectl events compressor | 2 | 50% | 50% | 50% | 50% | 0% | 0% |
+| stamp invariant-cert sha prefix on compact/verbose | 2 | 50% | 0% | 0% | 50% | 0% | 0% |
+| inject NO_COLOR + strip ANSI escapes pre-compress | 2 | 0% | 0% | 0% | 0% | 0% | 0% |
+| tokenizer-aware substitution table for compact/ultra | 1 | 0% | 0% | 0% | 0% | 0% | 0% |
+| tighten ', ' and ': ' whitespace post-normalise | 1 | 100% | 0% | 0% | 0% | 0% | 0% |
+| memoise compiled regex in verify_must_preserve | 1 | 100% | 100% | 0% | 100% | 0% | 0% |
+| --baseline gating for cmd-bench + bundled cmd_baseline.js... | 2 | 50% | 50% | 0% | 0% | 0% | 0% |
+| blend PageRank with engine ranker (T4.A3) | 1 | 0% | 0% | 0% | 0% | 0% | 0% |
+| extract_imports() across Python/TS/JS/Rust/Go/Java/Ruby/C... | 3 | 67% | 67% | 0% | 0% | 0% | 0% |
+| LLMLingua-2 opt-in semantic fallback (T3.D) | 2 | 0% | 0% | 50% | 50% | 0% | 0% |

--- a/context-eval/run.py
+++ b/context-eval/run.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""context-eval CLI.
+
+Usage:
+    python context-eval/run.py --repo . --budget 16000 --max-tasks 20
+    python context-eval/run.py --tools redcon,keyword-topk,random
+
+Writes results/results.json and results/results.md next to this script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_here = Path(__file__).resolve().parent
+sys.path.insert(0, str(_here))
+sys.path.insert(0, str(_here.parent))  # import redcon from the repo checkout
+
+from contexteval.adapters import ADAPTERS  # noqa: E402
+from contexteval.report import as_dict, render_markdown  # noqa: E402
+from contexteval.runner import evaluate  # noqa: E402
+from contexteval.tasks import extract_tasks  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run the context-eval benchmark.")
+    parser.add_argument("--repo", default=str(_here.parent), help="Repository to evaluate on")
+    parser.add_argument("--rev", default="HEAD", help="History to draw tasks from")
+    parser.add_argument("--budget", type=int, default=24_000, help="Token budget per task")
+    parser.add_argument("--max-tasks", type=int, default=33)
+    parser.add_argument(
+        "--tools",
+        default="all",
+        help="Comma-separated adapter names (default: all of " + ",".join(ADAPTERS) + ")",
+    )
+    parser.add_argument("--out", default=str(_here / "results"))
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    if args.tools == "all":
+        adapters = dict(ADAPTERS)
+    else:
+        adapters = {name: ADAPTERS[name] for name in args.tools.split(",")}
+
+    tasks = extract_tasks(repo, rev=args.rev, max_tasks=args.max_tasks)
+    if not tasks:
+        print("No usable tasks found in git history.", file=sys.stderr)
+        return 1
+    print(f"Extracted {len(tasks)} tasks from {repo}")
+
+    results = evaluate(repo, tasks, adapters, budget=args.budget)
+
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    payload = as_dict(results, budget=args.budget, repo=repo.name)
+    payload["generated"] = generated
+    (out_dir / "results.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    markdown = render_markdown(results, budget=args.budget, repo=repo.name, generated=generated)
+    (out_dir / "results.md").write_text(markdown, encoding="utf-8")
+
+    print()
+    print(markdown.split("## Per-task", 1)[0])
+    print(f"Wrote {out_dir / 'results.json'} and {out_dir / 'results.md'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds `context-eval/`: an open, tool-agnostic benchmark that measures how well context-selection tools pick the files a coding task actually needs, with committed, reproducible results comparing redcon against the real aider repo map and four baselines.

## Problem

Every context-selection tool (redcon included) claims to select the right files, and none of the claims were comparable because no common measurement existed. The benchmark needs to be public and rerunnable so redcon's numbers can be verified by anyone instead of taken on faith.

## Approach

- **Tasks from real git history**: a `feat`/`fix`/`perf`/`refactor` commit is a task; its subject is the task description; the source files it modified are the ground truth. Tools are evaluated against a worktree at the commit's parent, so nothing about the change leaks. Newly added files are excluded from ground truth. Hidden directories are excluded on both sides.
- **Same budget, same estimator**: each adapter returns a file ranking; the harness greedily packs full file contents into a fixed budget (24k default) using one chars/4 estimator for every tool, isolating selection quality from compression.
- **Metrics**: coverage (share of ground-truth files inside the budget) and tokens per coverage point.
- **Adapters**: `redcon`, `aider-repomap` (the actual `aider` RepoMap ranking), `keyword-topk`, `pagerank`, `full-dump`, `random`.
- **Committed results** (33 tasks): redcon 43.8% mean coverage at 306.8 tokens/point; keyword-only 29.8%; real aider repo map 15.3%; pagerank 11.4%; random 5.8%. The README documents methodology and honest limitations (proxy ground truth, selection-only packing, one repository so far).
- Root README gains a Benchmark section linking to the harness.

## Test Coverage

- [x] All existing tests pass: `893 passed, 2 skipped`
- [x] Committed `context-eval/results/results.{json,md}` are the sample output of a full run

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added (the harness uses stdlib + redcon; `aider-chat` is optional)
- [x] Deterministic behavior preserved in core scoring/compression: no changes to `redcon/`