### PR TITLE
fix(report): report real budget utilization instead of constant zero

### DIFF
--- a/redcon/engine.py
+++ b/redcon/engine.py
@@ -379,10 +379,13 @@ class RedconEngine:
             ):
                 logger.info("pack: no files matched the scan for task=%r", task)
 
-            # Defensive division-by-zero guard for token percentage calculations
+            # Defensive division-by-zero guard for token percentage calculations.
+            # The budget dict carries max_tokens since the report builder was
+            # fixed; fall back to the report-level value for artifacts built
+            # before that, where this recompute always produced 0.0.
             budget = result.get("budget")
             if isinstance(budget, dict):
-                max_tok = budget.get("max_tokens") or 0
+                max_tok = budget.get("max_tokens") or result.get("max_tokens") or 0
                 estimated = budget.get("estimated_input_tokens") or 0
                 if max_tok > 0:
                     budget["utilization_pct"] = round(estimated / max_tok * 100, 2)

--- a/redcon/stages/workflow.py
+++ b/redcon/stages/workflow.py
@@ -1,11 +1,11 @@
-from __future__ import annotations
-
 """Explicit pipeline stages for scan, score, pack, cache, and render boundaries."""
 
+from __future__ import annotations
+
+import subprocess
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-import subprocess
 
 from redcon.cache.run_history import load_run_history
 from redcon.cache.summary_cache import SummaryCacheBackend, create_summary_cache_backend
@@ -18,9 +18,9 @@ from redcon.plugins import ResolvedPlugins, resolve_plugins
 from redcon.scanners.incremental import ScanRefreshResult, refresh_scan_index
 from redcon.scanners.workspace import ScannedWorkspaceRepo, scan_workspace
 from redcon.schemas.models import (
+    DEFAULT_TOP_FILES,
     AgentPlanReport,
     CompressedFile,
-    DEFAULT_TOP_FILES,
     FileRecord,
     ModelProfileReport,
     RankedFile,
@@ -255,8 +255,14 @@ def run_render_stage(
         files_included=compressed.files_included,
         files_skipped=compressed.files_skipped,
         budget={
+            "max_tokens": max_tokens,
             "estimated_input_tokens": compressed.estimated_input_tokens,
             "estimated_saved_tokens": compressed.estimated_saved_tokens,
+            "utilization_pct": (
+                round(compressed.estimated_input_tokens / max_tokens * 100, 2)
+                if max_tokens > 0
+                else 0.0
+            ),
             "duplicate_reads_prevented": compressed.duplicate_reads_prevented,
             "quality_risk_estimate": compressed.quality_risk_estimate,
         },

--- a/redcon/stages/workflow.py
+++ b/redcon/stages/workflow.py
@@ -146,7 +146,11 @@ def _get_git_dirty_paths(repo: Path) -> set[str]:
     try:
         result = subprocess.run(
             ["git", "diff", "--name-only", "HEAD"],
-            cwd=repo, capture_output=True, text=True, timeout=5, check=False,
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
         )
         if result.returncode == 0:
             return {line.strip() for line in result.stdout.splitlines() if line.strip()}
@@ -251,7 +255,9 @@ def run_render_stage(
         repo=str(repo),
         max_tokens=max_tokens,
         ranked_files=[_serialize_ranked_file(item) for item in ranked[:effective_top_files]],
-        compressed_context=[_serialize_compressed_file(item) for item in compressed.compressed_files],
+        compressed_context=[
+            _serialize_compressed_file(item) for item in compressed.compressed_files
+        ],
         files_included=compressed.files_included,
         files_skipped=compressed.files_skipped,
         budget={

--- a/tests/test_pack_pipeline.py
+++ b/tests/test_pack_pipeline.py
@@ -794,3 +794,64 @@ snippet_total_line_limit = 20
             f"{entry['path']}: compressed_tokens ({entry['compressed_tokens']}) "
             f"exceeds original_tokens ({entry['original_tokens']})"
         )
+
+
+def test_run_pack_reports_truthful_budget_utilization(tmp_path: Path) -> None:
+    # The budget block must be self-describing: it carries the max_tokens the
+    # pack ran against and a utilization_pct derived from it. Before the fix
+    # the budget dict had no max_tokens key, so downstream consumers reading
+    # only the budget block computed utilization as 0.0 on every run.
+    _write(tmp_path / "src" / "auth.py", "def auth():\n    return 'ok'\n" * 20)
+
+    data = as_json_dict(run_pack("refactor auth", repo=tmp_path, max_tokens=1000))
+    budget = data["budget"]
+
+    assert budget["max_tokens"] == data["max_tokens"]
+    assert budget["estimated_input_tokens"] > 0
+    expected = round(budget["estimated_input_tokens"] / budget["max_tokens"] * 100, 2)
+    assert budget["utilization_pct"] == expected
+    assert budget["utilization_pct"] > 0
+
+
+def test_engine_pack_reports_nonzero_utilization(tmp_path: Path) -> None:
+    # Audit repro: engine.pack() always reported utilization_pct == 0.0
+    # because it looked for max_tokens inside the budget dict, which never
+    # contained it.
+    from redcon import RedconEngine
+
+    _write(tmp_path / "src" / "auth.py", "def login() -> bool:\n    return True\n" * 10)
+
+    result = RedconEngine().pack(task="tighten auth checks", repo=tmp_path, max_tokens=300)
+    budget = result["budget"]
+
+    assert budget["estimated_input_tokens"] > 0
+    assert budget["utilization_pct"] > 0
+
+
+def test_engine_pack_backfills_utilization_for_legacy_budget_shape(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    # Reports built before the budget block carried max_tokens must still get
+    # a truthful utilization_pct from the engine via the report-level value.
+    from redcon import RedconEngine
+    from redcon import engine as engine_module
+
+    _write(tmp_path / "src" / "auth.py", "def login() -> bool:\n    return True\n" * 10)
+
+    real_run_pack = engine_module.run_pack
+
+    def legacy_run_pack(*args: object, **kwargs: object):
+        report = real_run_pack(*args, **kwargs)
+        report.budget.pop("max_tokens", None)
+        report.budget.pop("utilization_pct", None)
+        return report
+
+    monkeypatch.setattr(engine_module, "run_pack", legacy_run_pack)
+
+    result = RedconEngine().pack(task="tighten auth checks", repo=tmp_path, max_tokens=300)
+    budget = result["budget"]
+
+    assert "max_tokens" not in budget
+    assert budget["estimated_input_tokens"] > 0
+    assert budget["utilization_pct"] > 0


### PR DESCRIPTION
## Summary

Every pack run reported `utilization_pct: 0.0` no matter how full the token budget was. The budget block now carries `max_tokens` and a truthful `utilization_pct` for every consumer of the run report.

## Problem

`engine.pack()` computed utilization as `budget["estimated_input_tokens"] / budget["max_tokens"]`, guarded by an `if max_tok > 0` check. But the budget dict built in `build_run_report` never contained a `max_tokens` key (it only lives at the report top level), so the guard always failed and the else branch wrote `0.0` on every run. A tool whose whole pitch is honest token budgeting was reporting a made up utilization number.

## Approach

Fix it where the report is born instead of patching the one consumer:

- `redcon/stages/workflow.py`: the budget block now includes `max_tokens` and `utilization_pct` (rounded to 2 decimals, `0.0` only when `max_tokens` is not positive). This means CLI `run.json` artifacts, MCP and gateway paths all get the real number, not just `engine.pack()` callers.
- `redcon/engine.py`: the defensive recompute now falls back to the report level `max_tokens`, so artifacts produced before this change also get a truthful backfill instead of a constant zero.
- The module header of `stages/workflow.py` had the docstring below `from __future__ import annotations` (making it a no op expression statement), which tripped E402 on every import once the file was touched. Docstring moved above, imports sorted. A separate mechanical `ruff format` commit covers two pre-existing format drift spots the changed files gate surfaces.

`quality_risk_estimate` (the related audit finding) is intentionally out of scope: its formula never sees `max_tokens` at all and needs a design decision, not a patch.

## Test Coverage

- [x] Added/updated unit tests
- [x] All existing tests pass
- [x] Before/after sample report included (if behavior changes)

New tests in `tests/test_pack_pipeline.py`:

- `test_run_pack_reports_truthful_budget_utilization`: the budget block carries `max_tokens` equal to the report level value and `utilization_pct` matching the round formula.
- `test_engine_pack_reports_nonzero_utilization`: the exact audit repro; `engine.pack()` used to return `0.0` here.
- `test_engine_pack_backfills_utilization_for_legacy_budget_shape`: a report whose budget block lacks `max_tokens` (pre-fix artifact shape) still gets a truthful value from the engine fallback.

Full suite: 895 passed, 13 skipped locally.

Before:

```json
"budget": {
  "estimated_input_tokens": 742,
  "estimated_saved_tokens": 118,
  "utilization_pct": 0.0
}
```

After (max_tokens 1000):

```json
"budget": {
  "max_tokens": 1000,
  "estimated_input_tokens": 742,
  "estimated_saved_tokens": 118,
  "utilization_pct": 74.2
}
```

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added (or justified if added)
- [x] Deterministic behavior preserved in core scoring/compression