### PR TITLE
ci(release): PyPI trusted publishing and clean wheel contents

### DIFF
--- a/.github/workflows/redcon-pr-audit.yml
+++ b/.github/workflows/redcon-pr-audit.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install Redcon
-        run: pip install git+https://github.com/natiixnt/ContextBudget
+        run: pip install git+https://github.com/natiixnt/redcon
 
       - name: Run PR audit
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Must match the trusted publisher registered on PyPI
+    # (owner/repo + release.yml + environment "pypi").
+    environment: pypi
     permissions:
       contents: write
       id-token: write
@@ -28,11 +31,13 @@ jobs:
       - name: Build package
         run: python -m build
 
+      - name: Check package metadata
+        run: twine check dist/*
+
+      # Trusted publishing (OIDC): no API token or password involved.
+      # PyPA recommends tracking the release/v1 branch for this action.
       - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: twine upload dist/*
+        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Stop sending agents 200k tokens of irrelevant code. Redcon scores, compresses, and packs repo context so your agent gets what it actually needs.
 
-[![Tests](https://github.com/natiixnt/ContextBudget/actions/workflows/test.yml/badge.svg)](https://github.com/natiixnt/ContextBudget/actions/workflows/test.yml)
+[![Tests](https://github.com/natiixnt/redcon/actions/workflows/test.yml/badge.svg)](https://github.com/natiixnt/redcon/actions/workflows/test.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![VS Code Extension](https://img.shields.io/visual-studio-marketplace/v/redcon.redcon?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=redcon.redcon)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
@@ -38,7 +38,7 @@ The extension installs the CLI via pip, registers the MCP server for Claude Code
 ### Option 2: CLI + MCP Server
 
 ```bash
-pip install "redcon[mcp] @ git+https://github.com/natiixnt/ContextBudget"
+pip install "redcon[mcp] @ git+https://github.com/natiixnt/redcon"
 redcon init                      # creates redcon.toml + registers MCP
 ```
 
@@ -47,7 +47,7 @@ The `init` command auto-configures MCP so your AI agent can call `redcon_rank`, 
 ### Option 3: CLI only
 
 ```bash
-pip install git+https://github.com/natiixnt/ContextBudget
+pip install git+https://github.com/natiixnt/redcon
 redcon init --no-mcp
 ```
 

--- a/context-eval/README.md
+++ b/context-eval/README.md
@@ -63,7 +63,7 @@ failure mode budgets exist to expose.
 ## Run it yourself
 
 ```bash
-pip install git+https://github.com/natiixnt/ContextBudget
+pip install git+https://github.com/natiixnt/redcon
 pip install aider-chat   # optional, enables the aider-repomap adapter
 
 python context-eval/run.py --repo /path/to/any/git/repo --budget 24000

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -53,7 +53,7 @@ redis_ttl_seconds = 86400
 Install the extra dependency:
 
 ```
-pip install "redcon[redis] @ git+https://github.com/natiixnt/ContextBudget"
+pip install "redcon[redis] @ git+https://github.com/natiixnt/redcon"
 ```
 
 ### Cache key structure

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -34,7 +34,7 @@ The two tiers are **decoupled** - the agent tier runs without the control plane.
 The runtime gateway is part of the `redcon` Python package.
 
 ```bash
-pip install "redcon[gateway] @ git+https://github.com/natiixnt/ContextBudget"
+pip install "redcon[gateway] @ git+https://github.com/natiixnt/redcon"
 export RC_GATEWAY_API_KEY=my-secret-key
 redcon gateway --host 0.0.0.0 --port 8787
 ```

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -6,7 +6,7 @@ The Redcon Runtime Gateway exposes the full context optimization pipeline as an 
 
 ```bash
 # Install gateway extras (FastAPI + Uvicorn)
-pip install "redcon[gateway] @ git+https://github.com/natiixnt/ContextBudget"
+pip install "redcon[gateway] @ git+https://github.com/natiixnt/redcon"
 
 # Start with API key auth
 export RC_GATEWAY_API_KEY=my-secret-key
@@ -166,7 +166,7 @@ server.stop()
 
 ```dockerfile
 FROM python:3.12-slim
-RUN pip install "redcon[gateway] @ git+https://github.com/natiixnt/ContextBudget"
+RUN pip install "redcon[gateway] @ git+https://github.com/natiixnt/redcon"
 ENV RC_GATEWAY_HOST=0.0.0.0
 ENV RC_GATEWAY_PORT=8787
 CMD ["redcon-gateway"]

--- a/examples/ci/redcon-ci.yml
+++ b/examples/ci/redcon-ci.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install Redcon
-        run: pip install git+https://github.com/natiixnt/ContextBudget
+        run: pip install git+https://github.com/natiixnt/redcon
 
       # Pack the repository context for the current task.
       # Adjust --max-tokens and the task description to match your workflow.

--- a/pilot-readiness.md
+++ b/pilot-readiness.md
@@ -130,7 +130,7 @@ This document describes what is production-ready, what is in beta, known limitat
 
 ```
 [Developer Machine / CI]
-  └─ redcon CLI (pip install git+https://github.com/natiixnt/ContextBudget)
+  └─ redcon CLI (pip install git+https://github.com/natiixnt/redcon)
        ├─ cb pack / cb roi / cb benchmark-report
        └─ GitHub Action (action.yml in repo)
 
@@ -142,7 +142,7 @@ This document describes what is production-ready, what is in beta, known limitat
 ```
 
 **Setup steps:**
-1. `pip install git+https://github.com/natiixnt/ContextBudget` on developer machines or in CI.
+1. `pip install git+https://github.com/natiixnt/redcon` on developer machines or in CI.
 2. Run `redcon init` in each repo to generate `redcon.toml`.
 3. Deploy `redcon-cloud` using `docker-compose.prod.yml`.
 4. Run migrations (automatically applied via Docker init scripts).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,10 @@ redcon-gateway = "redcon.gateway.server:run_gateway"
 include-package-data = true
 
 [tool.setuptools.packages.find]
-include = ["redcon*"]
+# "redcon*" would also match the sibling redcon-cloud/ and
+# redcon-benchmarks/ directories and ship them in the wheel.
+include = ["redcon", "redcon.*"]
+namespaces = false
 
 [tool.ruff]
 target-version = "py310"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,13 @@ description = "Deterministic context budgeting for coding-agent workflows"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
-authors = [{ name = "Redcon Contributors" }]
+authors = [{ name = "Natalia Szczepanik" }]
 dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/natiixnt/redcon"
+Repository = "https://github.com/natiixnt/redcon"
+Issues = "https://github.com/natiixnt/redcon/issues"
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "fakeredis>=2.0", "redis>=5.0"]

--- a/redcon/cache/backends.py
+++ b/redcon/cache/backends.py
@@ -579,7 +579,7 @@ class RedisSummaryCacheBackend(SummaryCacheBackend):
             except ModuleNotFoundError as exc:  # pragma: no cover
                 raise RuntimeError(
                     "The 'redis' package is required for the Redis cache backend. "
-                    "Install it with: pip install 'redcon[redis] @ git+https://github.com/natiixnt/ContextBudget'"
+                    "Install it with: pip install 'redcon[redis] @ git+https://github.com/natiixnt/redcon'"
                 ) from exc
             try:
                 client = _redis.Redis.from_url(self.redis_url, decode_responses=False)

--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -272,7 +272,7 @@ def cmd_mcp(args: argparse.Namespace) -> int:
     except ImportError as e:
         print(
             f"Error: mcp package not available: {e}\n"
-            f"Install with: pip install 'redcon[mcp] @ git+https://github.com/natiixnt/ContextBudget'",
+            f"Install with: pip install 'redcon[mcp] @ git+https://github.com/natiixnt/redcon'",
             file=sys.stderr,
         )
         return 1
@@ -1704,7 +1704,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install Redcon
-        run: pip install git+https://github.com/natiixnt/ContextBudget
+        run: pip install git+https://github.com/natiixnt/redcon
 
       - name: Run PR audit
         run: |

--- a/redcon/core/doctor.py
+++ b/redcon/core/doctor.py
@@ -88,7 +88,7 @@ def _check_optional_dep(name: str, package: str, extra: str) -> CheckResult:
         return CheckResult(
             name=name,
             status="warn",
-            message=f"Not installed - install with: pip install 'redcon[{extra}] @ git+https://github.com/natiixnt/ContextBudget'",
+            message=f"Not installed - install with: pip install 'redcon[{extra}] @ git+https://github.com/natiixnt/redcon'",
         )
 
 

--- a/redcon/gateway/server.py
+++ b/redcon/gateway/server.py
@@ -9,7 +9,7 @@ provides a production-grade ASGI gateway.  Without them, it falls back to the
 existing stdlib implementation so no new hard dependency is introduced.
 
 Install gateway extras:
-    pip install 'redcon[gateway] @ git+https://github.com/natiixnt/ContextBudget'
+    pip install 'redcon[gateway] @ git+https://github.com/natiixnt/redcon'
 """
 
 from __future__ import annotations
@@ -196,7 +196,7 @@ class GatewayServer:
         else:
             logger.warning(
                 "fastapi/uvicorn not installed - using stdlib HTTP gateway. "
-                "For production use: pip install 'redcon[gateway] @ git+https://github.com/natiixnt/ContextBudget'"
+                "For production use: pip install 'redcon[gateway] @ git+https://github.com/natiixnt/redcon'"
             )
             self._start_stdlib(block=block)
 

--- a/redcon/mcp/server.py
+++ b/redcon/mcp/server.py
@@ -384,7 +384,7 @@ def create_server() -> Any:
     if not _MCP_AVAILABLE:
         raise RuntimeError(
             "mcp package is not installed. Run: "
-            "pip install 'redcon[mcp] @ git+https://github.com/natiixnt/ContextBudget'"
+            "pip install 'redcon[mcp] @ git+https://github.com/natiixnt/redcon'"
         )
 
     server = Server("redcon")
@@ -414,7 +414,7 @@ async def serve() -> None:
     if not _MCP_AVAILABLE:
         raise RuntimeError(
             "mcp package is not installed. Run: "
-            "pip install 'redcon[mcp] @ git+https://github.com/natiixnt/ContextBudget'"
+            "pip install 'redcon[mcp] @ git+https://github.com/natiixnt/redcon'"
         )
 
     server = create_server()

--- a/vscode-redcon/README.md
+++ b/vscode-redcon/README.md
@@ -81,7 +81,7 @@ Open Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`) and type `Redcon`:
 
 - **Redcon CLI** installed and available in PATH:
   ```bash
-  pip install git+https://github.com/natiixnt/ContextBudget
+  pip install git+https://github.com/natiixnt/redcon
   ```
 - Python 3.10+
 - A `redcon.toml` config file in your project root (or run `Redcon: Initialize Config`)
@@ -107,7 +107,7 @@ Open Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`) and type `Redcon`:
 ## Quick Start
 
 1. Install the extension
-2. Install the CLI: `pip install git+https://github.com/natiixnt/ContextBudget`
+2. Install the CLI: `pip install git+https://github.com/natiixnt/redcon`
 3. Open a project and run `Redcon: Initialize Config`
 4. Run `Redcon: Pack Context` with a task description
 5. Explore results in the sidebar, status bar, and dashboard


### PR DESCRIPTION
## Summary

Prepares the repo for the first PyPI release of `redcon` via trusted publishing (OIDC), and fixes a packaging bug that shipped the entire `redcon-cloud` app inside the wheel.

## Problem

Two blockers for publishing:

1. The release workflow uploaded with twine using a `PYPI_TOKEN` secret that does not exist. PyPI's recommended path today is trusted publishing: PyPI trusts the GitHub Actions identity directly, no token or password involved.
2. Package discovery used `include = ["redcon*"]`, which also matches the sibling `redcon-cloud/` directory. `pip install redcon` would have dropped the whole cloud app into the user's site-packages. The wheel had 171 files with `redcon-cloud/` at top level.

## Approach

- `release.yml`: replace the twine upload with `pypa/gh-action-pypi-publish@release/v1`, add `environment: pypi` to match the trusted publisher registration, and add a `twine check` step so malformed metadata fails before upload.
- `pyproject.toml`: restrict discovery to `include = ["redcon", "redcon.*"]` with `namespaces = false`.

## Test Coverage

- [x] All existing tests pass
- [x] Verified by building the artifact: `python -m build` succeeds; `twine check dist/*` passes. Wheel drops from 171 to 148 files; top level is now only `redcon/` and the dist-info. Fresh-venv install works end to end.

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression