### PR TITLE
release: bump version to 1.7.0 for the first PyPI publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redcon"
-version = "1.1.0"
+version = "1.7.0"
 description = "Deterministic context budgeting for coding-agent workflows"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/redcon/__init__.py
+++ b/redcon/__init__.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-__version__ = "1.1.0"
+__version__ = "1.7.0"
 
 # Mapping from public symbol name to the submodule it lives in. The first
 # attribute access triggers an import of that module and caches the symbol

--- a/redcon/__init__.py
+++ b/redcon/__init__.py
@@ -1,12 +1,12 @@
 """Redcon - deterministic context packing for LLM agents.
 
 Top-level public API uses PEP 562 lazy loading. Importing this package is
-~150 ms cheaper than eager loading because submodules like \`redcon.gateway\`
+~150 ms cheaper than eager loading because submodules like ``redcon.gateway``
 (which transitively pulls in asyncio) only load when something actually
-references them. Submodule imports like \`from redcon.cmd import X\` no longer
+references them. Submodule imports like ``from redcon.cmd import X`` no longer
 pay for the full SDK chain.
 
-Public symbol behaviour is unchanged: \`from redcon import RedconEngine\`
+Public symbol behaviour is unchanged: ``from redcon import RedconEngine``
 still works, it just defers the SDK + agents + runtime imports until the
 first attribute access.
 """


### PR DESCRIPTION
## Summary

Bumps the package version from 1.1.0 to 1.7.0 so the first PyPI publish does not go out with a version older than the repo's existing tag history.

## Problem

Pushing the release tag surfaced a mismatch: the repo already has release tags up to `v1.6.0` (a `v1.1.0` tag from March exists and points at old code), but `pyproject.toml` and `redcon.__version__` still said 1.1.0. Publishing 1.1.0 to PyPI would have created a permanent release older than the tag history, and the `v1.1.0` tag cannot be reused.

## Approach

- `pyproject.toml` and `redcon/__init__.py`: version 1.7.0, the next free number after `v1.6.0`.
- The package docstring in `__init__.py` escaped backticks with backslashes, which Python treats as invalid escape sequences (W605); switched to double backticks since the changed files lint gate now covers the file.

After merge, tagging `v1.7.0` triggers the release workflow (trusted publishing, merged in #149) and creates the `redcon` project on PyPI.

## Test Coverage

- [x] All existing tests pass

Version bump only, no behavior change. Full suite locally: 895 passed, 13 skipped. `python -m build` and `twine check` pass for the 1.7.0 wheel and sdist.

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression