### PR TITLE
docs: install from PyPI now that redcon 1.7.0 is published

### DIFF
--- a/.github/workflows/redcon-pr-audit.yml
+++ b/.github/workflows/redcon-pr-audit.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install Redcon
-        run: pip install git+https://github.com/natiixnt/redcon
+        run: pip install redcon
 
       - name: Run PR audit
         run: |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 Stop sending agents 200k tokens of irrelevant code. Redcon scores, compresses, and packs repo context so your agent gets what it actually needs.
 
+[![PyPI](https://img.shields.io/pypi/v/redcon)](https://pypi.org/project/redcon/)
 [![Tests](https://github.com/natiixnt/redcon/actions/workflows/test.yml/badge.svg)](https://github.com/natiixnt/redcon/actions/workflows/test.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![VS Code Extension](https://img.shields.io/visual-studio-marketplace/v/redcon.redcon?label=VS%20Code)](https://marketplace.visualstudio.com/items?itemName=redcon.redcon)
@@ -38,7 +39,7 @@ The extension installs the CLI via pip, registers the MCP server for Claude Code
 ### Option 2: CLI + MCP Server
 
 ```bash
-pip install "redcon[mcp] @ git+https://github.com/natiixnt/redcon"
+pip install "redcon[mcp]"
 redcon init                      # creates redcon.toml + registers MCP
 ```
 
@@ -47,11 +48,10 @@ The `init` command auto-configures MCP so your AI agent can call `redcon_rank`, 
 ### Option 3: CLI only
 
 ```bash
-pip install git+https://github.com/natiixnt/redcon
+pip install redcon
 redcon init --no-mcp
 ```
 
-> Redcon installs directly from GitHub for now; a PyPI package is planned. Same package, same `redcon` command.
 
 ## Quick Start
 

--- a/context-eval/README.md
+++ b/context-eval/README.md
@@ -63,7 +63,7 @@ failure mode budgets exist to expose.
 ## Run it yourself
 
 ```bash
-pip install git+https://github.com/natiixnt/redcon
+pip install redcon
 pip install aider-chat   # optional, enables the aider-repomap adapter
 
 python context-eval/run.py --repo /path/to/any/git/repo --budget 24000

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -53,7 +53,7 @@ redis_ttl_seconds = 86400
 Install the extra dependency:
 
 ```
-pip install "redcon[redis] @ git+https://github.com/natiixnt/redcon"
+pip install "redcon[redis]"
 ```
 
 ### Cache key structure

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -34,7 +34,7 @@ The two tiers are **decoupled** - the agent tier runs without the control plane.
 The runtime gateway is part of the `redcon` Python package.
 
 ```bash
-pip install "redcon[gateway] @ git+https://github.com/natiixnt/redcon"
+pip install "redcon[gateway]"
 export RC_GATEWAY_API_KEY=my-secret-key
 redcon gateway --host 0.0.0.0 --port 8787
 ```

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -6,7 +6,7 @@ The Redcon Runtime Gateway exposes the full context optimization pipeline as an 
 
 ```bash
 # Install gateway extras (FastAPI + Uvicorn)
-pip install "redcon[gateway] @ git+https://github.com/natiixnt/redcon"
+pip install "redcon[gateway]"
 
 # Start with API key auth
 export RC_GATEWAY_API_KEY=my-secret-key
@@ -166,7 +166,7 @@ server.stop()
 
 ```dockerfile
 FROM python:3.12-slim
-RUN pip install "redcon[gateway] @ git+https://github.com/natiixnt/redcon"
+RUN pip install "redcon[gateway]"
 ENV RC_GATEWAY_HOST=0.0.0.0
 ENV RC_GATEWAY_PORT=8787
 CMD ["redcon-gateway"]

--- a/examples/ci/redcon-ci.yml
+++ b/examples/ci/redcon-ci.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install Redcon
-        run: pip install git+https://github.com/natiixnt/redcon
+        run: pip install redcon
 
       # Pack the repository context for the current task.
       # Adjust --max-tokens and the task description to match your workflow.

--- a/pilot-readiness.md
+++ b/pilot-readiness.md
@@ -130,7 +130,7 @@ This document describes what is production-ready, what is in beta, known limitat
 
 ```
 [Developer Machine / CI]
-  └─ redcon CLI (pip install git+https://github.com/natiixnt/redcon)
+  └─ redcon CLI (pip install redcon)
        ├─ cb pack / cb roi / cb benchmark-report
        └─ GitHub Action (action.yml in repo)
 
@@ -142,7 +142,7 @@ This document describes what is production-ready, what is in beta, known limitat
 ```
 
 **Setup steps:**
-1. `pip install git+https://github.com/natiixnt/redcon` on developer machines or in CI.
+1. `pip install redcon` on developer machines or in CI.
 2. Run `redcon init` in each repo to generate `redcon.toml`.
 3. Deploy `redcon-cloud` using `docker-compose.prod.yml`.
 4. Run migrations (automatically applied via Docker init scripts).

--- a/redcon/cache/backends.py
+++ b/redcon/cache/backends.py
@@ -579,7 +579,7 @@ class RedisSummaryCacheBackend(SummaryCacheBackend):
             except ModuleNotFoundError as exc:  # pragma: no cover
                 raise RuntimeError(
                     "The 'redis' package is required for the Redis cache backend. "
-                    "Install it with: pip install 'redcon[redis] @ git+https://github.com/natiixnt/redcon'"
+                    "Install it with: pip install 'redcon[redis]'"
                 ) from exc
             try:
                 client = _redis.Redis.from_url(self.redis_url, decode_responses=False)

--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -271,8 +271,7 @@ def cmd_mcp(args: argparse.Namespace) -> int:
         from redcon.mcp import serve
     except ImportError as e:
         print(
-            f"Error: mcp package not available: {e}\n"
-            f"Install with: pip install 'redcon[mcp] @ git+https://github.com/natiixnt/redcon'",
+            f"Error: mcp package not available: {e}\nInstall with: pip install 'redcon[mcp]'",
             file=sys.stderr,
         )
         return 1
@@ -1704,7 +1703,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install Redcon
-        run: pip install git+https://github.com/natiixnt/redcon
+        run: pip install redcon
 
       - name: Run PR audit
         run: |

--- a/redcon/core/doctor.py
+++ b/redcon/core/doctor.py
@@ -88,7 +88,7 @@ def _check_optional_dep(name: str, package: str, extra: str) -> CheckResult:
         return CheckResult(
             name=name,
             status="warn",
-            message=f"Not installed - install with: pip install 'redcon[{extra}] @ git+https://github.com/natiixnt/redcon'",
+            message=f"Not installed - install with: pip install 'redcon[{extra}]'",
         )
 
 

--- a/redcon/gateway/server.py
+++ b/redcon/gateway/server.py
@@ -9,7 +9,7 @@ provides a production-grade ASGI gateway.  Without them, it falls back to the
 existing stdlib implementation so no new hard dependency is introduced.
 
 Install gateway extras:
-    pip install 'redcon[gateway] @ git+https://github.com/natiixnt/redcon'
+    pip install 'redcon[gateway]'
 """
 
 from __future__ import annotations
@@ -196,7 +196,7 @@ class GatewayServer:
         else:
             logger.warning(
                 "fastapi/uvicorn not installed - using stdlib HTTP gateway. "
-                "For production use: pip install 'redcon[gateway] @ git+https://github.com/natiixnt/redcon'"
+                "For production use: pip install 'redcon[gateway]'"
             )
             self._start_stdlib(block=block)
 

--- a/redcon/mcp/server.py
+++ b/redcon/mcp/server.py
@@ -382,10 +382,7 @@ def _dispatch_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
 def create_server() -> Any:
     """Build and return a configured MCP server instance."""
     if not _MCP_AVAILABLE:
-        raise RuntimeError(
-            "mcp package is not installed. Run: "
-            "pip install 'redcon[mcp] @ git+https://github.com/natiixnt/redcon'"
-        )
+        raise RuntimeError("mcp package is not installed. Run: pip install 'redcon[mcp]'")
 
     server = Server("redcon")
 
@@ -412,10 +409,7 @@ def create_server() -> Any:
 async def serve() -> None:
     """Run the MCP server over stdio transport."""
     if not _MCP_AVAILABLE:
-        raise RuntimeError(
-            "mcp package is not installed. Run: "
-            "pip install 'redcon[mcp] @ git+https://github.com/natiixnt/redcon'"
-        )
+        raise RuntimeError("mcp package is not installed. Run: pip install 'redcon[mcp]'")
 
     server = create_server()
     async with stdio_server() as (read_stream, write_stream):

--- a/vscode-redcon/README.md
+++ b/vscode-redcon/README.md
@@ -81,7 +81,7 @@ Open Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`) and type `Redcon`:
 
 - **Redcon CLI** installed and available in PATH:
   ```bash
-  pip install git+https://github.com/natiixnt/redcon
+  pip install redcon
   ```
 - Python 3.10+
 - A `redcon.toml` config file in your project root (or run `Redcon: Initialize Config`)
@@ -107,7 +107,7 @@ Open Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`) and type `Redcon`:
 ## Quick Start
 
 1. Install the extension
-2. Install the CLI: `pip install git+https://github.com/natiixnt/redcon`
+2. Install the CLI: `pip install redcon`
 3. Open a project and run `Redcon: Initialize Config`
 4. Run `Redcon: Pack Context` with a task description
 5. Explore results in the sidebar, status bar, and dashboard


### PR DESCRIPTION
## Summary

`redcon 1.7.0` is live on PyPI, so every install instruction switches from building out of the git repo to plain `pip install redcon`.

## Changes

- README: `pip install redcon` / `pip install "redcon[mcp]"`, new PyPI version badge, and the "installs from GitHub for now; a PyPI package is planned" note is gone since it stopped being true.
- Docs (`gateway.md`, `cache.md`, `deployment.md`), `context-eval/README.md`, `vscode-redcon/README.md`, `pilot-readiness.md`, `examples/ci/redcon-ci.yml`: same replacement for the extras forms (`redcon[gateway]`, `redcon[redis]`).
- CLI hint strings in `cli.py`, `mcp/server.py`, `gateway/server.py`, `cache/backends.py`, `core/doctor.py`: error messages now suggest the PyPI install. Two shortened messages collapsed to single lines under ruff format.
- `.github/workflows/redcon-pr-audit.yml`: installs redcon from PyPI instead of building from source on every PR, which shaves the slowest step of that job.

## Test Coverage

- [x] All existing tests pass

String and docs change only. Full suite locally: 895 passed, 13 skipped. Lint and format clean on all touched Python files, YAML validated.

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression