### PR TITLE
fix(report): make quality_risk_estimate reflect actual content loss

### DIFF
--- a/redcon/compressors/context_compressor.py
+++ b/redcon/compressors/context_compressor.py
@@ -341,22 +341,49 @@ def _build_slice_relationship_contexts(
     return contexts
 
 
+# Token loss below this fraction is redcon doing its job (routine 2x
+# compression), not a quality alarm. Only loss beyond the grace zone
+# counts toward risk, scaling to 1.0 when all content is gone.
+_LOSS_GRACE = 0.5
+
+
 def _build_risk_estimate(
     cfg: CompressionSettings,
     files_skipped: list[str],
     ranked_files: list[RankedFile],
     total_compressed: int,
     total_raw: int,
+    *,
+    max_tokens: int | None = None,
+    files_included_count: int | None = None,
+    degraded_files: list[str] | None = None,
 ) -> str:
+    # A pack that exceeds its own budget can never be low risk: the
+    # invariant itself is broken, whatever the ratios below say.
+    if max_tokens is not None and max_tokens > 0 and total_compressed > max_tokens:
+        return "high"
+
     skipped_ratio = len(files_skipped) / max(1, len(ranked_files))
-    compression_ratio = total_compressed / max(1, total_raw)
-    bounded_ratio = min(1.0, max(0.0, compression_ratio))
+
+    # Risk grows with content the agent will NOT see. The old formula
+    # scored kept content as risk, so a full uncompressed pack rated
+    # worse than one that silently dropped 95% of the code.
+    loss_ratio = 1.0 - min(1.0, total_compressed / max(1, total_raw))
+    deep_loss = max(0.0, loss_ratio - _LOSS_GRACE) / (1.0 - _LOSS_GRACE)
+
+    # Files degraded to a lower tier kept their slot but lost fidelity;
+    # treat their share as content loss and take the stronger signal.
+    degraded_ratio = 0.0
+    if degraded_files and files_included_count:
+        degraded_ratio = min(1.0, len(degraded_files) / files_included_count)
+    content_risk = max(deep_loss, degraded_ratio)
+
     total_weight = cfg.risk_skip_weight + cfg.risk_compression_weight
     if total_weight <= 0:
         total_weight = 1.0
     skip_weight = cfg.risk_skip_weight / total_weight
     compression_weight = cfg.risk_compression_weight / total_weight
-    risk_score = skip_weight * skipped_ratio + compression_weight * bounded_ratio
+    risk_score = skip_weight * skipped_ratio + compression_weight * content_risk
     if risk_score < 0.25:
         return "low"
     if risk_score < 0.5:
@@ -671,7 +698,15 @@ def _compress_greedy(
         compressed_files.append(entry)
         files_included.append(ft.path)
 
-    risk = _build_risk_estimate(cfg, files_skipped, ranked_files, total_compressed, total_raw)
+    risk = _build_risk_estimate(
+        cfg,
+        files_skipped,
+        ranked_files,
+        total_compressed,
+        total_raw,
+        max_tokens=max_tokens,
+        files_included_count=len(files_included),
+    )
     cache_snapshot = cache.snapshot()
     return CompressionResult(
         compressed_files=compressed_files,
@@ -843,7 +878,16 @@ def _compress_progressive(
     compressed_files: list[CompressedFile] = [entry for _ft, entry in finalized]
     files_included: list[str] = [ft.path for ft, _entry in finalized]
 
-    risk = _build_risk_estimate(cfg, files_skipped, ranked_files, total_compressed, total_raw)
+    risk = _build_risk_estimate(
+        cfg,
+        files_skipped,
+        ranked_files,
+        total_compressed,
+        total_raw,
+        max_tokens=max_tokens,
+        files_included_count=len(files_included),
+        degraded_files=degraded_files,
+    )
     cache_snapshot = cache.snapshot()
     return CompressionResult(
         compressed_files=compressed_files,

--- a/tests/test_quality_risk.py
+++ b/tests/test_quality_risk.py
@@ -1,0 +1,139 @@
+"""Regression tests for the quality risk estimate.
+
+The old formula scored kept content as risk (a full uncompressed pack
+rated worse than one that silently dropped 95% of the code) and never
+saw the token budget or the degradation pass, so a blown or heavily
+degraded pack still reported "low".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from redcon.compressors.context_compressor import _build_risk_estimate
+from redcon.config import CompressionSettings
+from redcon.core.pipeline import as_json_dict, run_pack
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _ranked(n: int) -> list:
+    # _build_risk_estimate only reads len() of this list.
+    return [None] * n
+
+
+def test_full_uncompressed_pack_is_low_risk() -> None:
+    # Everything included, nothing compressed away: the agent sees all
+    # source content. The old formula called this medium.
+    risk = _build_risk_estimate(
+        CompressionSettings(),
+        files_skipped=[],
+        ranked_files=_ranked(10),
+        total_compressed=1000,
+        total_raw=1000,
+        max_tokens=5000,
+        files_included_count=10,
+    )
+    assert risk == "low"
+
+
+def test_over_budget_pack_is_always_high_risk() -> None:
+    # The budget invariant is broken; no ratio math may soften that.
+    risk = _build_risk_estimate(
+        CompressionSettings(),
+        files_skipped=[],
+        ranked_files=_ranked(10),
+        total_compressed=6000,
+        total_raw=6000,
+        max_tokens=5000,
+        files_included_count=10,
+    )
+    assert risk == "high"
+
+
+def test_routine_compression_stays_low_risk() -> None:
+    # A healthy 3x compression with nothing skipped is redcon working
+    # as designed, not an alarm. Policy gates on "low" must keep passing.
+    risk = _build_risk_estimate(
+        CompressionSettings(),
+        files_skipped=[],
+        ranked_files=_ranked(10),
+        total_compressed=333,
+        total_raw=1000,
+        max_tokens=5000,
+        files_included_count=10,
+    )
+    assert risk == "low"
+
+
+def test_extreme_loss_and_skips_are_high_risk() -> None:
+    # Most ranked files dropped and almost all tokens gone: the old
+    # formula called this low because heavy compression scored as safe.
+    risk = _build_risk_estimate(
+        CompressionSettings(),
+        files_skipped=["f"] * 7,
+        ranked_files=_ranked(10),
+        total_compressed=50,
+        total_raw=1000,
+        max_tokens=5000,
+        files_included_count=3,
+    )
+    assert risk == "high"
+
+
+def test_degraded_files_raise_risk_above_low() -> None:
+    # Every included file was degraded to a lower tier in Pass 2. Token
+    # loss alone sits inside the grace zone, so only the degradation
+    # signal can lift this above "low".
+    settings = CompressionSettings()
+    degraded = [f"src/f{i}.py" for i in range(8)]
+    risk = _build_risk_estimate(
+        settings,
+        files_skipped=[],
+        ranked_files=_ranked(10),
+        total_compressed=600,
+        total_raw=1000,
+        max_tokens=5000,
+        files_included_count=8,
+        degraded_files=degraded,
+    )
+    assert risk != "low"
+
+    baseline = _build_risk_estimate(
+        settings,
+        files_skipped=[],
+        ranked_files=_ranked(10),
+        total_compressed=600,
+        total_raw=1000,
+        max_tokens=5000,
+        files_included_count=8,
+    )
+    assert baseline == "low"
+
+
+def test_zero_weights_do_not_crash() -> None:
+    settings = CompressionSettings(risk_skip_weight=0.0, risk_compression_weight=0.0)
+    risk = _build_risk_estimate(
+        settings,
+        files_skipped=["a"],
+        ranked_files=_ranked(2),
+        total_compressed=10,
+        total_raw=100,
+        max_tokens=50,
+        files_included_count=1,
+    )
+    assert risk in {"low", "medium", "high"}
+
+
+def test_pack_of_small_repo_reports_low_risk(tmp_path: Path) -> None:
+    # End to end: a comfortable budget over a small repo must not warn.
+    _write(tmp_path / "src" / "auth.py", "def login():\n    return True\n" * 10)
+    _write(tmp_path / "src" / "api.py", "def handler(req):\n    return req\n" * 10)
+
+    data = as_json_dict(run_pack("refactor auth login", repo=tmp_path, max_tokens=30_000))
+
+    assert data["files_included"]
+    assert data["budget"]["quality_risk_estimate"] == "low"


### PR DESCRIPTION
## Summary

Last remaining "lying metric" from the audit: `quality_risk_estimate` reported "low" precisely in the situations it exists to warn about. The formula now measures what the agent will not see.

## Problem

Three blind spots in `_build_risk_estimate`:

1. **Inverted signal.** The formula added `compressed/raw` to the risk score, so keeping content scored as risk. A full uncompressed pack rated "medium" while a pack that silently dropped 95% of the source rated "low".
2. **No budget awareness.** `max_tokens` never reached the formula, so a pack exceeding its own budget could still say "low".
3. **No degradation awareness.** Files degraded to lower fidelity tiers in Pass 2 were invisible to the score.

## Approach

- Risk now grows with content loss: `1 - compressed/raw`, with a grace zone. Loss below 50% is routine compression doing its job and scores zero, so healthy packs stay "low".
- A pack with `total_compressed > max_tokens` reports "high" unconditionally; the invariant itself is broken.
- The share of included files that were degraded counts as content loss; the formula takes the stronger of the two signals.
- `risk_skip_weight` and `risk_compression_weight` keep their roles and defaults.

## Test Coverage

- [x] All existing tests pass

New `tests/test_quality_risk.py` with seven tests (inversion regression, over-budget always high, routine 3x compression stays low, extreme loss plus skips is high, degradation lifts risk, zero-weight safety, end-to-end pack). Full suite: 902 passed, 13 skipped.

| Pack | Old | New |
|---|---|---|
| Everything included, uncompressed | medium | low |
| 95% of tokens dropped, 70% files skipped | low | high |
| Over budget | low | high |
| Routine 3x compression | low | low |

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression