### PR TITLE
release: bump version to 1.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redcon"
-version = "1.7.0"
+version = "1.8.0"
 description = "Deterministic context budgeting for coding-agent workflows"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/redcon/__init__.py
+++ b/redcon/__init__.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-__version__ = "1.7.0"
+__version__ = "1.8.0"
 
 # Mapping from public symbol name to the submodule it lives in. The first
 # attribute access triggers an import of that module and caches the symbol


### PR DESCRIPTION
## Summary

Version bump to 1.8.0 so the one-command multi-agent setup (#154) and the honest `quality_risk_estimate` (#153) ship to PyPI. The README on main already describes the six-agent `redcon init`; the published 1.7.0 does not have it yet.

## Changes

- `pyproject.toml` and `redcon/__init__.py`: 1.7.0 to 1.8.0. Minor bump for a new feature per semver.

After merge: manual release dispatch with tag `v1.8.0`.

## Test Coverage

- [x] All existing tests pass

Version bump only. `python -m build` and `twine check` pass for the 1.8.0 wheel and sdist.

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression