### PR TITLE
feat(hooks): deterministic context injection for Claude Code

### DIFF
--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -179,6 +179,7 @@ def cmd_completion(args: argparse.Namespace) -> int:
         "init",
         "roi",
         "benchmark-report",
+        "hooks",
     ]
     if shell == "bash":
         print(f"""# Redcon bash completion - add to ~/.bashrc or ~/.bash_completion
@@ -294,6 +295,44 @@ def cmd_mcp(args: argparse.Namespace) -> int:
     except Exception as e:
         print(f"Error: MCP server failed: {e}", file=sys.stderr)
         return 1
+    return 0
+
+
+def cmd_hooks(args: argparse.Namespace) -> int:
+    """Manage deterministic agent hooks (Claude Code)."""
+    from redcon.hooks import hook_status, install_hook, run_user_prompt_submit, uninstall_hook
+
+    action = args.action
+    if action == "run":
+        if args.event != "user-prompt-submit":
+            print(f"Unknown hook event: {args.event}", file=sys.stderr)
+            return 0
+        return run_user_prompt_submit(sys.stdin.read())
+
+    project_root = Path(args.repo).resolve()
+    if action == "install":
+        r = install_hook(project_root)
+        icon = {"installed": "[OK]", "up_to_date": "[=]", "error": "[X]"}.get(r["status"], "[-]")
+        print(f"{icon} claude-code: {r['message']} ({r['path']})")
+        if r["status"] == "installed":
+            print()
+            print("Every Claude Code prompt in this project now starts with a")
+            print("ranked file map from redcon. Set REDCON_HOOK_DISABLE=1 to")
+            print("pause injection without uninstalling.")
+        return 1 if r["status"] == "error" else 0
+
+    if action == "uninstall":
+        r = uninstall_hook(project_root)
+        icon = {"removed": "[OK]", "not_installed": "[-]", "error": "[X]"}.get(r["status"], "[-]")
+        print(f"{icon} claude-code: {r['message']} ({r['path']})")
+        return 1 if r["status"] == "error" else 0
+
+    # status
+    path = hook_status(project_root)
+    if path is not None:
+        print(f"[OK] claude-code: hook registered at {path}")
+    else:
+        print("[-]  claude-code: hook not registered")
     return 0
 
 
@@ -1789,6 +1828,9 @@ jobs:
     print("  redcon doctor                              # verify setup")
     print("  redcon pack 'describe your task' --repo .  # compress context")
     print("  redcon plan 'describe your task' --repo .  # rank files")
+    print(
+        "  redcon hooks install                        # guaranteed context injection (Claude Code)"
+    )
     if mcp_installed_targets:
         print()
         print("MCP: restart your IDE to pick up the new redcon tools.")
@@ -2534,6 +2576,34 @@ def build_parser() -> argparse.ArgumentParser:
         help="Project root for project-scoped configs (default: current directory).",
     )
     mcp_parser.set_defaults(func=cmd_mcp)
+
+    hooks_parser = sub.add_parser(
+        "hooks",
+        help="Deterministic context injection via agent hooks (Claude Code)",
+    )
+    hooks_parser.add_argument(
+        "action",
+        choices=["install", "uninstall", "status", "run"],
+        help=(
+            "'install' registers a UserPromptSubmit hook in .claude/settings.json "
+            "so every Claude Code prompt starts with a ranked file map "
+            "(guaranteed by the hook system, not left to the model's choice). "
+            "'run' is the entry point Claude Code invokes; it reads the hook "
+            "payload from stdin and always exits 0."
+        ),
+    )
+    hooks_parser.add_argument(
+        "event",
+        nargs="?",
+        default="user-prompt-submit",
+        help="Hook event name for 'run' (default: user-prompt-submit).",
+    )
+    hooks_parser.add_argument(
+        "--repo",
+        default=".",
+        help="Project root (default: current directory).",
+    )
+    hooks_parser.set_defaults(func=cmd_hooks)
 
     plan = sub.add_parser("plan", help="Rank relevant files for a natural language task")
     plan.add_argument("task", help="Task description")

--- a/redcon/hooks/__init__.py
+++ b/redcon/hooks/__init__.py
@@ -1,0 +1,17 @@
+"""Deterministic agent integrations via editor/agent hook systems."""
+
+from redcon.hooks.claude_code import (
+    build_prompt_context,
+    hook_status,
+    install_hook,
+    run_user_prompt_submit,
+    uninstall_hook,
+)
+
+__all__ = [
+    "build_prompt_context",
+    "hook_status",
+    "install_hook",
+    "run_user_prompt_submit",
+    "uninstall_hook",
+]

--- a/redcon/hooks/claude_code.py
+++ b/redcon/hooks/claude_code.py
@@ -1,0 +1,221 @@
+"""
+Claude Code hook integration: deterministic context injection.
+
+MCP registration and AGENTS.md instructions are advisory - the model
+may or may not use the tools. Claude Code hooks are code, not advice:
+a UserPromptSubmit hook runs on every prompt, and whatever it prints
+to stdout is added to the model's context. Installing the redcon hook
+therefore guarantees the agent starts each task with a ranked map of
+the relevant files, regardless of which tools it later chooses.
+
+Safety rules, in order of importance:
+
+1. The hook must never break the user's prompt. Every failure path
+   exits 0 with no output (fail-open).
+2. The user's settings file is precious. If .claude/settings.json
+   exists but cannot be parsed, installation refuses to touch it
+   instead of overwriting.
+3. The injected block is small (hard character cap) - a context
+   budgeting tool must not become a context tax.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+# The command written into settings.json. Kept stable so status and
+# uninstall can find entries by substring across versions.
+HOOK_COMMAND = "redcon hooks run user-prompt-submit"
+_HOOK_MARKER = "redcon hooks run"
+_HOOK_TIMEOUT_SECONDS = 20
+
+# Injection size cap: roughly 600 tokens at ~4 chars/token.
+_MAX_CONTEXT_CHARS = 2400
+
+# Prompts shorter than this are conversational ("ok", "yes", "retry")
+# and get no injection; ranking noise would outweigh any value.
+_MIN_PROMPT_CHARS = 20
+
+_DISABLE_ENV = "REDCON_HOOK_DISABLE"
+
+
+def _settings_path(project_root: Path) -> Path:
+    return project_root / ".claude" / "settings.json"
+
+
+def _load_settings(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    """Return (settings, error). Missing file is an empty settings dict."""
+    if not path.exists():
+        return {}, None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        return None, f"cannot parse {path}: {e}"
+    if not isinstance(data, dict):
+        return None, f"{path} does not contain a JSON object"
+    return data, None
+
+
+def _entry_has_redcon(entry: Any) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    for hook in entry.get("hooks", []):
+        if isinstance(hook, dict) and _HOOK_MARKER in str(hook.get("command", "")):
+            return True
+    return False
+
+
+def install_hook(project_root: Path) -> dict[str, Any]:
+    """Register the UserPromptSubmit hook in .claude/settings.json."""
+    path = _settings_path(project_root)
+    settings, error = _load_settings(path)
+    if settings is None:
+        return {"status": "error", "path": str(path), "message": error}
+
+    hooks = settings.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        return {
+            "status": "error",
+            "path": str(path),
+            "message": "existing 'hooks' key is not an object; refusing to overwrite",
+        }
+    submit = hooks.setdefault("UserPromptSubmit", [])
+    if not isinstance(submit, list):
+        return {
+            "status": "error",
+            "path": str(path),
+            "message": "existing 'UserPromptSubmit' key is not a list; refusing to overwrite",
+        }
+
+    if any(_entry_has_redcon(entry) for entry in submit):
+        return {
+            "status": "up_to_date",
+            "path": str(path),
+            "message": "redcon hook already registered",
+        }
+
+    submit.append(
+        {
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": HOOK_COMMAND,
+                    "timeout": _HOOK_TIMEOUT_SECONDS,
+                }
+            ]
+        }
+    )
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+    except OSError as e:
+        return {"status": "error", "path": str(path), "message": f"write failed: {e}"}
+    return {
+        "status": "installed",
+        "path": str(path),
+        "message": "redcon UserPromptSubmit hook registered",
+    }
+
+
+def uninstall_hook(project_root: Path) -> dict[str, Any]:
+    """Remove redcon hook entries, preserving everything else."""
+    path = _settings_path(project_root)
+    settings, error = _load_settings(path)
+    if settings is None:
+        return {"status": "error", "path": str(path), "message": error}
+
+    hooks = settings.get("hooks")
+    submit = hooks.get("UserPromptSubmit") if isinstance(hooks, dict) else None
+    if not isinstance(submit, list) or not any(_entry_has_redcon(e) for e in submit):
+        return {"status": "not_installed", "path": str(path), "message": "no redcon hook found"}
+
+    hooks["UserPromptSubmit"] = [e for e in submit if not _entry_has_redcon(e)]
+    if not hooks["UserPromptSubmit"]:
+        del hooks["UserPromptSubmit"]
+    if not hooks:
+        settings.pop("hooks", None)
+
+    try:
+        path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+    except OSError as e:
+        return {"status": "error", "path": str(path), "message": f"write failed: {e}"}
+    return {"status": "removed", "path": str(path), "message": "redcon hook removed"}
+
+
+def hook_status(project_root: Path) -> Path | None:
+    """Return the settings path when the redcon hook is registered."""
+    path = _settings_path(project_root)
+    settings, _error = _load_settings(path)
+    if not settings:
+        return None
+    hooks = settings.get("hooks")
+    submit = hooks.get("UserPromptSubmit") if isinstance(hooks, dict) else None
+    if isinstance(submit, list) and any(_entry_has_redcon(e) for e in submit):
+        return path
+    return None
+
+
+def build_prompt_context(prompt: str, repo: Path, top_k: int = 8) -> str | None:
+    """Build the compact context block injected for a user prompt.
+
+    Returns None whenever injection would be noise: conversational or
+    slash-command prompts, empty rankings, or any internal error.
+    """
+    text = (prompt or "").strip()
+    if len(text) < _MIN_PROMPT_CHARS:
+        return None
+    if text.startswith("/") or text.startswith("#"):
+        return None
+
+    try:
+        from redcon.core.pipeline import run_plan
+
+        plan = run_plan(text, repo=repo, top_n=top_k)
+    except Exception:
+        return None
+
+    ranked = plan.get("ranked_files") or []
+    if not ranked:
+        return None
+
+    lines = ["<redcon-context>", "Most relevant files for this task (ranked by redcon):"]
+    for item in ranked[:top_k]:
+        path = item.get("path", "")
+        score = item.get("score", 0)
+        reasons = item.get("reasons") or []
+        reason = str(reasons[0])[:70] if reasons else ""
+        suffix = f" - {reason}" if reason else ""
+        lines.append(f"- {path} ({score:.1f}){suffix}")
+    lines.append(
+        "Read these cheaply via the redcon MCP tools: redcon_compress for "
+        "single files, redcon_budget before bulk reads."
+    )
+    lines.append("</redcon-context>")
+
+    block = "\n".join(lines)
+    if len(block) > _MAX_CONTEXT_CHARS:
+        block = block[: _MAX_CONTEXT_CHARS - 20].rsplit("\n", 1)[0] + "\n</redcon-context>"
+    return block
+
+
+def run_user_prompt_submit(stdin_text: str) -> int:
+    """Entry point for the UserPromptSubmit hook. Always exits 0."""
+    try:
+        if os.environ.get(_DISABLE_ENV, "") not in ("", "0"):
+            return 0
+        payload = json.loads(stdin_text or "{}")
+        if not isinstance(payload, dict):
+            return 0
+        prompt = str(payload.get("prompt", ""))
+        cwd = Path(str(payload.get("cwd") or ".")).resolve()
+        block = build_prompt_context(prompt, cwd)
+        if block:
+            print(block)
+    except Exception:
+        # Fail-open: the user's prompt must never be delayed or blocked
+        # by a context helper.
+        return 0
+    return 0

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -1,0 +1,182 @@
+"""Tests for the Claude Code UserPromptSubmit hook integration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from redcon.hooks.claude_code import (
+    HOOK_COMMAND,
+    build_prompt_context,
+    hook_status,
+    install_hook,
+    run_user_prompt_submit,
+    uninstall_hook,
+)
+
+
+def _settings(tmp_path: Path) -> dict:
+    return json.loads((tmp_path / ".claude" / "settings.json").read_text())
+
+
+def _write_settings(tmp_path: Path, data: dict) -> Path:
+    path = tmp_path / ".claude" / "settings.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def _write_repo(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir(parents=True, exist_ok=True)
+    (src / "auth.py").write_text("def login(token):\n    return token.startswith('prod_')\n" * 5)
+    (src / "billing.py").write_text("def charge(amount):\n    return amount\n" * 5)
+
+
+# --- install / uninstall / status ---
+
+
+def test_install_creates_settings_with_hook(tmp_path: Path):
+    result = install_hook(tmp_path)
+    assert result["status"] == "installed"
+
+    data = _settings(tmp_path)
+    entries = data["hooks"]["UserPromptSubmit"]
+    assert len(entries) == 1
+    hook = entries[0]["hooks"][0]
+    assert hook["type"] == "command"
+    assert hook["command"] == HOOK_COMMAND
+    assert hook["timeout"] > 0
+
+
+def test_install_is_idempotent(tmp_path: Path):
+    install_hook(tmp_path)
+    result = install_hook(tmp_path)
+    assert result["status"] == "up_to_date"
+    assert len(_settings(tmp_path)["hooks"]["UserPromptSubmit"]) == 1
+
+
+def test_install_preserves_existing_settings_and_hooks(tmp_path: Path):
+    _write_settings(
+        tmp_path,
+        {
+            "permissions": {"allow": ["Bash(npm test)"]},
+            "hooks": {
+                "UserPromptSubmit": [{"hooks": [{"type": "command", "command": "other-tool run"}]}],
+                "PreToolUse": [
+                    {"matcher": "Bash", "hooks": [{"type": "command", "command": "guard"}]}
+                ],
+            },
+        },
+    )
+
+    assert install_hook(tmp_path)["status"] == "installed"
+
+    data = _settings(tmp_path)
+    assert data["permissions"] == {"allow": ["Bash(npm test)"]}
+    assert len(data["hooks"]["PreToolUse"]) == 1
+    submit = data["hooks"]["UserPromptSubmit"]
+    assert len(submit) == 2
+    assert submit[0]["hooks"][0]["command"] == "other-tool run"
+
+
+def test_install_refuses_to_touch_unparseable_settings(tmp_path: Path):
+    path = tmp_path / ".claude" / "settings.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("{not json", encoding="utf-8")
+
+    result = install_hook(tmp_path)
+    assert result["status"] == "error"
+    # The broken file is left exactly as it was.
+    assert path.read_text() == "{not json"
+
+
+def test_uninstall_removes_only_redcon_entries(tmp_path: Path):
+    _write_settings(
+        tmp_path,
+        {
+            "hooks": {
+                "UserPromptSubmit": [
+                    {"hooks": [{"type": "command", "command": "other-tool run"}]},
+                    {"hooks": [{"type": "command", "command": HOOK_COMMAND}]},
+                ]
+            }
+        },
+    )
+
+    assert uninstall_hook(tmp_path)["status"] == "removed"
+    submit = _settings(tmp_path)["hooks"]["UserPromptSubmit"]
+    assert len(submit) == 1
+    assert submit[0]["hooks"][0]["command"] == "other-tool run"
+
+
+def test_uninstall_cleans_empty_structures(tmp_path: Path):
+    install_hook(tmp_path)
+    assert uninstall_hook(tmp_path)["status"] == "removed"
+    assert "hooks" not in _settings(tmp_path)
+
+
+def test_uninstall_when_not_installed(tmp_path: Path):
+    assert uninstall_hook(tmp_path)["status"] == "not_installed"
+
+
+def test_status_reflects_registration(tmp_path: Path):
+    assert hook_status(tmp_path) is None
+    install_hook(tmp_path)
+    assert hook_status(tmp_path) == tmp_path / ".claude" / "settings.json"
+
+
+# --- context building ---
+
+
+def test_context_block_ranks_relevant_files(tmp_path: Path):
+    _write_repo(tmp_path)
+    block = build_prompt_context("fix the login token validation in auth", tmp_path)
+    assert block is not None
+    assert block.startswith("<redcon-context>")
+    assert block.endswith("</redcon-context>")
+    assert "src/auth.py" in block
+    assert "redcon_compress" in block
+
+
+def test_short_and_slash_prompts_are_skipped(tmp_path: Path):
+    _write_repo(tmp_path)
+    assert build_prompt_context("ok", tmp_path) is None
+    assert build_prompt_context("retry", tmp_path) is None
+    assert build_prompt_context("/compact keep the current task list", tmp_path) is None
+
+
+def test_context_fails_open_on_broken_repo(tmp_path: Path):
+    assert build_prompt_context("fix the login token validation", tmp_path / "nope") is None
+
+
+# --- hook entry point ---
+
+
+def test_run_hook_prints_context_and_exits_zero(tmp_path: Path, capsys: pytest.CaptureFixture):
+    _write_repo(tmp_path)
+    payload = json.dumps({"prompt": "fix the login token validation in auth", "cwd": str(tmp_path)})
+    assert run_user_prompt_submit(payload) == 0
+    out = capsys.readouterr().out
+    assert "<redcon-context>" in out
+    assert "src/auth.py" in out
+
+
+def test_run_hook_is_silent_on_garbage_input(capsys: pytest.CaptureFixture):
+    assert run_user_prompt_submit("definitely not json") == 0
+    assert run_user_prompt_submit("") == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_run_hook_respects_disable_env(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _write_repo(tmp_path)
+    monkeypatch.setenv("REDCON_HOOK_DISABLE", "1")
+    payload = json.dumps({"prompt": "fix the login token validation in auth", "cwd": str(tmp_path)})
+    assert run_user_prompt_submit(payload) == 0
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
## Summary

First fully deterministic redcon integration. `redcon hooks install` registers a Claude Code `UserPromptSubmit` hook; from then on every prompt in the project starts with a compact ranked file map, guaranteed by the hook system rather than left to the model's tool-choosing mood.

## How it works

- `redcon hooks install [--repo .]` merges an entry into `.claude/settings.json` registering `redcon hooks run user-prompt-submit` on `UserPromptSubmit`.
- On every prompt, the agent pipes `{prompt, cwd, ...}` to the hook. The hook ranks the repo against the prompt (scan + score fast path, no compression) and prints a compact ranked file map. Stdout of a UserPromptSubmit hook is added to the model's context, so the map always arrives.
- `redcon hooks status` / `redcon hooks uninstall` complete the lifecycle; `redcon init` mentions the command.

## Safety rules (enforced and tested)

- **Fail-open**: every failure path exits 0 with no output; a context helper must never delay or block the user's prompt.
- **Settings are precious**: an unparseable `settings.json` is never overwritten. Install/uninstall preserve unrelated settings and other tools' hooks, and are idempotent.
- **No context tax**: the block is hard-capped (~600 tokens); conversational prompts (under 20 chars), slash commands and memory shortcuts get no injection. `REDCON_HOOK_DISABLE=1` pauses injection without uninstalling.

## Test Coverage

- [x] All existing tests pass

Fourteen new tests in `tests/test_claude_hooks.py` (settings creation, idempotence, preservation, refusal on unparseable settings, uninstall precision, status, context block content, skip guards, fail-open, hook entry point, disable env var). Full suite: 927 passed, 13 skipped. End-to-end verified via the real CLI in a sandbox project.

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression