### PR TITLE
feat(core): mirror every pack report into .redcon/runs/

### DIFF
--- a/redcon/core/pipeline.py
+++ b/redcon/core/pipeline.py
@@ -1,26 +1,30 @@
-from __future__ import annotations
-
 """Top-level pipeline API wrappers preserving CLI compatibility."""
 
+from __future__ import annotations
+
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any
 
 from redcon.cache import RunHistoryEntry, append_run_history_entry, normalize_cache_report
 from redcon.compressors.summarizers import normalize_summarizer_report
 from redcon.config import RedconConfig, WorkspaceDefinition, load_config
-from redcon.core.delta import build_delta_report, effective_pack_metrics, resolve_previous_run_label
 from redcon.core.agent_planning import build_agent_workflow_plan
 from redcon.core.agent_simulation import simulate_agent_workflow
-from redcon.core.model_profiles import normalize_model_profile_report, prepare_config_for_model_profile
+from redcon.core.delta import build_delta_report, effective_pack_metrics, resolve_previous_run_label
 from redcon.core.diffing import diff_run_artifacts
 from redcon.core.heatmap import build_heatmap_report, heatmap_as_dict
+from redcon.core.model_profiles import (
+    normalize_model_profile_report,
+    prepare_config_for_model_profile,
+)
 from redcon.core.pr_audit import analyze_pull_request, pr_audit_as_dict
 from redcon.core.render import read_json, render_pr_comment_markdown
+from redcon.core.run_feed import write_run_feed_artifact
 from redcon.core.tokens import normalize_token_estimator_report
 from redcon.plugins import ResolvedPlugins, resolve_plugins
-from redcon.scorers.import_graph import build_import_graph
 from redcon.schemas.models import DEFAULT_TOP_FILES, RunReport
-from redcon.telemetry import TelemetrySession, TelemetrySink, build_telemetry_sink
+from redcon.scorers.import_graph import build_import_graph
 from redcon.stages.workflow import (
     as_json_dict,
     build_agent_plan_result,
@@ -32,6 +36,7 @@ from redcon.stages.workflow import (
     run_scan_workspace_stage,
     run_score_stage,
 )
+from redcon.telemetry import TelemetrySession, TelemetrySink, build_telemetry_sink
 
 
 def _resolve_config(
@@ -93,7 +98,9 @@ def run_plan(
     cfg = _resolve_config(config, repo, workspace, config_path)
     prepared_cfg, model_profile = prepare_config_for_model_profile(cfg)
     resolved_plugins = plugins if plugins is not None else resolve_plugins(prepared_cfg)
-    effective_top_n = top_n if top_n is not None else (prepared_cfg.budget.top_files or DEFAULT_TOP_FILES)
+    effective_top_n = (
+        top_n if top_n is not None else (prepared_cfg.budget.top_files or DEFAULT_TOP_FILES)
+    )
     target_repo = workspace.root if workspace is not None else repo
     telemetry = _build_telemetry_session(
         repo=target_repo,
@@ -114,7 +121,12 @@ def run_plan(
         scanned_repos = []
     telemetry.emit("scan_completed", scanned_files=len(files), scanned_repos=len(scanned_repos))
     ranked = run_score_stage(task, files, prepared_cfg, repo=target_repo, plugins=resolved_plugins)
-    telemetry.emit("scoring_completed", scanned_files=len(files), ranked_files=len(ranked), top_files=effective_top_n)
+    telemetry.emit(
+        "scoring_completed",
+        scanned_files=len(files),
+        ranked_files=len(ranked),
+        top_files=effective_top_n,
+    )
     plan = build_plan_result(
         task,
         target_repo,
@@ -161,7 +173,9 @@ def run_plan_agent(
     cfg = _resolve_config(config, repo, workspace, config_path)
     prepared_cfg, model_profile = prepare_config_for_model_profile(cfg)
     resolved_plugins = plugins if plugins is not None else resolve_plugins(prepared_cfg)
-    effective_top_n = top_n if top_n is not None else (prepared_cfg.budget.top_files or DEFAULT_TOP_FILES)
+    effective_top_n = (
+        top_n if top_n is not None else (prepared_cfg.budget.top_files or DEFAULT_TOP_FILES)
+    )
     target_repo = workspace.root if workspace is not None else repo
     telemetry = _build_telemetry_session(
         repo=target_repo,
@@ -182,7 +196,12 @@ def run_plan_agent(
         scanned_repos = []
     telemetry.emit("scan_completed", scanned_files=len(files), scanned_repos=len(scanned_repos))
     ranked = run_score_stage(task, files, prepared_cfg, repo=target_repo, plugins=resolved_plugins)
-    telemetry.emit("scoring_completed", scanned_files=len(files), ranked_files=len(ranked), top_files=effective_top_n)
+    telemetry.emit(
+        "scoring_completed",
+        scanned_files=len(files),
+        ranked_files=len(ranked),
+        top_files=effective_top_n,
+    )
     workflow_plan = build_agent_workflow_plan(
         task=task,
         files=files,
@@ -251,7 +270,9 @@ def run_simulate_agent(
     cfg = _resolve_config(config, repo, workspace, config_path)
     prepared_cfg, model_profile = prepare_config_for_model_profile(cfg)
     resolved_plugins = plugins if plugins is not None else resolve_plugins(prepared_cfg)
-    effective_top_n = top_n if top_n is not None else (prepared_cfg.budget.top_files or DEFAULT_TOP_FILES)
+    effective_top_n = (
+        top_n if top_n is not None else (prepared_cfg.budget.top_files or DEFAULT_TOP_FILES)
+    )
     target_repo = workspace.root if workspace is not None else repo
     telemetry = _build_telemetry_session(
         repo=target_repo,
@@ -272,7 +293,12 @@ def run_simulate_agent(
         scanned_repos = []
     telemetry.emit("scan_completed", scanned_files=len(files), scanned_repos=len(scanned_repos))
     ranked = run_score_stage(task, files, prepared_cfg, repo=target_repo, plugins=resolved_plugins)
-    telemetry.emit("scoring_completed", scanned_files=len(files), ranked_files=len(ranked), top_files=effective_top_n)
+    telemetry.emit(
+        "scoring_completed",
+        scanned_files=len(files),
+        ranked_files=len(ranked),
+        top_files=effective_top_n,
+    )
 
     simulation = simulate_agent_workflow(
         task=task,
@@ -350,7 +376,9 @@ def run_pack(
     """Run pack command pipeline and return typed run report."""
 
     cfg = _resolve_config(config, repo, workspace, config_path)
-    prepared_cfg, model_profile = prepare_config_for_model_profile(cfg, requested_max_tokens=max_tokens)
+    prepared_cfg, model_profile = prepare_config_for_model_profile(
+        cfg, requested_max_tokens=max_tokens
+    )
     resolved_plugins = plugins if plugins is not None else resolve_plugins(prepared_cfg)
     effective_max_tokens = prepared_cfg.budget.max_tokens
     effective_top_files = top_files if top_files is not None else prepared_cfg.budget.top_files
@@ -361,7 +389,9 @@ def run_pack(
         command="pack",
         telemetry_sink=telemetry_sink,
     )
-    telemetry_top_files = effective_top_files if effective_top_files is not None else DEFAULT_TOP_FILES
+    telemetry_top_files = (
+        effective_top_files if effective_top_files is not None else DEFAULT_TOP_FILES
+    )
     telemetry.emit(
         "run_started",
         max_tokens=effective_max_tokens,
@@ -378,12 +408,19 @@ def run_pack(
     telemetry.emit("scan_completed", scanned_files=len(files), scanned_repos=len(scanned_repos))
     ranked = run_score_stage(task, files, prepared_cfg, repo=target_repo, plugins=resolved_plugins)
     ranked_count = len(ranked)
-    telemetry.emit("scoring_completed", scanned_files=len(files), ranked_files=ranked_count, top_files=telemetry_top_files)
+    telemetry.emit(
+        "scoring_completed",
+        scanned_files=len(files),
+        ranked_files=ranked_count,
+        top_files=telemetry_top_files,
+    )
     if effective_top_files is not None:
         ranked = ranked[:effective_top_files]
     # Build import graph once and share with compression stage to avoid
     # rebuilding it from disk reads.
-    import_graph = build_import_graph(files) if prepared_cfg.score.enable_import_graph_signals else None
+    import_graph = (
+        build_import_graph(files) if prepared_cfg.score.enable_import_graph_signals else None
+    )
     cache = run_cache_stage(target_repo, prepared_cfg)
     pack_plugins = resolved_plugins
     if import_graph is not None:
@@ -392,7 +429,10 @@ def run_pack(
             scorer=resolved_plugins.scorer,
             scorer_options=resolved_plugins.scorer_options,
             compressor=resolved_plugins.compressor,
-            compressor_options={**resolved_plugins.compressor_options, "import_graph": import_graph},
+            compressor_options={
+                **resolved_plugins.compressor_options,
+                "import_graph": import_graph,
+            },
             token_estimator=resolved_plugins.token_estimator,
             token_estimator_options=resolved_plugins.token_estimator_options,
             token_estimator_report=resolved_plugins.token_estimator_report,
@@ -432,6 +472,14 @@ def run_pack(
         model_profile=model_profile,
     )
     if record_history:
+        # Mirror the full report into .redcon/runs/ so editor
+        # integrations see this run no matter which entry point made it
+        # (CLI, SDK, MCP tools, middleware).
+        feed_path = (
+            write_run_feed_artifact(target_repo, as_json_dict(report))
+            if prepared_cfg.cache.run_history_enabled
+            else None
+        )
         selected_set = set(report.files_included)
         considered_files = [item.file.path for item in ranked]
         append_run_history_entry(
@@ -444,12 +492,18 @@ def run_pack(
                 candidate_files=considered_files,
                 token_usage={
                     "max_tokens": effective_max_tokens,
-                    "estimated_input_tokens": int(report.budget.get("estimated_input_tokens", 0) or 0),
-                    "estimated_saved_tokens": int(report.budget.get("estimated_saved_tokens", 0) or 0),
-                    "quality_risk_estimate": str(report.budget.get("quality_risk_estimate", "unknown")),
+                    "estimated_input_tokens": int(
+                        report.budget.get("estimated_input_tokens", 0) or 0
+                    ),
+                    "estimated_saved_tokens": int(
+                        report.budget.get("estimated_saved_tokens", 0) or 0
+                    ),
+                    "quality_risk_estimate": str(
+                        report.budget.get("quality_risk_estimate", "unknown")
+                    ),
                 },
                 result_artifacts={
-                    "run_json": "",
+                    "run_json": str(feed_path) if feed_path else "",
                     "run_markdown": "",
                 },
                 repo=str(target_repo),
@@ -506,6 +560,7 @@ def run_pack(
     )
     return report
 
+
 def run_report_from_json(data: dict) -> dict:
     """Extract report summary fields from a run JSON payload."""
 
@@ -541,7 +596,9 @@ def run_report_from_json(data: dict) -> dict:
     return report
 
 
-def run_diff_from_json(old_data: dict, new_data: dict, old_label: str = "old", new_label: str = "new") -> dict:
+def run_diff_from_json(
+    old_data: dict, new_data: dict, old_label: str = "old", new_label: str = "new"
+) -> dict:
     """Build a run-to-run delta report from two run JSON payloads."""
 
     return diff_run_artifacts(old_data, new_data, old_label=old_label, new_label=new_label)
@@ -577,5 +634,3 @@ def run_heatmap(history: Sequence[str | Path] | None = None, *, limit: int = 10)
 
     report = build_heatmap_report(history, limit=limit)
     return heatmap_as_dict(report)
-
-

--- a/redcon/core/run_feed.py
+++ b/redcon/core/run_feed.py
@@ -1,0 +1,88 @@
+"""Run feed - mirror every pack report into ``.redcon/runs/``.
+
+Editor integrations (the VS Code panel and dashboard) can only show
+runs they can find on disk. The CLI writes ``run.json`` next to the
+repo, but packs triggered through the SDK, the MCP tools or the agent
+middleware never produced an artifact, so those runs were invisible.
+
+This module gives every entry point one shared sink: the pipeline
+mirrors the full run report into ``.redcon/runs/`` right where the
+run happened. Consumers just watch that directory; no polling of
+SQLite history (which non-Python tooling cannot read) is needed.
+
+The feed is best-effort by design: a failed write never fails a pack.
+Set the ``REDCON_NO_RUN_FEED`` environment variable to disable it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+RUN_FEED_DIRNAME = "runs"
+RUN_FEED_MAX_FILES = 30
+RUN_FEED_DISABLE_ENV = "REDCON_NO_RUN_FEED"
+
+
+def run_feed_dir(repo_path: Path | str) -> Path:
+    return Path(repo_path) / ".redcon" / RUN_FEED_DIRNAME
+
+
+def write_run_feed_artifact(repo_path: Path | str, report: dict[str, Any]) -> Path | None:
+    """Write ``report`` (a serialized RunReport) into the feed directory.
+
+    Returns the artifact path, or ``None`` when the feed is disabled or
+    the write failed. Never raises: the feed is a side channel and must
+    not break the pack that produced the report.
+    """
+    if os.environ.get(RUN_FEED_DISABLE_ENV):
+        return None
+    try:
+        feed_dir = run_feed_dir(repo_path)
+        feed_dir.mkdir(parents=True, exist_ok=True)
+        path = _next_artifact_path(feed_dir, str(report.get("generated_at", "")))
+        path.write_text(
+            json.dumps(report, indent=2, default=str, sort_keys=False),
+            encoding="utf-8",
+        )
+        prune_run_feed(feed_dir)
+        return path
+    except Exception:
+        logger.debug("run feed: artifact write failed", exc_info=True)
+        return None
+
+
+def _next_artifact_path(feed_dir: Path, generated_at: str) -> Path:
+    # "2026-07-13T09:01:23.456Z" -> "20260713T090123"; empty/odd inputs
+    # fall back to a bare "run" stem instead of failing the write.
+    stamp = re.sub(r"[^0-9T]", "", generated_at)[:15]
+    base = f"run-{stamp}" if stamp else "run"
+    path = feed_dir / f"{base}.json"
+    counter = 1
+    while path.exists():
+        path = feed_dir / f"{base}-{counter}.json"
+        counter += 1
+    return path
+
+
+def prune_run_feed(feed_dir: Path, keep: int = RUN_FEED_MAX_FILES) -> None:
+    """Keep the newest ``keep`` artifacts, delete the rest."""
+    try:
+        files = sorted(
+            feed_dir.glob("run-*.json"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+    except OSError:
+        return
+    for stale in files[keep:]:
+        try:
+            stale.unlink()
+        except OSError:
+            logger.debug("run feed: could not prune %s", stale, exc_info=True)

--- a/tests/test_pack_pipeline.py
+++ b/tests/test_pack_pipeline.py
@@ -40,7 +40,13 @@ def test_run_pack_records_history_entry(tmp_path: Path) -> None:
     assert entry.task == "tighten auth checks"
     assert entry.selected_files == data["files_included"]
     assert entry.token_usage["estimated_input_tokens"] == data["budget"]["estimated_input_tokens"]
-    assert entry.result_artifacts == {"run_json": "", "run_markdown": ""}
+    # The run feed mirrors the report into .redcon/runs/ and the history
+    # entry points at that artifact.
+    run_json = entry.result_artifacts["run_json"]
+    assert run_json
+    assert Path(run_json).is_file()
+    assert json.loads(Path(run_json).read_text(encoding="utf-8"))["task"] == "tighten auth checks"
+    assert entry.result_artifacts["run_markdown"] == ""
 
 
 def test_pack_never_exceeds_budget_under_degradation(tmp_path: Path) -> None:

--- a/tests/test_run_feed.py
+++ b/tests/test_run_feed.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from redcon.core.pipeline import run_pack
+from redcon.core.run_feed import (
+    RUN_FEED_DISABLE_ENV,
+    prune_run_feed,
+    run_feed_dir,
+    write_run_feed_artifact,
+)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_pack_writes_feed_artifact(tmp_path: Path) -> None:
+    """Every pack run leaves a full report in .redcon/runs/.
+
+    This is the plug and play contract for editor integrations: the
+    pipeline is the chokepoint every entry point (CLI, SDK, MCP tools,
+    middleware) flows through, so a pack made by an agent in Cursor or
+    Claude Code is visible to the VS Code panel without any manual step.
+    """
+    _write(tmp_path / "src" / "auth.py", "def auth():\n    return True\n" * 10)
+
+    run_pack("add rate limiting", repo=tmp_path, max_tokens=500)
+
+    artifacts = list(run_feed_dir(tmp_path).glob("run-*.json"))
+    assert len(artifacts) == 1
+    data = json.loads(artifacts[0].read_text(encoding="utf-8"))
+    assert data["command"] == "pack"
+    assert data["task"] == "add rate limiting"
+    assert "estimated_saved_tokens" in data["budget"]
+    assert data["generated_at"]
+
+
+def test_feed_disabled_by_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(RUN_FEED_DISABLE_ENV, "1")
+    _write(tmp_path / "src" / "auth.py", "def auth():\n    return True\n")
+
+    run_pack("add rate limiting", repo=tmp_path, max_tokens=500)
+
+    assert not run_feed_dir(tmp_path).exists()
+
+
+def test_feed_respects_history_disabled(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "auth.py", "def auth():\n    return True\n")
+    _write(
+        tmp_path / "redcon.toml",
+        "[cache]\nrun_history_enabled = false\n",
+    )
+
+    run_pack("add rate limiting", repo=tmp_path, max_tokens=500)
+
+    assert not run_feed_dir(tmp_path).exists()
+
+
+def test_feed_artifacts_get_unique_names(tmp_path: Path) -> None:
+    report = {"generated_at": "2026-07-13T09:00:00Z", "command": "pack"}
+    first = write_run_feed_artifact(tmp_path, report)
+    second = write_run_feed_artifact(tmp_path, report)
+
+    assert first is not None and second is not None
+    assert first != second
+    assert first.parent == second.parent == run_feed_dir(tmp_path)
+
+
+def test_feed_prunes_to_newest(tmp_path: Path) -> None:
+    feed = run_feed_dir(tmp_path)
+    feed.mkdir(parents=True)
+    for i in range(12):
+        artifact = feed / f"run-2026071310{i:02d}.json"
+        artifact.write_text("{}", encoding="utf-8")
+        # Distinct mtimes so newest-first ordering is deterministic.
+        import os
+
+        os.utime(artifact, (1000 + i, 1000 + i))
+
+    prune_run_feed(feed, keep=5)
+
+    remaining = sorted(p.name for p in feed.glob("run-*.json"))
+    assert len(remaining) == 5
+    assert remaining == [f"run-2026071310{i:02d}.json" for i in range(7, 12)]
+
+
+def test_feed_write_failure_is_silent(tmp_path: Path) -> None:
+    # A file where the .redcon directory should be makes mkdir fail;
+    # the feed must swallow it and return None instead of raising.
+    (tmp_path / ".redcon").write_text("not a directory", encoding="utf-8")
+
+    result = write_run_feed_artifact(tmp_path, {"generated_at": "x"})
+
+    assert result is None


### PR DESCRIPTION
## Summary

The Python half of plug&play run visibility: every pack run now mirrors its full report into `.redcon/runs/`, so editor integrations (the VS Code panel and dashboard) see runs made by any entry point without any manual step.

## Problem

The CLI writes `run.json` next to the repo, but packs triggered through the SDK, the MCP tools or the agent middleware never produced an artifact on disk - those runs were invisible to the VS Code extension. The run history entry's `result_artifacts.run_json` field was also always left empty.

## Changes

- New `redcon/core/run_feed.py`: `write_run_feed_artifact` writes the serialized run report into `.redcon/runs/`, prunes to the newest 30, and never raises. `REDCON_NO_RUN_FEED` disables it.
- `run_pack` in `core/pipeline.py` calls it at the single chokepoint every entry point flows through (CLI, SDK, MCP tools, middleware), gated by the same `run_history_enabled` config. The history entry now records the artifact path.
- Pre-existing ruff debt in `pipeline.py` cleared.

## Test Coverage

- [x] All existing tests pass

New `tests/test_run_feed.py` (artifact written by a real `run_pack`, env kill-switch, config gating, unique naming on timestamp collision, pruning order, silent failure when `.redcon` is not writable). Verified end-to-end that a pack triggered through the MCP `redcon_budget` tool leaves a feed artifact.

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression