### PR TITLE
release: bump version to 1.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redcon"
-version = "1.8.0"
+version = "1.9.0"
 description = "Deterministic context budgeting for coding-agent workflows"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/redcon/__init__.py
+++ b/redcon/__init__.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-__version__ = "1.8.0"
+__version__ = "1.9.0"
 
 # Mapping from public symbol name to the submodule it lives in. The first
 # attribute access triggers an import of that module and caches the symbol


### PR DESCRIPTION
## Summary

Version bump to 1.9.0 for the next PyPI release.

## Problem

PyPI is at 1.8.0; three merged features are unreleased: deterministic Claude Code hooks (#158), the sharpened MCP tool descriptions (#157) and the `.redcon/runs` run feed (#159) that makes agent runs visible to the VS Code extension.

## Changes

- `pyproject.toml` and `redcon/__init__.py` bumped 1.8.0 to 1.9.0. Nothing else.

After merge, the release workflow is dispatched on main with tag `v1.9.0` (trusted publishing to PyPI) and verified with a fresh-venv install.

## Test Coverage

- [x] All existing tests pass

Version-string-only change; CI runs the full suite on this PR.

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression