### PR TITLE
docs: pip-first getting started, MCP and hooks page, CLI reference gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Full reference: [docs/python-api.md](docs/python-api.md).
 
 - [Getting Started](docs/getting-started.md) - first pack in 60 seconds
 - [CLI Reference](docs/cli.md) - all commands and flags
+- [MCP and Hooks](docs/mcp-and-hooks.md) - agent integration, tool list, deterministic context injection
 - [Configuration](docs/configuration.md) - redcon.toml fields
 - [Workspaces](docs/workspace.md) - multi-repo setup
 - [Python API](docs/python-api.md) - programmatic usage

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,5 +1,32 @@
 # CLI Reference
 
+## Setup and Diagnostics
+
+### `redcon init`
+One-command project setup: writes a commented `redcon.toml`, registers the
+MCP server for detected agents (Claude Code, Cursor, Windsurf, VS Code,
+Codex, Gemini), installs the Claude Code hook and updates `AGENTS.md`.
+Idempotent; safe to re-run.
+
+### `redcon doctor`
+Environment diagnostics: Python version, optional extras (`tokenizers`,
+`redis`, `gateway`, `mcp`, `symbols`, `ast_grep`), MCP registration state,
+config validity, cache directory, git and disk space. Exit code reflects
+failures, so it works as a CI gate too.
+
+### `redcon mcp install | status | uninstall | serve`
+Manage the MCP server registration for coding agents. `serve` runs the
+stdio server itself (agents invoke it; you rarely run it by hand).
+See [MCP and hooks](mcp-and-hooks.md).
+
+### `redcon hooks install | status | uninstall | run`
+Manage the Claude Code `UserPromptSubmit` hook that injects a compact
+`<redcon-context>` block into every qualifying prompt. `run` is the hook
+entry point Claude Code executes. See [MCP and hooks](mcp-and-hooks.md).
+
+### `redcon completion <shell>`
+Print shell completion for bash, zsh or fish.
+
 ## Commands
 
 ### `redcon plan <task> --repo <path>`
@@ -647,3 +674,37 @@ ignore_globs = ["**/generated/**"]
 
 `plan`, `pack`, and `benchmark` automatically maintain `.redcon/scan-index.json`.
 Unchanged files reuse prior scan metadata; changed and deleted files are refreshed incrementally.
+
+## Command Output Compression
+
+### `redcon run <command>`
+Run a shell command and print its output compressed with the schema-aware
+compressor registry (pytest, git diff/status/log, grep, ls/find/tree, npm,
+go test, cargo, docker, kubectl, lint, coverage, profiler, json logs, sql
+explain, bundle stats). Flags: `--max-output-tokens`, `--remaining-tokens`,
+`--quality-floor {verbose,compact,ultra}`, `--timeout-seconds`, `--json`,
+`--no-history`, `--prefer-compact-output`.
+
+```bash
+redcon run "pytest -x"
+redcon run "git diff" --max-output-tokens 2000
+```
+
+### `redcon cmd-quality`
+Run the compression quality gate over the built-in case corpus (every
+registered compressor, small and stress fixtures). Fails non-zero on any
+quality regression; usable as a CI gate.
+
+### `redcon cmd-bench [--baseline <file>] [--tolerance N] [--json]`
+Benchmark compressor reduction rates against the same corpus and compare
+with an optional saved baseline.
+
+## Repo Map and ROI
+
+### `redcon repo-map <task> [--repo <path>] [--budget N] [--top-files N] [--json]`
+Symbol-level repository map ranked by task relevance (tree-sitter based;
+install `redcon[symbols]`). Cheap orientation for a new task or agent.
+
+### `redcon roi [runs ...] [--model M | --price-input P] [--json]`
+Aggregate estimated dollar savings across pack run artifacts. Defaults to
+`redcon-*.json` in the current directory; accepts files or directories.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,12 +3,37 @@
 ## Install
 
 ```bash
+pip install redcon
+```
+
+Useful extras (see [Optional extras](#optional-extras) below):
+
+```bash
+pip install "redcon[mcp]"          # MCP server for coding agents
+pip install "redcon[tokenizers]"   # exact token counts via tiktoken
+```
+
+Working on redcon itself? Use an editable install from a checkout instead:
+
+```bash
+git clone https://github.com/natiixnt/redcon
+cd redcon
 python3 -m pip install -e .[dev]
 ```
 
-## Core Workflow
+## First pack in 60 seconds
 
 ```bash
+cd your-project
+
+# One-command setup: writes redcon.toml, registers the MCP server for
+# detected agents (Claude Code, Cursor, Windsurf, VS Code, Codex,
+# Gemini) and updates AGENTS.md.
+redcon init
+
+# Check the environment (optional deps, MCP registration, config)
+redcon doctor
+
 # Rank relevant files
 redcon plan "add caching to search API" --repo .
 
@@ -19,6 +44,20 @@ redcon pack "add caching to search API" --repo . --max-tokens 30000
 redcon report run.json
 ```
 
+## Agent integration
+
+Two mechanisms make agents use redcon automatically:
+
+- **MCP server** (`redcon mcp install` / `status` / `uninstall`): exposes
+  redcon tools (rank, overview, compress, search, budget, run) to any
+  MCP-compatible agent. See [MCP and hooks](mcp-and-hooks.md).
+- **Claude Code hooks** (`redcon hooks install`): deterministic context
+  injection on every prompt, no reliance on the model choosing to call a
+  tool. See [MCP and hooks](mcp-and-hooks.md).
+
+`redcon init` sets both up for detected agents; the VS Code extension
+mirrors every run into its dashboard automatically.
+
 ## Extended Workflow
 
 ```bash
@@ -27,6 +66,23 @@ redcon diff old-run.json new-run.json
 
 # Compare packing strategies
 redcon benchmark "add rate limiting to auth API" --repo .
+```
+
+## Optional extras
+
+| Extra | Installs | Unlocks |
+| --- | --- | --- |
+| `mcp` | `mcp` | `redcon mcp serve` - the MCP server for coding agents |
+| `tokenizers` | `tiktoken` | exact token counts instead of the heuristic estimator |
+| `symbols` | `tree-sitter` + language packs | symbol extraction for repo-map and better file context |
+| `ast_grep` | `ast-grep-py` | structural code search fallback (CLI binary preferred) |
+| `redis` | `redis` | shared cache backend |
+| `gateway` | `fastapi`, `uvicorn` | `redcon-gateway` HTTP runtime |
+| `heavy_compression` | `llmlingua` | LLMLingua-2 semantic compression fallback (heavy: pulls torch) |
+| `dev` | `pytest`, `fakeredis` | running the test suite |
+
+```bash
+pip install "redcon[mcp,tokenizers,symbols]"
 ```
 
 ## Example Repositories

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@ Redcon is local-first infrastructure for deterministic context selection, compre
 
 - [Getting Started](getting-started.md)
 - [CLI Reference](cli.md)
+- [MCP and Hooks](mcp-and-hooks.md)
 - [Configuration](configuration.md)
 - [Workspace](workspace.md)
 - [Python API](python-api.md)

--- a/docs/mcp-and-hooks.md
+++ b/docs/mcp-and-hooks.md
@@ -1,0 +1,91 @@
+# MCP Server and Claude Code Hooks
+
+redcon integrates with coding agents through two complementary
+mechanisms. The MCP server is *advisory*: it gives the agent tools and
+good reasons to call them, but the model decides. The Claude Code hook
+is *deterministic*: redcon context is injected on every qualifying
+prompt whether or not the model would have asked for it.
+
+Both are configured automatically by `redcon init`; the commands below
+manage them individually.
+
+## MCP server
+
+Requires the `mcp` extra:
+
+```bash
+pip install "redcon[mcp]"
+```
+
+### Registering
+
+```bash
+redcon mcp install      # register for detected agents in this project
+redcon mcp status       # where is redcon registered?
+redcon mcp uninstall    # remove the registrations
+redcon mcp serve        # run the stdio server (agents invoke this)
+```
+
+`install` writes the appropriate config for each detected agent:
+Claude Code (`.mcp.json`), Cursor (`.cursor/mcp.json`), Windsurf,
+VS Code (`.vscode/mcp.json`), Codex (`~/.codex/config.toml`) and
+Gemini (`~/.gemini/settings.json`). Restart the IDE or agent session
+after installing so it picks up the new tools.
+
+### Tools exposed
+
+| Tool | What it does |
+| --- | --- |
+| `redcon_rank` | rank repository files by relevance to the task |
+| `redcon_overview` | lightweight repo map grouped by directory |
+| `redcon_compress` | compressed single-file content for cheap inspection |
+| `redcon_search` | regex search scoped to ranked files or the full repo |
+| `redcon_structural_search` | ast-grep structural code search |
+| `redcon_repo_map` | symbol-level repository map (tree-sitter) |
+| `redcon_quality_check` | compression quality gate for a command output |
+| `redcon_budget` | plan file packing within a token budget |
+| `redcon_run` | run a shell command and return its output compressed |
+
+Every pack triggered through MCP lands in `.redcon/runs/`, so the
+VS Code extension picks it up automatically.
+
+## Claude Code hooks
+
+No extra dependencies needed:
+
+```bash
+redcon hooks install    # writes a UserPromptSubmit hook to .claude/settings.json
+redcon hooks status     # is the hook registered?
+redcon hooks uninstall  # remove it
+```
+
+### What the hook does
+
+On every prompt submitted to Claude Code, `redcon hooks run
+user-prompt-submit` runs a fast file ranking (`run_plan`, top 8 files)
+and injects a compact `<redcon-context>` block with the most relevant
+files. The agent starts every task already knowing where to look,
+without reading the repository first.
+
+Guardrails, all deterministic:
+
+- prompts shorter than 20 characters are skipped (greetings, "ok")
+- slash commands (`/...`) and memory notes (`#...`) are skipped
+- the injected block is capped at 2400 characters
+- the hook is fail-open: any error exits 0 with no output, so a broken
+  hook can never block your prompt
+- set `REDCON_HOOK_DISABLE=1` to turn injection off without
+  uninstalling
+
+### Removing safely
+
+`redcon hooks uninstall` only removes the redcon entry from
+`.claude/settings.json`; it refuses to touch a file it cannot parse and
+leaves all other hooks intact.
+
+## Which one do I want?
+
+Both. MCP gives the agent on-demand tools for search, compression and
+budgeting mid-task; the hook guarantees a relevance-ranked starting
+point on every prompt. They share the same config (`redcon.toml`) and
+the same run feed, and `redcon doctor` verifies both setups.

--- a/docs/token-estimation.md
+++ b/docs/token-estimation.md
@@ -74,7 +74,7 @@ fallback_backend = "model_aligned"
 Install the optional exact tokenizer backend with:
 
 ```bash
-python3 -m pip install -e .[tokenizers]
+pip install "redcon[tokenizers]"
 ```
 
 ## Artifact Reporting


### PR DESCRIPTION
## Summary

Documentation half of the open-core readiness audit: the primary onboarding path now works for a PyPI user, the two flagship agent-integration features get a real page, and the CLI reference stops omitting shipped commands.

## Problem

- `docs/getting-started.md` opened with `pip install -e .[dev]`, which fails for anyone without a source checkout; `docs/token-estimation.md` repeated the same form.
- `redcon hooks` and `redcon mcp` had zero documentation anywhere.
- `docs/cli.md` had no sections for `init`, `doctor`, `mcp`, `hooks`, `run`, `cmd-quality`, `cmd-bench`, `repo-map`, `roi`.
- The optional-dependency extras were undocumented apart from `[mcp]`.

## Changes

- `docs/getting-started.md` rewritten: `pip install redcon` first, editable install moved to a contributor note, `redcon init` + `redcon doctor` as the entry path, and a table of all extras.
- New `docs/mcp-and-hooks.md`: registration commands per agent, the nine MCP tools, the deterministic Claude Code hook, safe uninstall, and when to use which.
- `docs/cli.md`: new Setup/Diagnostics and Command Output Compression sections, flags checked against the real parsers.
- `docs/token-estimation.md` install line fixed; new page linked from the docs index and README.

## Test Coverage

- [x] All existing tests pass

Docs-only change. Tool names, hook constants and command flags verified against the real code and `--help` output.

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression