### PR TITLE
docs(vscode): record the Pangram Pangram verdict on Telegraf

### DIFF
--- a/vscode-redcon/CHANGELOG.md
+++ b/vscode-redcon/CHANGELOG.md
@@ -45,9 +45,12 @@
 
 ### Notes
 
-- Telegraf display font is referenced with a system-stack fallback but
-  NOT bundled: the Pangram Pangram license must be verified before
-  shipping the OTF files inside the extension.
+- Telegraf display font is referenced with a system-stack fallback and
+  is NOT bundled, permanently: Pangram Pangram confirmed that OTF files
+  may not be redistributed inside an app or a public repository. Their
+  licenses cover embedding in closed, non-extractable products only, so
+  a font license only becomes relevant for a future closed commercial
+  tier.
 - Run history now records tokens saved per run (drives the hero and
   trend). Dashboard HTML rendering lives in a pure module
   (`webview/dashboardHtml.ts`) with no vscode dependency, verified by


### PR DESCRIPTION
## Summary

One-paragraph changelog update: the font licensing question is resolved.

## Problem

The 0.9.0 changelog said the font license "must be verified before shipping the OTF files inside the extension" - the verification has now happened and the answer is final, so the note should state the outcome instead of a pending question.

## Changes

- `vscode-redcon/CHANGELOG.md`: confirmed the OTF files may not be redistributed inside an app or a public repository; their licenses cover embedding in closed, non-extractable products only. The system-stack fallback is therefore the permanent solution for the public extension, and a font license only becomes relevant for a future closed commercial tier.

## Test Coverage

- [x] All existing tests pass

Docs-only change.

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression