### PR TITLE
fix(vscode): absolute image URLs so Marketplace screenshots load, 0.9.2

### DIFF
--- a/vscode-redcon/CHANGELOG.md
+++ b/vscode-redcon/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.9.2 - 2026-07-14
+
+### Fixed
+
+- README screenshots load on the Marketplace listing: image links now
+  use absolute raw URLs, since relative paths in a monorepo subfolder
+  get rewritten without the vscode-redcon/ prefix and 404.
+
 ## 0.9.1 - 2026-07-14
 
 ### Changed

--- a/vscode-redcon/README.md
+++ b/vscode-redcon/README.md
@@ -5,7 +5,7 @@ Deterministic context budgeting for AI coding agents. Rank, compress, and pack r
 ![VS Code](https://img.shields.io/badge/VS%20Code-1.85+-blue)
 ![License](https://img.shields.io/badge/license-FSL--1.1--MIT-blue)
 
-![Redcon Analytics dashboard](media/dashboard-dark.png)
+![Redcon Analytics dashboard](https://raw.githubusercontent.com/natiixnt/redcon/main/vscode-redcon/media/dashboard-dark.png)
 
 ---
 
@@ -19,7 +19,7 @@ full dashboard. Below it, a live run feed: every run shows the tokens
 that actually went to the agent against the gray would-be total, the
 cut percentage, age and a risk dot. Click any run to inspect it.
 
-<img src="media/panel-dark.png" width="330" alt="Redcon sidebar panel" />
+<img src="https://raw.githubusercontent.com/natiixnt/redcon/main/vscode-redcon/media/panel-dark.png" width="330" alt="Redcon sidebar panel" />
 
 ### Plug and play: agent runs appear by themselves
 

--- a/vscode-redcon/package.json
+++ b/vscode-redcon/package.json
@@ -2,7 +2,7 @@
   "name": "redcon",
   "displayName": "Redcon - Context Budget",
   "description": "Deterministic context budgeting for AI coding agents. Rank, compress, and pack repository context under token limits.",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "publisher": "redcon",
   "license": "FSL-1.1-MIT",
   "icon": "resources/icon.png",


### PR DESCRIPTION
## Summary

The Marketplace listing showed broken screenshot frames; this fixes the README image links and bumps to 0.9.2.

## Problem

vsce rewrites relative image paths in the README against the repository root, but this extension lives in the `vscode-redcon/` subfolder of a monorepo. The rewritten URLs lose the subfolder prefix and 404 on the listing, which renders as empty broken-image frames.

## Changes

- `README.md`: both screenshot links now use absolute `raw.githubusercontent.com/natiixnt/redcon/main/vscode-redcon/media/...` URLs, which work on the Marketplace, on GitHub and in the VSIX preview alike.
- Version 0.9.1 to 0.9.2, changelog entry added.

## Test Coverage

- [x] All existing tests pass

`tsc --noEmit` clean, build passes, `vsce package` produced the 0.9.2 VSIX; the raw URLs return the images.

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression