### PR TITLE
feat(vscode): benefit-led display name and description, 0.9.3

### DIFF
--- a/vscode-redcon/CHANGELOG.md
+++ b/vscode-redcon/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.9.3 - 2026-07-14
+
+### Changed
+
+- Display name is now "Redcon - Token Savings for AI Coding Agents"
+  and the listing description leads with the benefit; the extension id
+  (redcon.redcon) is unchanged, so installs and stats carry over.
+
 ## 0.9.2 - 2026-07-14
 
 ### Fixed

--- a/vscode-redcon/README.md
+++ b/vscode-redcon/README.md
@@ -1,4 +1,4 @@
-# Redcon - Context Budget for VS Code
+# Redcon - Token Savings for AI Coding Agents
 
 Deterministic context budgeting for AI coding agents. Rank, compress, and pack repository context under explicit token limits - and watch how many tokens (and dollars) redcon saves you, directly in your editor.
 

--- a/vscode-redcon/package.json
+++ b/vscode-redcon/package.json
@@ -1,8 +1,8 @@
 {
   "name": "redcon",
-  "displayName": "Redcon - Context Budget",
-  "description": "Deterministic context budgeting for AI coding agents. Rank, compress, and pack repository context under token limits.",
-  "version": "0.9.2",
+  "displayName": "Redcon - Token Savings for AI Coding Agents",
+  "description": "Save tokens and money on Claude Code, Cursor, Windsurf and other AI coding agents: redcon deterministically ranks, compresses and packs repository context under token limits, and shows you the savings.",
+  "version": "0.9.3",
   "publisher": "redcon",
   "license": "FSL-1.1-MIT",
   "icon": "resources/icon.png",


### PR DESCRIPTION
## Summary

The extension's Marketplace title now says what the user gets.

## Problem

"Redcon - Context Budget" describes the mechanism, not the benefit; a visitor scanning search results cannot tell what the extension does for them.

## Changes

- `displayName`: "Redcon - Token Savings for AI Coding Agents".
- `description` leads with the benefit: saving tokens and money on Claude Code, Cursor, Windsurf and other agents, with the mechanism second.
- README title matches. Version 0.9.2 to 0.9.3, changelog entry added.
- The extension id (`redcon.redcon`) is untouched, so installs, ratings and stats carry over.

## Test Coverage

- [x] All existing tests pass

`tsc --noEmit` clean, build passes, 0.9.3 VSIX packaged and manifest fields verified.

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression