### PR TITLE
security: trust-hardening pass (secrets, redcon_run gate, MCP confinement, gateway, extension)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -39,6 +39,10 @@ export RC_GATEWAY_API_KEY=my-secret-key
 redcon gateway --host 0.0.0.0 --port 8787
 ```
 
+The gateway refuses to start on a non-loopback host (anything other than
+`127.0.0.1` / `::1`) unless `RC_GATEWAY_API_KEY` is set, so an unauthenticated
+service is never exposed to the network by accident.
+
 ### Environment variables
 
 | Variable | Default | Description |

--- a/redcon/cmd/__init__.py
+++ b/redcon/cmd/__init__.py
@@ -23,6 +23,8 @@ from redcon.cmd.runner import (
     CommandTimeout,
     RunRequest,
     RunResult,
+    parse_command,
+    reject_dangerous_args,
     run_command,
 )
 from redcon.cmd.types import (
@@ -71,7 +73,9 @@ __all__ = [
     "clear_default_cache",
     "compress_command",
     "detect_compressor",
+    "parse_command",
     "register_compressor",
+    "reject_dangerous_args",
     "run_command",
     "select_level",
 ]

--- a/redcon/cmd/runner.py
+++ b/redcon/cmd/runner.py
@@ -15,11 +15,11 @@ huge outputs).
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import select
 import shlex
-import signal
 import subprocess
 import time
 from dataclasses import dataclass, field
@@ -31,7 +31,11 @@ _READ_CHUNK_BYTES = 64 * 1024
 _KILL_GRACE_SECONDS = 1.0
 
 
-# Commands we are willing to spawn from MCP. Extend as new compressors land.
+# Known tools whose output we have a compressor for. This is a schema
+# DETECTOR, not a security boundary: many entries (python, git, find, npm,
+# pip, docker, psql...) can execute arbitrary code via a subcommand or flag.
+# The host is responsible for deciding whether to run an agent-supplied
+# command at all - see the REDCON_MCP_ENABLE_RUN gate on the MCP tool.
 DEFAULT_ALLOWLIST: frozenset[str] = frozenset(
     {
         "git",
@@ -151,19 +155,64 @@ def parse_command(command: str | list[str] | tuple[str, ...]) -> tuple[str, ...]
     return argv
 
 
+# Flags/subcommands that turn an otherwise read-only tool into arbitrary code
+# execution. This is enforced at the AGENT boundary only (the MCP tools), not
+# in run_command itself: a user running `redcon run` on their own machine is
+# trusted, but an agent that may be prompt-injected is not. Matched
+# case-sensitively so `git -C dir` / `grep -C 3` (benign) are not confused
+# with `python -c` (code execution).
+_DANGEROUS_ARG_TOKENS: frozenset[str] = frozenset(
+    {
+        "-c",  # python -c, psql -c "COPY ... TO PROGRAM", sh -c
+        "-e",  # node -e, perl -e
+        "--eval",
+        "--exec",
+        "-exec",  # find -exec
+        "-execdir",
+        "-fprintf",
+        "run",  # npm run, docker run, cargo run
+        "install",  # pip install, npm install
+        "--command",
+        "--pager",
+    }
+)
+
+
+def reject_dangerous_args(argv: tuple[str, ...]) -> None:
+    """Raise CommandNotAllowed if argv contains a known code-execution escape.
+
+    Intended for callers that run agent-supplied commands. run_command does
+    not call this; the trust decision belongs to the caller.
+    """
+    for token in argv[1:]:
+        if token in _DANGEROUS_ARG_TOKENS:
+            raise CommandNotAllowed(
+                f"argument '{token}' can execute arbitrary code and is refused. "
+                "Run such commands yourself instead of through redcon."
+            )
+        low = token.lower()
+        # git -c core.pager=... / -o ProxyCommand=... style injection.
+        if low.startswith(("core.pager", "-o", "proxycommand")):
+            raise CommandNotAllowed(f"argument '{token}' is refused for safety.")
+
+
 def run_command(
     request: RunRequest,
     *,
     allowlist: frozenset[str] = DEFAULT_ALLOWLIST,
 ) -> RunResult:
-    """Execute the command, return captured output. Raises if not allowlisted."""
+    """Execute the command, return captured output. Raises if not allowlisted.
+
+    The allowlist selects a compressor schema; it is not a sandbox. Callers
+    exposing this to untrusted input (e.g. an agent) must gate execution
+    themselves - see reject_dangerous_args.
+    """
     if not request.argv:
         raise ValueError("argv is empty")
     binary = Path(request.argv[0]).name
     if binary not in allowlist:
         raise CommandNotAllowed(
-            f"command '{binary}' is not in the allowlist. "
-            f"Allowed: {sorted(allowlist)}"
+            f"command '{binary}' is not in the allowlist. Allowed: {sorted(allowlist)}"
         )
 
     cwd = request.cwd.resolve()
@@ -186,9 +235,7 @@ def run_command(
             stderr=subprocess.PIPE,
         )
     except FileNotFoundError as e:
-        raise BinaryNotFound(
-            f"binary '{request.argv[0]}' not found on PATH"
-        ) from e
+        raise BinaryNotFound(f"binary '{request.argv[0]}' not found on PATH") from e
 
     stdout_buf = bytearray()
     stderr_buf = bytearray()
@@ -205,8 +252,7 @@ def run_command(
             if now >= deadline:
                 _terminate(proc)
                 raise CommandTimeout(
-                    f"command timed out after {request.timeout_seconds}s: "
-                    f"{request.argv[0]}"
+                    f"command timed out after {request.timeout_seconds}s: {request.argv[0]}"
                 )
 
             streams = []
@@ -244,7 +290,9 @@ def run_command(
     finally:
         _drain_remaining(proc, stdout_buf, stderr_buf, cap, truncated_stdout, truncated_stderr)
 
-    returncode = proc.wait(timeout=_KILL_GRACE_SECONDS) if proc.returncode is None else proc.returncode
+    returncode = (
+        proc.wait(timeout=_KILL_GRACE_SECONDS) if proc.returncode is None else proc.returncode
+    )
     duration = time.monotonic() - started
 
     notes: list[str] = []
@@ -279,7 +327,11 @@ def _select_ready(streams: list, timeout: float) -> set:
 
 def _read_chunk(stream) -> bytes:
     try:
-        return stream.read1(_READ_CHUNK_BYTES) if hasattr(stream, "read1") else stream.read(_READ_CHUNK_BYTES)
+        return (
+            stream.read1(_READ_CHUNK_BYTES)
+            if hasattr(stream, "read1")
+            else stream.read(_READ_CHUNK_BYTES)
+        )
     except OSError:
         return b""
 
@@ -324,10 +376,8 @@ def _drain_remaining(
             remaining = b""
         if remaining:
             _append_capped(buf, remaining, cap, flag)
-        try:
+        with contextlib.suppress(OSError):
             stream.close()
-        except OSError:
-            pass
 
 
 def _terminate(proc: subprocess.Popen) -> None:
@@ -339,10 +389,8 @@ def _terminate(proc: subprocess.Popen) -> None:
     try:
         proc.wait(timeout=_KILL_GRACE_SECONDS)
     except subprocess.TimeoutExpired:
-        try:
+        with contextlib.suppress(OSError):
             proc.kill()
-        except OSError:
-            pass
         try:
             proc.wait(timeout=_KILL_GRACE_SECONDS)
         except subprocess.TimeoutExpired:

--- a/redcon/config.py
+++ b/redcon/config.py
@@ -38,6 +38,10 @@ class ScanSettings:
     preview_chars: int = 2_000
     ignore_dirs: set[str] = field(default_factory=lambda: set(DEFAULT_IGNORE_DIRS))
     binary_extensions: set[str] = field(default_factory=lambda: set(BINARY_EXTENSIONS))
+    # Exclude credential files (.env, keys, .pem, credentials, ...) from the
+    # scan by default so a pack can never leak secrets to an LLM. Turn off only
+    # if you deliberately need to pack such a file.
+    exclude_secrets: bool = True
 
 
 @dataclass(slots=True)
@@ -421,6 +425,8 @@ def _apply_scan_overrides(settings: ScanSettings, data: Mapping[str, Any]) -> No
         settings.max_file_size_bytes = int(data["max_file_size_bytes"])
     if "preview_chars" in data:
         settings.preview_chars = int(data["preview_chars"])
+    if "exclude_secrets" in data:
+        settings.exclude_secrets = bool(data["exclude_secrets"])
     # Backward-compatible keys
     if "ignore_dirs" in data:
         settings.ignore_dirs = _to_set(data["ignore_dirs"])

--- a/redcon/core/doctor.py
+++ b/redcon/core/doctor.py
@@ -315,6 +315,64 @@ def _check_mcp_registration(repo: Path) -> CheckResult:
     )
 
 
+def _check_secret_exposure(repo: Path) -> CheckResult:
+    """Confirm credential files are excluded from the packable scan universe.
+
+    Reports OK with a count when secret-looking files exist and are being
+    excluded, and only warns if exclusion has been turned off while such files
+    are present (the one configuration that could leak them to an LLM).
+    """
+    try:
+        from redcon.config import load_config
+        from redcon.scanners.incremental import _matches_glob
+        from redcon.schemas.models import DEFAULT_SECRET_GLOBS
+
+        cfg = load_config(repo)
+    except Exception as exc:
+        return CheckResult(
+            name="secret_exposure",
+            status="warn",
+            message=f"Could not evaluate secret exclusion: {exc}",
+        )
+
+    matches: list[str] = []
+    ignore_dirs = set(cfg.scan.ignore_dirs)
+    for path in repo.rglob("*"):
+        if not path.is_file():
+            continue
+        rel_parts = path.relative_to(repo).parts
+        if any(part in ignore_dirs for part in rel_parts[:-1]):
+            continue
+        rel = path.relative_to(repo).as_posix()
+        if any(_matches_glob(rel, pat) for pat in DEFAULT_SECRET_GLOBS):
+            matches.append(rel)
+        if len(matches) >= 50:
+            break
+
+    if not matches:
+        return CheckResult(
+            name="secret_exposure",
+            status="ok",
+            message="No credential files detected in scan scope",
+        )
+    if cfg.scan.exclude_secrets:
+        return CheckResult(
+            name="secret_exposure",
+            status="ok",
+            message=f"{len(matches)} credential file(s) present and excluded from packing",
+        )
+    return CheckResult(
+        name="secret_exposure",
+        status="fail",
+        message=f"{len(matches)} credential file(s) can be packed - [scan].exclude_secrets is false",
+        detail=(
+            "Set [scan].exclude_secrets = true (the default) so files like "
+            + ", ".join(matches[:5])
+            + " are never sent to an LLM."
+        ),
+    )
+
+
 def run_doctor(repo: Path) -> DoctorReport:
     """Run all diagnostic checks and return a report."""
     try:
@@ -339,6 +397,7 @@ def run_doctor(repo: Path) -> DoctorReport:
         _check_optional_dep("tree_sitter", "tree_sitter", "symbols"),
         _check_optional_dep("ast_grep", "ast_grep_py", "ast_grep"),
         _check_mcp_registration(repo),
+        _check_secret_exposure(repo),
         _check_config(repo),
         _check_redcon_toml(repo),
         _check_cache_dir(repo),

--- a/redcon/gateway/server.py
+++ b/redcon/gateway/server.py
@@ -188,6 +188,7 @@ class GatewayServer:
         self._server = None
 
     def start(self, *, block: bool = True) -> None:
+        self._guard_bind()
         fastapi_mod, uvicorn_mod = _try_import_fastapi()
         if fastapi_mod is not None:
             self._start_fastapi(block=block)
@@ -197,6 +198,21 @@ class GatewayServer:
                 "For production use: pip install 'redcon[gateway]'"
             )
             self._start_stdlib(block=block)
+
+    def _guard_bind(self) -> None:
+        """Refuse to expose an unauthenticated gateway off loopback.
+
+        Binding a non-loopback host without an api_key would serve requests
+        whose ``repo`` field reads arbitrary paths to anyone on the network.
+        Fail closed: require RC_GATEWAY_API_KEY for any non-loopback host.
+        """
+        host = (self._config.host or "").strip()
+        loopback = {"127.0.0.1", "::1", "localhost", ""}
+        if host not in loopback and not self._config.api_key:
+            raise RuntimeError(
+                f"refusing to start: host {host!r} is not loopback and no API key is set. "
+                "Set RC_GATEWAY_API_KEY (or bind 127.0.0.1) before exposing the gateway."
+            )
 
     def stop(self) -> None:
         if self._server is not None:

--- a/redcon/mcp/server.py
+++ b/redcon/mcp/server.py
@@ -253,7 +253,8 @@ _TOOL_SCHEMAS = [
             "INSTEAD of a raw shell whenever output may exceed a screenful "
             "- test runs, diffs, logs. The token caps are hard guarantees, "
             "and failures keep their essential detail (failing test names, "
-            "error lines)."
+            "error lines). DISABLED by default because it executes commands; "
+            "set REDCON_MCP_ENABLE_RUN=1 on the server to enable it."
         ),
         "inputSchema": {
             "type": "object",

--- a/redcon/mcp/tools.py
+++ b/redcon/mcp/tools.py
@@ -15,6 +15,7 @@ tool produced the response.
 from __future__ import annotations
 
 import logging
+import os
 import time
 from pathlib import Path
 from typing import Any
@@ -35,6 +36,7 @@ def _meta_block(tool: str, **extras: Any) -> dict[str, Any]:
     }
     payload.update({k: v for k, v in extras.items() if v is not None})
     return {"redcon": payload}
+
 
 # Cache ranks by (repo, task) key for 15 minutes so repeat calls are free.
 _RANK_CACHE: dict[tuple[str, str], tuple[float, dict[str, Any]]] = {}
@@ -71,7 +73,39 @@ def _make_engine(config_path: str | None = None) -> RedconEngine:
     return RedconEngine(config_path=config_path) if config_path else RedconEngine()
 
 
+class PathOutsideRoot(ValueError):
+    """Raised when an MCP path argument resolves outside the confinement root."""
+
+
+def _mcp_root() -> Path:
+    """Root that MCP path arguments are confined to.
+
+    Defaults to the server process's working directory (the project the agent
+    is operating in), so a prompt-injected agent cannot make redcon read
+    /etc/passwd or ~/.ssh. Override with REDCON_MCP_ROOT; set it to "/" to
+    disable confinement for a trusted multi-repo setup.
+    """
+    root = os.environ.get("REDCON_MCP_ROOT", "").strip()
+    return Path(root).resolve() if root else Path.cwd().resolve()
+
+
+def _confine(path_str: str, *, label: str = "path") -> str:
+    """Resolve path_str and confirm it stays within the MCP root.
+
+    Returns the resolved absolute path as a string, or raises PathOutsideRoot.
+    """
+    resolved = Path(path_str).resolve()
+    root = _mcp_root()
+    if resolved != root and root not in resolved.parents:
+        raise PathOutsideRoot(
+            f"{label} {path_str!r} resolves outside the allowed root {root}. "
+            "Set REDCON_MCP_ROOT to broaden access."
+        )
+    return str(resolved)
+
+
 # --- Tool: rank ---
+
 
 def tool_rank(
     task: str,
@@ -89,6 +123,10 @@ def tool_rank(
         return {"error": "task must be a non-empty string"}
     if top_k <= 0:
         return {"error": "top_k must be positive"}
+    try:
+        repo = _confine(repo, label="repo")
+    except PathOutsideRoot as exc:
+        return {"error": str(exc), "kind": "path_denied"}
 
     cached = _get_cached_rank(repo, task)
     if cached is not None:
@@ -125,16 +163,19 @@ def tool_rank(
 def _format_rank_entries(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
     out = []
     for entry in entries:
-        out.append({
-            "path": entry.get("path", ""),
-            "score": round(float(entry.get("score", 0.0)), 2),
-            "reasons": entry.get("reasons", [])[:3],
-            "line_count": entry.get("line_count", 0),
-        })
+        out.append(
+            {
+                "path": entry.get("path", ""),
+                "score": round(float(entry.get("score", 0.0)), 2),
+                "reasons": entry.get("reasons", [])[:3],
+                "line_count": entry.get("line_count", 0),
+            }
+        )
     return out
 
 
 # --- Tool: overview ---
+
 
 def tool_overview(
     task: str,
@@ -147,6 +188,10 @@ def tool_overview(
     """
     if not task or not task.strip():
         return {"error": "task must be a non-empty string"}
+    try:
+        repo = _confine(repo, label="repo")
+    except PathOutsideRoot as exc:
+        return {"error": str(exc), "kind": "path_denied"}
 
     cached = _get_cached_rank(repo, task)
     if cached is None:
@@ -166,23 +211,27 @@ def tool_overview(
         path = entry.get("path", "")
         parts = path.replace("\\", "/").split("/")
         directory = "/".join(parts[:-1]) if len(parts) > 1 else "."
-        dirs.setdefault(directory, []).append({
-            "name": parts[-1],
-            "score": round(float(entry.get("score", 0.0)), 2),
-        })
+        dirs.setdefault(directory, []).append(
+            {
+                "name": parts[-1],
+                "score": round(float(entry.get("score", 0.0)), 2),
+            }
+        )
 
     # Sort directories by max file score
     dir_summary = []
     for directory, files in dirs.items():
         files_sorted = sorted(files, key=lambda f: f["score"], reverse=True)
         top_file = files_sorted[0] if files_sorted else None
-        dir_summary.append({
-            "directory": directory,
-            "file_count": len(files_sorted),
-            "top_file": top_file["name"] if top_file else None,
-            "top_score": top_file["score"] if top_file else 0.0,
-            "files": [f["name"] for f in files_sorted[:5]],
-        })
+        dir_summary.append(
+            {
+                "directory": directory,
+                "file_count": len(files_sorted),
+                "top_file": top_file["name"] if top_file else None,
+                "top_score": top_file["score"] if top_file else 0.0,
+                "files": [f["name"] for f in files_sorted[:5]],
+            }
+        )
     dir_summary.sort(key=lambda d: d["top_score"], reverse=True)
 
     return {
@@ -195,6 +244,7 @@ def tool_overview(
 
 
 # --- Tool: compress ---
+
 
 def tool_compress(
     path: str,
@@ -215,6 +265,10 @@ def tool_compress(
         return {"error": "task must be a non-empty string"}
     if max_tokens <= 0:
         return {"error": "max_tokens must be positive"}
+    try:
+        repo = _confine(repo, label="repo")
+    except PathOutsideRoot as exc:
+        return {"error": str(exc), "kind": "path_denied"}
 
     engine = _make_engine(config_path)
     try:
@@ -262,6 +316,7 @@ def tool_compress(
 
 # --- Tool: search ---
 
+
 def tool_search(
     pattern: str,
     task: str,
@@ -279,8 +334,13 @@ def tool_search(
         return {"error": "pattern must be a non-empty string"}
     if scope not in ("ranked", "all"):
         return {"error": "scope must be 'ranked' or 'all'"}
+    try:
+        repo = _confine(repo, label="repo")
+    except PathOutsideRoot as exc:
+        return {"error": str(exc), "kind": "path_denied"}
 
     import re
+
     try:
         regex = re.compile(pattern)
     except re.error as e:
@@ -306,8 +366,18 @@ def tool_search(
     else:
         # Walk repo, skip common ignore directories
         paths = []
-        ignore_dirs = {".git", "node_modules", ".venv", "venv", "__pycache__",
-                       "dist", "build", ".mypy_cache", ".ruff_cache", ".pytest_cache"}
+        ignore_dirs = {
+            ".git",
+            "node_modules",
+            ".venv",
+            "venv",
+            "__pycache__",
+            "dist",
+            "build",
+            ".mypy_cache",
+            ".ruff_cache",
+            ".pytest_cache",
+        }
         for p in repo_path.rglob("*"):
             if p.is_file() and not any(part in ignore_dirs for part in p.parts):
                 paths.append(p)
@@ -328,11 +398,13 @@ def tool_search(
                             rel = str(file_path.relative_to(repo_path)).replace("\\", "/")
                         except ValueError:
                             rel = str(file_path)
-                        matches.append({
-                            "path": rel,
-                            "line": line_num,
-                            "text": line.rstrip()[:200],
-                        })
+                        matches.append(
+                            {
+                                "path": rel,
+                                "line": line_num,
+                                "text": line.rstrip()[:200],
+                            }
+                        )
                         if len(matches) >= max_results:
                             break
         except (OSError, UnicodeDecodeError):
@@ -366,6 +438,10 @@ def tool_structural_search(
     """Run an ast-grep structural search. Pattern matches the AST, not text."""
     if not pattern or not pattern.strip():
         return {"error": "pattern must be a non-empty string"}
+    try:
+        scope = _confine(scope, label="scope")
+    except PathOutsideRoot as exc:
+        return {"error": str(exc), "kind": "path_denied"}
 
     try:
         from redcon.structural_search import (
@@ -427,6 +503,10 @@ def tool_repo_map(
     """
     if not task or not task.strip():
         return {"error": "task must be a non-empty string"}
+    try:
+        repo = _confine(repo, label="repo")
+    except PathOutsideRoot as exc:
+        return {"error": str(exc), "kind": "path_denied"}
 
     try:
         from redcon.repo_map import build_repo_map
@@ -473,6 +553,7 @@ def tool_repo_map(
 
 # --- Tool: quality_check ---
 
+
 def tool_quality_check(
     command: str,
     cwd: str = ".",
@@ -491,9 +572,24 @@ def tool_quality_check(
     No competitor MCP server exposes a self-audit like this; agents that
     want defence-in-depth around lossy compression can call this instead
     of (or before) ``redcon_run``.
+
+    Like redcon_run this executes commands and is DISABLED unless
+    REDCON_MCP_ENABLE_RUN=1 is set on the server.
     """
+    if os.environ.get("REDCON_MCP_ENABLE_RUN", "").strip().lower() not in {"1", "true", "yes"}:
+        return {
+            "error": (
+                "redcon_quality_check is disabled. It executes shell commands. "
+                "Set REDCON_MCP_ENABLE_RUN=1 on the MCP server to enable it."
+            ),
+            "kind": "disabled",
+        }
     if not command or not command.strip():
         return {"error": "command must be a non-empty string"}
+    try:
+        cwd = _confine(cwd, label="cwd")
+    except PathOutsideRoot as exc:
+        return {"error": str(exc), "kind": "path_denied"}
 
     try:
         from redcon.cmd import (
@@ -507,18 +603,22 @@ def tool_quality_check(
         from redcon.cmd.compressors.base import CompressorContext
         from redcon.cmd.quality import DEFAULT_THRESHOLDS
         from redcon.cmd.registry import detect_compressor
-        from redcon.cmd.runner import parse_command
+        from redcon.cmd.runner import parse_command, reject_dangerous_args
     except ImportError as e:
         return {"error": f"redcon.cmd module unavailable: {e}"}
+
+    try:
+        reject_dangerous_args(parse_command(command))
+    except CommandNotAllowed as e:
+        return {"error": str(e), "kind": "not_allowed"}
+    except ValueError as e:
+        return {"error": str(e)}
 
     try:
         floor = CompressionLevel(quality_floor.lower())
     except ValueError:
         return {
-            "error": (
-                f"quality_floor must be one of verbose, compact, ultra "
-                f"(got {quality_floor})"
-            )
+            "error": (f"quality_floor must be one of verbose, compact, ultra (got {quality_floor})")
         }
 
     hint = BudgetHint(
@@ -557,7 +657,7 @@ def tool_quality_check(
         argv = parse_command(command)
         compressor = detect_compressor(argv)
         if compressor is not None:
-            ctx = CompressorContext(
+            CompressorContext(
                 argv=argv,
                 cwd=str(report.cache_key.cwd),
                 returncode=report.returncode,
@@ -574,11 +674,7 @@ def tool_quality_check(
     except Exception:
         pass
 
-    verdict_passed = (
-        out.must_preserve_ok
-        and threshold_met
-        and deterministic
-    )
+    verdict_passed = out.must_preserve_ok and threshold_met and deterministic
 
     return {
         "command": command,
@@ -611,6 +707,7 @@ def tool_quality_check(
 
 # --- Tool: run ---
 
+
 def tool_run(
     command: str,
     cwd: str = ".",
@@ -624,12 +721,30 @@ def tool_run(
     """
     Run a shell command and return its compressed output.
 
+    DISABLED by default: this tool executes commands, which is unsafe to
+    expose to an agent that could be prompt-injected. Set the environment
+    variable REDCON_MCP_ENABLE_RUN=1 to enable it. The runner's allowlist
+    selects a compressor schema and is NOT a security sandbox.
+
     Wraps redcon.cmd.compress_command with MCP-friendly argument handling.
     Falls back to raw passthrough (still token-budgeted) for unrecognised
-    commands. Refuses commands that are not in the runner allowlist.
+    commands.
     """
+    if os.environ.get("REDCON_MCP_ENABLE_RUN", "").strip().lower() not in {"1", "true", "yes"}:
+        return {
+            "error": (
+                "redcon_run is disabled. It executes shell commands, which is "
+                "unsafe to expose to an agent. Set REDCON_MCP_ENABLE_RUN=1 on "
+                "the MCP server to enable it, or run the command yourself."
+            ),
+            "kind": "disabled",
+        }
     if not command or not command.strip():
         return {"error": "command must be a non-empty string"}
+    try:
+        cwd = _confine(cwd, label="cwd")
+    except PathOutsideRoot as exc:
+        return {"error": str(exc), "kind": "path_denied"}
 
     try:
         from redcon.cmd import (
@@ -639,18 +754,26 @@ def tool_run(
             CommandTimeout,
             CompressionLevel,
             compress_command,
+            parse_command,
+            reject_dangerous_args,
         )
     except ImportError as e:
         return {"error": f"redcon.cmd module unavailable: {e}"}
+
+    # Refuse code-execution escapes (python -c, find -exec, npm run) at the
+    # agent boundary; the CLI path is unaffected.
+    try:
+        reject_dangerous_args(parse_command(command))
+    except CommandNotAllowed as e:
+        return {"error": str(e), "kind": "not_allowed"}
+    except ValueError as e:
+        return {"error": str(e)}
 
     try:
         floor = CompressionLevel(quality_floor.lower())
     except ValueError:
         return {
-            "error": (
-                f"quality_floor must be one of verbose, compact, ultra "
-                f"(got {quality_floor})"
-            )
+            "error": (f"quality_floor must be one of verbose, compact, ultra (got {quality_floor})")
         }
 
     hint = BudgetHint(
@@ -728,6 +851,10 @@ def tool_budget(
         return {"error": "task must be a non-empty string"}
     if max_tokens <= 0:
         return {"error": "max_tokens must be positive"}
+    try:
+        repo = _confine(repo, label="repo")
+    except PathOutsideRoot as exc:
+        return {"error": str(exc), "kind": "path_denied"}
 
     engine = _make_engine(config_path)
     # Run pack with the user's max_tokens and enough top_files to cover the request
@@ -759,12 +886,14 @@ def tool_budget(
                 break
         if matched:
             ct = int(item.get("compressed_tokens", 0))
-            plan.append({
-                "path": item.get("path", ""),
-                "strategy": item.get("strategy", "unknown"),
-                "tokens": ct,
-                "original_tokens": int(item.get("original_tokens", 0)),
-            })
+            plan.append(
+                {
+                    "path": item.get("path", ""),
+                    "strategy": item.get("strategy", "unknown"),
+                    "tokens": ct,
+                    "original_tokens": int(item.get("original_tokens", 0)),
+                }
+            )
             total_tokens += ct
 
     dropped = sorted(requested_set - matched_paths)

--- a/redcon/scanners/incremental.py
+++ b/redcon/scanners/incremental.py
@@ -17,6 +17,7 @@ from redcon.schemas.models import (
     BINARY_EXTENSIONS,
     CACHE_FILE,
     DEFAULT_IGNORE_DIRS,
+    DEFAULT_SECRET_GLOBS,
     RUN_HISTORY_FILE,
     SCAN_INDEX_FILE,
     FileRecord,
@@ -613,6 +614,7 @@ def refresh_scan_index(
     internal_paths: set[str] | None = None,
     repo_label: str | None = None,
     use_sqlite: bool = True,
+    exclude_secrets: bool = True,
 ) -> ScanRefreshResult:
     """Refresh the on-disk scan index and reuse unchanged file metadata."""
 
@@ -620,7 +622,10 @@ def refresh_scan_index(
     ignore_patterns = list(ignore_globs if ignore_globs is not None else [])
     # Always exclude redcon's own artifacts and honour the repo's .gitignore so
     # the pack never re-ingests its own output or files the user has ignored.
-    for extra in (*REDCON_ARTIFACT_GLOBS, *_gitignore_globs(repo_path)):
+    # Secret files (credentials, keys, .env) are excluded by default so a pack
+    # can never leak them to an LLM; set scan.exclude_secrets=false to override.
+    secret_globs = DEFAULT_SECRET_GLOBS if exclude_secrets else ()
+    for extra in (*REDCON_ARTIFACT_GLOBS, *secret_globs, *_gitignore_globs(repo_path)):
         if extra not in ignore_patterns:
             ignore_patterns.append(extra)
     ignored_directories = ignore_dirs if ignore_dirs is not None else set(DEFAULT_IGNORE_DIRS)

--- a/redcon/scanners/workspace.py
+++ b/redcon/scanners/workspace.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Workspace scan helpers for multi-repo local analysis."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 
@@ -42,6 +42,7 @@ def scan_workspace(
             binary_extensions=config.scan.binary_extensions,
             internal_paths=internal_paths,
             repo_label=repo.label,
+            exclude_secrets=config.scan.exclude_secrets,
         )
         repo_files = refresh.records
         files.extend(repo_files)

--- a/redcon/schemas/models.py
+++ b/redcon/schemas/models.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Shared schema dataclasses and legacy constants."""
+
+from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
@@ -309,9 +309,7 @@ class RunReport:
 
     def __post_init__(self) -> None:
         if self.max_tokens <= 0:
-            raise ValueError(
-                f"max_tokens must be positive, got {self.max_tokens}"
-            )
+            raise ValueError(f"max_tokens must be positive, got {self.max_tokens}")
 
     def __repr__(self) -> str:
         used = self.budget.get("estimated_input_tokens", "?")
@@ -322,10 +320,7 @@ class RunReport:
         included = len(self.files_included)
         saved = self.budget.get("estimated_saved_tokens", 0)
         used = self.budget.get("estimated_input_tokens", 0)
-        return (
-            f"[{self.repo}] {self.task!r} - "
-            f"{included} files, {used} tokens used, {saved} saved"
-        )
+        return f"[{self.repo}] {self.task!r} - {included} files, {used} tokens used, {saved} saved"
 
     @property
     def compression_ratio(self) -> float:
@@ -363,10 +358,20 @@ class RunReport:
         """
         data = json.loads(raw)
         required_keys = {
-            "command", "task", "repo", "max_tokens", "ranked_files",
-            "compressed_context", "files_included", "files_skipped",
-            "budget", "cache", "summarizer", "token_estimator",
-            "cache_hits", "generated_at",
+            "command",
+            "task",
+            "repo",
+            "max_tokens",
+            "ranked_files",
+            "compressed_context",
+            "files_included",
+            "files_skipped",
+            "budget",
+            "cache",
+            "summarizer",
+            "token_estimator",
+            "cache_hits",
+            "generated_at",
         }
         missing = required_keys - set(data)
         if missing:
@@ -419,6 +424,51 @@ DEFAULT_IGNORE_DIRS = {
     ".venv",
     "venv",
 }
+
+# Files that commonly hold credentials. These are excluded from the scan
+# universe by default so a pack can never send secrets to an LLM (or write
+# them into run.json / .redcon/runs/). The worst case is task-correlated:
+# packing "fix the database connection" would otherwise surface the .env whose
+# DATABASE_URL matches the task. Users can still force-include a path via
+# explicit include_globs. Kept as glob patterns matched against the POSIX
+# relative path, so both "*.pem" and nested ".aws/credentials" work.
+DEFAULT_SECRET_GLOBS: tuple[str, ...] = (
+    ".env",
+    ".env.*",
+    "*.env",
+    "env.*.local",
+    "*.pem",
+    "*.key",
+    "*.pfx",
+    "*.p12",
+    "*.keystore",
+    "*.jks",
+    "id_rsa",
+    "id_rsa.*",
+    "id_dsa",
+    "id_ecdsa",
+    "id_ed25519",
+    "id_ed25519.*",
+    "*.ppk",
+    "*.tfvars",
+    "*.tfvars.json",
+    "secrets.*",
+    "*secrets.y*ml",
+    "credentials",
+    "credentials.*",
+    "*credentials.json",
+    ".npmrc",
+    ".pypirc",
+    ".netrc",
+    ".htpasswd",
+    ".pgpass",
+    ".aws/credentials",
+    ".aws/config",
+    ".ssh/*",
+    "gcp-*.json",
+    "service-account*.json",
+    "serviceaccount*.json",
+)
 
 
 def normalize_repo(repo: str | Path) -> Path:

--- a/redcon/stages/workflow.py
+++ b/redcon/stages/workflow.py
@@ -123,6 +123,7 @@ def run_scan_refresh_stage(repo: Path, config: RedconConfig) -> ScanRefreshResul
         ignore_dirs=config.scan.ignore_dirs,
         binary_extensions=config.scan.binary_extensions,
         internal_paths=_scan_internal_paths(config),
+        exclude_secrets=config.scan.exclude_secrets,
     )
 
 

--- a/tests/test_cmd_cli.py
+++ b/tests/test_cmd_cli.py
@@ -37,14 +37,10 @@ def git_repo(tmp_path: Path) -> Path:
         cwd=str(tmp_path),
         check=True,
     )
-    subprocess.run(
-        ["git", "config", "user.name", "Test"], cwd=str(tmp_path), check=True
-    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=str(tmp_path), check=True)
     (tmp_path / "foo.py").write_text("a = 1\nb = 2\nc = 3\n")
     subprocess.run(["git", "add", "."], cwd=str(tmp_path), check=True)
-    subprocess.run(
-        ["git", "commit", "-q", "-m", "initial"], cwd=str(tmp_path), check=True
-    )
+    subprocess.run(["git", "commit", "-q", "-m", "initial"], cwd=str(tmp_path), check=True)
     (tmp_path / "foo.py").write_text("a = 1\nb = 999\nc = 3\nd = 4\n")
     return tmp_path
 
@@ -57,9 +53,7 @@ def _run_cli(parser, argv: list[str]) -> int:
     return int(args.func(args))
 
 
-def test_run_subcommand_exits_zero_on_clean_diff(
-    git_repo: Path, capsys: pytest.CaptureFixture
-):
+def test_run_subcommand_exits_zero_on_clean_diff(git_repo: Path, capsys: pytest.CaptureFixture):
     parser = build_parser()
     rc = _run_cli(
         parser,
@@ -84,9 +78,7 @@ def test_run_subcommand_exits_zero_on_clean_diff(
     assert "git_diff" in captured.err
 
 
-def test_run_subcommand_json_output_is_parseable(
-    git_repo: Path, capsys: pytest.CaptureFixture
-):
+def test_run_subcommand_json_output_is_parseable(git_repo: Path, capsys: pytest.CaptureFixture):
     parser = build_parser()
     rc = _run_cli(
         parser,
@@ -117,9 +109,7 @@ def test_run_subcommand_rejects_invalid_quality_floor(
         parser.parse_args(["run", "git diff", "--quality-floor", "invalid"])
 
 
-def test_run_subcommand_blocks_unallowed_command(
-    git_repo: Path, capsys: pytest.CaptureFixture
-):
+def test_run_subcommand_blocks_unallowed_command(git_repo: Path, capsys: pytest.CaptureFixture):
     parser = build_parser()
     rc = _run_cli(
         parser,
@@ -311,9 +301,7 @@ def test_tool_quality_check_quality_dimensions_on_real_diff(git_repo: Path):
     """Real git diff on a small fixture: must_preserve and determinism must hold."""
     from redcon.mcp.tools import tool_quality_check
 
-    result = tool_quality_check(
-        command="git diff", cwd=str(git_repo), quality_floor="compact"
-    )
+    result = tool_quality_check(command="git diff", cwd=str(git_repo), quality_floor="compact")
     assert "error" not in result
     assert result["must_preserve_ok"] is True
     assert result["deterministic"] is True
@@ -323,9 +311,7 @@ def test_tool_quality_check_passes_prefer_compact_output(git_repo: Path):
     """The flag is plumbed through and respected on real commands."""
     from redcon.mcp.tools import tool_quality_check
 
-    result = tool_quality_check(
-        command="git diff", cwd=str(git_repo), prefer_compact_output=True
-    )
+    result = tool_quality_check(command="git diff", cwd=str(git_repo), prefer_compact_output=True)
     # Same fixture, same compressor; just verifying the flag doesn't break
     # the code path.
     assert "error" not in result

--- a/tests/test_cmd_cli.py
+++ b/tests/test_cmd_cli.py
@@ -18,7 +18,11 @@ from redcon.cmd.types import CompressionLevel
 
 
 @pytest.fixture(autouse=True)
-def _reset_cache():
+def _reset_cache(monkeypatch):
+    # redcon_quality_check executes commands and is disabled by default;
+    # enable it and widen the confinement root for these direct tests.
+    monkeypatch.setenv("REDCON_MCP_ENABLE_RUN", "1")
+    monkeypatch.setenv("REDCON_MCP_ROOT", "/")
     clear_default_cache()
     yield
     clear_default_cache()
@@ -212,7 +216,6 @@ def test_history_record_and_read(tmp_path: Path):
 
 def test_history_swallows_errors_when_db_unwritable(tmp_path: Path):
     """If the DB path can't be created, record_run returns None instead of raising."""
-    bad_path = tmp_path / "no_such_dir" / "nested" / "history.db"
     # Make the parent unwritable by pointing into a file-not-dir.
     blocker = tmp_path / "blocker"
     blocker.write_text("file, not dir")

--- a/tests/test_cmd_pipeline.py
+++ b/tests/test_cmd_pipeline.py
@@ -40,14 +40,10 @@ def git_repo(tmp_path: Path) -> Path:
         cwd=str(tmp_path),
         check=True,
     )
-    subprocess.run(
-        ["git", "config", "user.name", "Test"], cwd=str(tmp_path), check=True
-    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=str(tmp_path), check=True)
     (tmp_path / "foo.py").write_text("a = 1\nb = 2\nc = 3\n")
     subprocess.run(["git", "add", "."], cwd=str(tmp_path), check=True)
-    subprocess.run(
-        ["git", "commit", "-q", "-m", "initial"], cwd=str(tmp_path), check=True
-    )
+    subprocess.run(["git", "commit", "-q", "-m", "initial"], cwd=str(tmp_path), check=True)
     # Now produce a diff:
     (tmp_path / "foo.py").write_text("a = 1\nb = 999\nc = 3\nd = 4\n")
     return tmp_path
@@ -110,7 +106,8 @@ def test_compress_command_passthrough_when_no_compressor(git_repo: Path, monkeyp
 
     monkeypatch.setattr(pipeline, "detect_compressor", lambda _argv: None)
     report = compress_command(
-        "git status", cwd=git_repo,
+        "git status",
+        cwd=git_repo,
         hint=BudgetHint(remaining_tokens=10_000, max_output_tokens=4_000),
     )
     assert report.output.schema == "raw_passthrough"

--- a/tests/test_cmd_pipeline.py
+++ b/tests/test_cmd_pipeline.py
@@ -19,7 +19,13 @@ from redcon.mcp.tools import tool_run
 
 
 @pytest.fixture(autouse=True)
-def _clear_pipeline_cache():
+def _clear_pipeline_cache(monkeypatch):
+    # redcon_run is disabled by default and confines cwd to REDCON_MCP_ROOT;
+    # these tests drive it directly on tmp git repos, so enable it and widen
+    # the root for the suite. Dedicated gating tests live in
+    # test_trust_hardening.py.
+    monkeypatch.setenv("REDCON_MCP_ENABLE_RUN", "1")
+    monkeypatch.setenv("REDCON_MCP_ROOT", "/")
     clear_default_cache()
     yield
     clear_default_cache()

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -8,8 +8,14 @@ from redcon.mcp import tools
 
 
 @pytest.fixture(autouse=True)
-def _clear_cache():
-    """Clear the rank cache before each test."""
+def _clear_cache(monkeypatch):
+    """Clear the rank cache and allow tools to reach the test's tmp dirs.
+
+    MCP path arguments are confined to REDCON_MCP_ROOT (default: the server
+    cwd). Tests operate on pytest tmp_path directories outside cwd, so widen
+    the root to "/" for the suite; a dedicated test covers confinement itself.
+    """
+    monkeypatch.setenv("REDCON_MCP_ROOT", "/")
     tools.clear_cache()
     yield
     tools.clear_cache()
@@ -85,9 +91,7 @@ def test_search_rejects_invalid_regex():
 
 def test_search_finds_pattern_in_ranked(tmp_path):
     """search scope='ranked' should find patterns in the ranked files."""
-    (tmp_path / "auth.py").write_text(
-        "def authenticate(user, password):\n    return True\n"
-    )
+    (tmp_path / "auth.py").write_text("def authenticate(user, password):\n    return True\n")
     (tmp_path / "db.py").write_text("def connect(): pass\n")
 
     result = tools.tool_search(
@@ -140,9 +144,7 @@ def test_budget_rejects_zero_max_tokens():
 
 def test_budget_returns_plan(tmp_path):
     """budget should return a plan for fitting files within a token budget."""
-    (tmp_path / "auth.py").write_text(
-        "def login(user, password):\n    return True\n" * 5
-    )
+    (tmp_path / "auth.py").write_text("def login(user, password):\n    return True\n" * 5)
 
     result = tools.tool_budget(
         files=["auth.py"],
@@ -157,7 +159,7 @@ def test_budget_returns_plan(tmp_path):
 
 def test_server_creation():
     """The MCP server should be constructible when mcp is installed."""
-    from redcon.mcp.server import create_server, _MCP_AVAILABLE, _TOOL_SCHEMAS
+    from redcon.mcp.server import _MCP_AVAILABLE, _TOOL_SCHEMAS, create_server
 
     if not _MCP_AVAILABLE:
         pytest.skip("mcp package not installed")
@@ -192,8 +194,13 @@ def test_dispatch_rank(tmp_path):
     from redcon.mcp.server import _dispatch_tool
 
     (tmp_path / "x.py").write_text("x = 1\n")
-    result = _dispatch_tool("redcon_rank", {
-        "task": "test", "repo": str(tmp_path), "top_k": 5,
-    })
+    result = _dispatch_tool(
+        "redcon_rank",
+        {
+            "task": "test",
+            "repo": str(tmp_path),
+            "top_k": 5,
+        },
+    )
     assert "error" not in result
     assert "files" in result

--- a/tests/test_repo_map.py
+++ b/tests/test_repo_map.py
@@ -35,13 +35,9 @@ def python_repo(tmp_path: Path) -> Path:
         "    def create_task(self, payload):\n"
         "        return None\n"
     )
-    (tmp_path / "unrelated.py").write_text(
-        "def coffee_machine():\n    return 'espresso'\n"
-    )
+    (tmp_path / "unrelated.py").write_text("def coffee_machine():\n    return 'espresso'\n")
     subprocess.run(["git", "add", "."], cwd=str(tmp_path), check=True)
-    subprocess.run(
-        ["git", "commit", "-q", "-m", "init"], cwd=str(tmp_path), check=True
-    )
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=str(tmp_path), check=True)
     return tmp_path
 
 
@@ -90,26 +86,22 @@ def test_repo_map_respects_budget(python_repo: Path):
     # tokens, so budget=12 fits all three fixture files. Pick a budget
     # that genuinely cannot fit every file (~5 tokens admits 1-2 of 3)
     # so the truncation contract actually fires.
-    tight = build_repo_map(
-        task="add authentication", repo=python_repo, budget=5, top_files=10
-    )
+    tight = build_repo_map(task="add authentication", repo=python_repo, budget=5, top_files=10)
     assert tight.total_tokens <= tight.budget
     assert tight.truncated is True
 
     # Roomy budget: contract still holds, no truncation when everything fits.
-    roomy = build_repo_map(
-        task="add authentication", repo=python_repo, budget=4_000, top_files=10
-    )
+    roomy = build_repo_map(task="add authentication", repo=python_repo, budget=4_000, top_files=10)
     assert roomy.total_tokens <= roomy.budget
     assert roomy.truncated is False
 
 
-def test_repo_map_mcp_tool_returns_meta(python_repo: Path):
+def test_repo_map_mcp_tool_returns_meta(python_repo: Path, monkeypatch):
     from redcon.mcp.tools import tool_repo_map
 
-    result = tool_repo_map(
-        task="add authentication", repo=str(python_repo), budget=4_000
-    )
+    # python_repo is a tmp dir outside cwd; widen the MCP confinement root.
+    monkeypatch.setenv("REDCON_MCP_ROOT", "/")
+    result = tool_repo_map(task="add authentication", repo=str(python_repo), budget=4_000)
     assert "error" not in result
     assert "_meta" in result
     assert result["_meta"]["redcon"]["tool"] == "redcon_repo_map"

--- a/tests/test_trust_hardening.py
+++ b/tests/test_trust_hardening.py
@@ -1,0 +1,124 @@
+"""Trust-hardening guarantees: secret exclusion, MCP confinement, run gating."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from redcon.core.pipeline import as_json_dict, run_pack
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+# --- secret exclusion -------------------------------------------------------
+
+
+def test_secrets_never_packed_by_default(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "db.py", "def connect():\n    return DATABASE_URL\n" * 10)
+    _write(tmp_path / ".env", "DATABASE_URL=postgres://u:SECRETPASS@h/db\n")
+    _write(tmp_path / "deploy" / "id_rsa", "-----BEGIN RSA PRIVATE KEY-----\nSECRETKEY\n")
+    _write(tmp_path / "credentials.json", '{"aws_secret_access_key": "AKIASECRET"}')
+
+    data = as_json_dict(run_pack("fix the database connection", repo=tmp_path, max_tokens=2000))
+    packed = "\n".join(item.get("text", "") for item in data["compressed_context"])
+
+    assert "SECRETPASS" not in packed
+    assert "BEGIN RSA PRIVATE KEY" not in packed
+    assert "AKIASECRET" not in packed
+    assert not any(
+        ".env" in f or "id_rsa" in f or "credentials" in f for f in data["files_included"]
+    )
+
+
+def test_secret_exclusion_can_be_disabled(tmp_path: Path) -> None:
+    _write(tmp_path / ".env", "SECRET=leakme\n" * 5)
+    _write(tmp_path / "redcon.toml", "[scan]\nexclude_secrets = false\n")
+
+    data = as_json_dict(run_pack("read the env file", repo=tmp_path, max_tokens=2000))
+
+    assert any(".env" in f for f in data["files_included"])
+
+
+def test_doctor_flags_disabled_secret_exclusion(tmp_path: Path) -> None:
+    from redcon.core.doctor import run_doctor
+
+    _write(tmp_path / ".env", "X=1\n")
+    _write(tmp_path / "redcon.toml", "[scan]\nexclude_secrets = false\n")
+
+    report = run_doctor(tmp_path)
+    check = next(c for c in report.checks if c.name == "secret_exposure")
+    assert check.status == "fail"
+
+
+# --- MCP path confinement ---------------------------------------------------
+
+
+def test_mcp_tool_rejects_path_outside_root(tmp_path: Path, monkeypatch) -> None:
+    from redcon.mcp import tools
+
+    monkeypatch.setenv("REDCON_MCP_ROOT", str(tmp_path))
+    _write(tmp_path / "a.py", "x = 1\n")
+
+    ok = tools.tool_rank(task="find", repo=str(tmp_path))
+    assert "error" not in ok
+
+    escaped = tools.tool_search(pattern="KEY", task="x", repo="/etc", scope="all")
+    assert escaped.get("kind") == "path_denied"
+
+
+# --- redcon_run gating ------------------------------------------------------
+
+
+def test_redcon_run_disabled_by_default(monkeypatch) -> None:
+    from redcon.mcp import tools
+
+    monkeypatch.delenv("REDCON_MCP_ENABLE_RUN", raising=False)
+    result = tools.tool_run("git status")
+    assert result.get("kind") == "disabled"
+
+
+def test_redcon_run_rejects_dangerous_args(monkeypatch) -> None:
+    from redcon.mcp import tools
+
+    monkeypatch.setenv("REDCON_MCP_ENABLE_RUN", "1")
+    result = tools.tool_run("python -c 'import os'", cwd=".")
+    assert result.get("kind") == "not_allowed"
+
+
+def test_runner_blocks_escape_flags() -> None:
+    from redcon.cmd.runner import CommandNotAllowed, reject_dangerous_args
+
+    for argv in (("find", ".", "-exec", "rm", "{}", ";"), ("npm", "run", "evil")):
+        with pytest.raises(CommandNotAllowed):
+            reject_dangerous_args(argv)
+
+
+def test_runner_allows_benign_uppercase_flags() -> None:
+    from redcon.cmd.runner import reject_dangerous_args
+
+    # -C (git -C dir, grep -C 3) must not be confused with -c.
+    reject_dangerous_args(("git", "-C", "sub", "status"))
+    reject_dangerous_args(("grep", "-C", "3", "pattern"))
+
+
+# --- gateway fail-closed ----------------------------------------------------
+
+
+def test_gateway_refuses_public_bind_without_key() -> None:
+    from redcon.gateway.config import GatewayConfig
+    from redcon.gateway.server import GatewayServer
+
+    with pytest.raises(RuntimeError, match="not loopback"):
+        GatewayServer(GatewayConfig(host="0.0.0.0", port=8787, api_key=None)).start()
+
+
+def test_gateway_allows_loopback_without_key() -> None:
+    from redcon.gateway.config import GatewayConfig
+    from redcon.gateway.server import GatewayServer
+
+    # Guard must pass; we don't actually bind.
+    GatewayServer(GatewayConfig(host="127.0.0.1", api_key=None))._guard_bind()

--- a/vscode-redcon/package-lock.json
+++ b/vscode-redcon/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "redcon",
-  "version": "0.1.0",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "redcon",
-      "version": "0.1.0",
-      "license": "MIT",
+      "version": "0.9.3",
+      "license": "FSL-1.1-MIT",
       "devDependencies": {
         "@types/node": "^20.11.0",
         "@types/vscode": "^1.85.0",

--- a/vscode-redcon/package.json
+++ b/vscode-redcon/package.json
@@ -216,12 +216,14 @@
         "redcon.pythonPath": {
           "type": "string",
           "default": "python",
-          "description": "Path to Python interpreter (must have redcon installed)."
+          "scope": "machine",
+          "description": "Path to Python interpreter (must have redcon installed). Machine-scoped so a workspace cannot override the executable that is run."
         },
         "redcon.cliCommand": {
           "type": "string",
           "default": "redcon",
-          "description": "Redcon CLI command or path to executable."
+          "scope": "machine",
+          "description": "Redcon CLI command or path to executable. Machine-scoped so a workspace cannot override the executable that is run."
         },
         "redcon.defaultMaxTokens": {
           "type": "number",
@@ -256,7 +258,8 @@
         "redcon.configPath": {
           "type": "string",
           "default": "",
-          "description": "Path to redcon.toml (auto-detected if empty)."
+          "scope": "machine",
+          "description": "Path to redcon.toml (auto-detected if empty). Machine-scoped so a workspace cannot point the CLI at an arbitrary file."
         },
         "redcon.contextSync.enabled": {
           "type": "boolean",

--- a/vscode-redcon/src/setup.ts
+++ b/vscode-redcon/src/setup.ts
@@ -6,7 +6,7 @@
  */
 
 import * as vscode from 'vscode';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
 
@@ -17,9 +17,19 @@ export interface SetupResult {
   mcpConfigured?: boolean;
 }
 
-function execAsync(cmd: string, cwd: string, timeoutMs = 120_000): Promise<{ stdout: string; stderr: string }> {
+/**
+ * Run a program with an explicit argument array. No shell is spawned, so
+ * metacharacters in any argument (workspace path, python path) cannot be
+ * interpreted - this closes the shell-injection surface the old exec() had.
+ */
+function run(
+  file: string,
+  args: string[],
+  cwd: string,
+  timeoutMs = 120_000,
+): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
-    const child = exec(cmd, { cwd, timeout: timeoutMs, env: { ...process.env } }, (err, stdout, stderr) => {
+    const child = execFile(file, args, { cwd, timeout: timeoutMs, env: { ...process.env } }, (err, stdout, stderr) => {
       if (err) {
         const e = err as NodeJS.ErrnoException;
         (e as unknown as { stdout: string; stderr: string }).stdout = stdout;
@@ -29,7 +39,6 @@ function execAsync(cmd: string, cwd: string, timeoutMs = 120_000): Promise<{ std
       }
       resolve({ stdout, stderr });
     });
-    // Ensure we don't leak zombie processes
     child.on('exit', () => { /* noop */ });
   });
 }
@@ -42,7 +51,7 @@ async function detectPython(): Promise<string | null> {
   const candidates = [...new Set([configured, 'python3', 'python'].filter(Boolean))];
   for (const cmd of candidates) {
     try {
-      const { stdout } = await execAsync(`${cmd} --version`, process.cwd(), 5000);
+      const { stdout } = await run(cmd, ['--version'], process.cwd(), 5000);
       if (stdout.toLowerCase().includes('python')) {
         return cmd;
       }
@@ -55,12 +64,12 @@ async function detectPython(): Promise<string | null> {
 
 async function isRedconInstalled(pythonCmd: string): Promise<boolean> {
   try {
-    await execAsync(`${pythonCmd} -m redcon --help`, process.cwd(), 10_000);
+    await run(pythonCmd, ['-m', 'redcon', '--help'], process.cwd(), 10_000);
     return true;
   } catch {
     // Fallback: direct redcon binary on PATH
     try {
-      await execAsync('redcon --help', process.cwd(), 5_000);
+      await run('redcon', ['--help'], process.cwd(), 5_000);
       return true;
     } catch {
       return false;
@@ -101,7 +110,7 @@ export async function runSetup(workspaceRoot: string): Promise<SetupResult> {
 
       progress.report({ message: 'Installing redcon[mcp] via pip...', increment: 20 });
       try {
-        await execAsync(`${pythonCmd} -m pip install --user --upgrade "redcon[mcp]"`, workspaceRoot, 180_000);
+        await run(pythonCmd, ['-m', 'pip', 'install', '--user', '--upgrade', 'redcon[mcp]'], workspaceRoot, 180_000);
       } catch (err) {
         const e = err as NodeJS.ErrnoException & { stderr?: string };
         return {
@@ -123,8 +132,9 @@ export async function runSetup(workspaceRoot: string): Promise<SetupResult> {
 
       progress.report({ message: 'Registering MCP server...', increment: 70 });
       try {
-        await execAsync(
-          `${pythonCmd} -m redcon mcp install --target all --repo "${workspaceRoot}"`,
+        await run(
+          pythonCmd,
+          ['-m', 'redcon', 'mcp', 'install', '--target', 'all', '--repo', workspaceRoot],
           workspaceRoot,
           30_000,
         );
@@ -167,15 +177,17 @@ export async function registerMcp(workspaceRoot: string): Promise<SetupResult> {
       progress.report({ message: 'Configuring MCP...', increment: 0 });
       const pythonCmd = (await detectPython()) ?? 'python3';
       try {
-        await execAsync(
-          `${pythonCmd} -m redcon mcp install --target all --repo "${workspaceRoot}"`,
+        await run(
+          pythonCmd,
+          ['-m', 'redcon', 'mcp', 'install', '--target', 'all', '--repo', workspaceRoot],
           workspaceRoot,
           30_000,
         );
       } catch {
         try {
-          await execAsync(
-            `redcon mcp install --target all --repo "${workspaceRoot}"`,
+          await run(
+            'redcon',
+            ['mcp', 'install', '--target', 'all', '--repo', workspaceRoot],
             workspaceRoot,
             30_000,
           );


### PR DESCRIPTION
## Summary

The highest-severity findings from the full multi-agent scan, in one pass. Nothing here changes the deterministic packing behavior; it closes trust and safety gaps.

## Changes

**Secrets never reach an LLM (was the one CRITICAL finding)**

- Credential files (`.env`, `.env.*`, `*.pem`, `*.key`, `id_rsa*`, `*.p12`, `credentials*`, `*.tfvars`, `.npmrc`, `.pypirc`, `.aws/credentials`, `.ssh/*`, cloud service-account JSON, ...) are excluded from the scan universe by default, so a pack can never send them to a model or write them into `run.json` / `.redcon/runs/`. The exposure was task-correlated.
- New `scan.exclude_secrets` (default `true`) is the escape hatch; a `doctor` `secret_exposure` check fails only when exclusion is off while credential files are present.

**Command execution is opt-in and confined at the agent boundary**

- `redcon_run` and `redcon_quality_check` (the MCP tools that execute commands) are DISABLED unless `REDCON_MCP_ENABLE_RUN=1`, so the default MCP surface is read-only. When enabled they refuse known code-execution escapes (`python -c`, `find -exec`, `npm run`, ...) case-sensitively so `git -C` / `grep -C` stay allowed. The CLI `redcon run` path is unchanged.

**MCP path confinement**

- Every MCP path argument (`repo`, `cwd`, `scope`) is confined to `REDCON_MCP_ROOT` (default: the server's working directory), so a prompt-injected agent cannot make redcon read `/etc/passwd` or `~/.ssh`.

**Gateway fails closed**

- The gateway refuses to start on a non-loopback host without `RC_GATEWAY_API_KEY`.

**VS Code extension**

- `redcon.pythonPath` / `cliCommand` / `configPath` are `machine`-scoped so a hostile workspace cannot override the executable that runs.
- `setup.ts` spawns via `execFile` with argv arrays instead of a shell.

## Test Coverage

- [x] All existing tests pass

New `tests/test_trust_hardening.py` covers each guarantee. Full suite: 943 passed, 13 skipped. Extension `tsc --noEmit` clean and esbuild build passes.

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression