### PR TITLE
Memoize import graph builds for monorepo performance

### DIFF
--- a/redcon/core/pipeline.py
+++ b/redcon/core/pipeline.py
@@ -416,10 +416,13 @@ def run_pack(
     )
     if effective_top_files is not None:
         ranked = ranked[:effective_top_files]
-    # Build import graph once and share with compression stage to avoid
-    # rebuilding it from disk reads.
+    # Reuse the graph the scoring stage already built (memoized on the file
+    # set + entrypoints) instead of rebuilding it from disk. Pass the same
+    # entrypoint_filenames so the cache key matches the scorer's build.
     import_graph = (
-        build_import_graph(files) if prepared_cfg.score.enable_import_graph_signals else None
+        build_import_graph(files, entrypoint_filenames=prepared_cfg.score.entrypoint_filenames)
+        if prepared_cfg.score.enable_import_graph_signals
+        else None
     )
     cache = run_cache_stage(target_repo, prepared_cfg)
     pack_plugins = resolved_plugins

--- a/redcon/scorers/import_graph.py
+++ b/redcon/scorers/import_graph.py
@@ -1,19 +1,21 @@
-from __future__ import annotations
-
 """Lightweight import/dependency graph extraction for local repository files."""
 
+from __future__ import annotations
+
+import posixpath
+import re
 from collections import defaultdict
 from dataclasses import dataclass
-import posixpath
 from pathlib import Path, PurePosixPath
-import re
 
 from redcon.schemas.models import FileRecord
 
 PY_IMPORT_RE = re.compile(r"^\s*import\s+(.+)$")
 PY_FROM_RE = re.compile(r"^\s*from\s+([\.\w]+)\s+import\s+(.+)$")
 
-JS_IMPORT_FROM_RE = re.compile(r"(?:import|export)\s+(?:type\s+)?[^\n;]*?\sfrom\s+[\"']([^\"']+)[\"']")
+JS_IMPORT_FROM_RE = re.compile(
+    r"(?:import|export)\s+(?:type\s+)?[^\n;]*?\sfrom\s+[\"']([^\"']+)[\"']"
+)
 JS_SIDE_EFFECT_IMPORT_RE = re.compile(r"\bimport\s+[\"']([^\"']+)[\"']")
 JS_REQUIRE_RE = re.compile(r"\brequire\(\s*[\"']([^\"']+)[\"']\s*\)")
 
@@ -66,7 +68,9 @@ def _build_python_module_map(files: list[FileRecord]) -> dict[str, str]:
     return module_map
 
 
-def _resolve_python_module_spec(spec: str, current_path: str, module_map: dict[str, str]) -> str | None:
+def _resolve_python_module_spec(
+    spec: str, current_path: str, module_map: dict[str, str]
+) -> str | None:
     if not spec:
         return None
 
@@ -75,10 +79,10 @@ def _resolve_python_module_spec(spec: str, current_path: str, module_map: dict[s
         level = len(spec) - len(spec.lstrip("."))
         remainder = spec.lstrip(".")
         current = list(PurePosixPath(current_path).with_suffix("").parts)
-        if current and current[-1] == "__init__":
-            package_parts = current[:-1]
-        else:
-            package_parts = current[:-1]
+        # Drop the module/__init__ name to get the containing package; both a
+        # regular module and a package __init__ resolve relative imports
+        # against their containing package.
+        package_parts = current[:-1]
 
         keep_count = max(0, len(package_parts) - (level - 1))
         resolved_parts = package_parts[:keep_count]
@@ -132,7 +136,10 @@ def _extract_python_import_edges(files: list[FileRecord]) -> dict[str, set[str]]
 
                 import_match = PY_IMPORT_RE.match(raw_line)
                 if import_match:
-                    modules = [token.strip().split(" as ")[0].strip() for token in import_match.group(1).split(",")]
+                    modules = [
+                        token.strip().split(" as ")[0].strip()
+                        for token in import_match.group(1).split(",")
+                    ]
                     for module in modules:
                         target = _resolve_python_module_spec(module, current_path, module_map)
                         if target and target != record.path:
@@ -144,7 +151,10 @@ def _extract_python_import_edges(files: list[FileRecord]) -> dict[str, set[str]]
                     continue
 
                 module_spec = from_match.group(1).strip()
-                imported_items = [token.strip().split(" as ")[0].strip() for token in from_match.group(2).split(",")]
+                imported_items = [
+                    token.strip().split(" as ")[0].strip()
+                    for token in from_match.group(2).split(",")
+                ]
                 specs = [module_spec]
                 for imported in imported_items:
                     if imported in {"", "*"}:
@@ -212,6 +222,9 @@ def _extract_js_ts_import_edges(files: list[FileRecord]) -> dict[str, set[str]]:
             for record in repo_files
             if record.extension in JS_TS_EXTENSIONS
         }
+        # Constant for the whole repo group; build the lookup set once instead
+        # of rebuilding it for every import spec of every file (was O(specs x files)).
+        existing_keys = set(existing_paths)
 
         for record in repo_files:
             if record.extension not in JS_TS_EXTENSIONS:
@@ -227,7 +240,7 @@ def _extract_js_ts_import_edges(files: list[FileRecord]) -> dict[str, set[str]]:
 
             current_path = record.relative_path or record.path
             for spec in specs:
-                target_relative_path = _resolve_js_ts_spec(current_path, spec, set(existing_paths))
+                target_relative_path = _resolve_js_ts_spec(current_path, spec, existing_keys)
                 if target_relative_path is None:
                     continue
                 target = existing_paths[target_relative_path]
@@ -318,7 +331,40 @@ def _extract_go_import_edges(files: list[FileRecord]) -> dict[str, set[str]]:
     return edges
 
 
-def build_import_graph(files: list[FileRecord], entrypoint_filenames: set[str] | None = None) -> ImportGraph:
+# Per-process memoization of the last few graphs. A single pack builds the
+# graph twice (scoring stage + compression stage) and plan-agent/simulate
+# rebuild it once per workflow step over the same file set; each build reads
+# every source file from disk, so on a monorepo that is the dominant cost.
+# Keyed on (entrypoints, (path, content_hash)...) - the content hash already
+# lives in the scan index, so the key needs no disk reads and invalidates
+# automatically when any file changes.
+_GRAPH_CACHE: dict[tuple, ImportGraph] = {}
+_GRAPH_CACHE_MAX = 4
+
+
+def _graph_cache_key(files: list[FileRecord], entrypoint_filenames: set[str] | None) -> tuple:
+    ep = tuple(sorted(entrypoint_filenames)) if entrypoint_filenames else ()
+    return (ep, tuple((f.path, f.content_hash) for f in files))
+
+
+def build_import_graph(
+    files: list[FileRecord], entrypoint_filenames: set[str] | None = None
+) -> ImportGraph:
+    """Build a deterministic, local-file import graph, memoized per file set."""
+    key = _graph_cache_key(files, entrypoint_filenames)
+    cached = _GRAPH_CACHE.get(key)
+    if cached is not None:
+        return cached
+    graph = _build_import_graph_uncached(files, entrypoint_filenames)
+    if len(_GRAPH_CACHE) >= _GRAPH_CACHE_MAX:
+        _GRAPH_CACHE.clear()
+    _GRAPH_CACHE[key] = graph
+    return graph
+
+
+def _build_import_graph_uncached(
+    files: list[FileRecord], entrypoint_filenames: set[str] | None = None
+) -> ImportGraph:
     """Build a deterministic, local-file import graph for Python, JS/TS, and Go files."""
 
     py_edges = _extract_python_import_edges(files)

--- a/tests/test_import_graph_cache.py
+++ b/tests/test_import_graph_cache.py
@@ -1,0 +1,76 @@
+"""Memoization behavior for build_import_graph.
+
+A single pack builds the import graph twice (scoring stage + compression
+stage) and plan-agent/simulate rebuild it once per workflow step over the
+same file set. Each build reads every source file from disk, so on a
+monorepo that is the dominant cost. These guard that identical file sets
+return the cached graph and that any content change invalidates it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from redcon.scanners.repository import scan_repository
+from redcon.scorers import import_graph
+from redcon.scorers.import_graph import build_import_graph
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _sample_repo(root: Path) -> None:
+    _write(root / "src" / "main.py", "from src import auth\n")
+    _write(root / "src" / "auth.py", "value = 1\n")
+    _write(root / "src" / "__init__.py", "")
+
+
+def test_build_import_graph_memoizes_identical_file_sets(tmp_path: Path) -> None:
+    _sample_repo(tmp_path)
+    import_graph._GRAPH_CACHE.clear()
+    records = scan_repository(tmp_path)
+
+    first = build_import_graph(records)
+    second = build_import_graph(records)
+
+    # Same paths + content hashes -> the second call returns the cached graph.
+    assert first is second
+
+
+def test_build_import_graph_rebuilds_after_content_change(tmp_path: Path) -> None:
+    _sample_repo(tmp_path)
+    import_graph._GRAPH_CACHE.clear()
+    first = build_import_graph(scan_repository(tmp_path))
+
+    (tmp_path / "src" / "main.py").write_text("from src import auth\n# changed\n", encoding="utf-8")
+    second = build_import_graph(scan_repository(tmp_path))
+
+    # A changed content_hash invalidates the key -> a fresh build.
+    assert first is not second
+
+
+def test_build_import_graph_entrypoints_are_part_of_the_key(tmp_path: Path) -> None:
+    _sample_repo(tmp_path)
+    import_graph._GRAPH_CACHE.clear()
+    records = scan_repository(tmp_path)
+
+    without = build_import_graph(records)
+    with_entrypoints = build_import_graph(records, entrypoint_filenames={"main.py"})
+
+    # Different entrypoints -> different key -> distinct cached graphs.
+    assert without is not with_entrypoints
+
+
+def test_build_import_graph_cache_is_bounded(tmp_path: Path) -> None:
+    _sample_repo(tmp_path)
+    import_graph._GRAPH_CACHE.clear()
+    records = scan_repository(tmp_path)
+
+    # Distinct entrypoint sets produce distinct keys; the cache must not grow
+    # without bound as unique file sets accumulate across runs.
+    for index in range(import_graph._GRAPH_CACHE_MAX + 3):
+        build_import_graph(records, entrypoint_filenames={f"entry_{index}.py"})
+
+    assert len(import_graph._GRAPH_CACHE) <= import_graph._GRAPH_CACHE_MAX


### PR DESCRIPTION
## What

Repeated `build_import_graph` calls over the same file set were the dominant cost on large repos. Each build reads every source file from disk to parse imports, and the graph gets built multiple times per run:

- a single pack builds it twice (scoring stage + compression stage)
- plan-agent / simulate rebuild it once per workflow step over the same files

This adds a small per-process cache and removes an O(specs x files) hotspot.

## How

- **Memoize `build_import_graph`** keyed on the entrypoint set plus each file's `(path, content_hash)`. The content hash already lives in the scan index, so the key needs no extra disk reads and invalidates automatically when any file changes. Cache is bounded (`_GRAPH_CACHE_MAX = 4`) and cleared when full.
- **Pipeline shares the scorer's cache entry**: `run_pack` now passes `entrypoint_filenames` so its build hits the same key the scoring stage already populated.
- **JS/TS hotspot**: the edge extractor rebuilt the lookup set for every import spec of every file; build it once per group.
- **Lint debt** in the touched file folded in.

Sharing a cached instance is safe: every consumer only reads the graph, none mutate it.

## Tests

New `tests/test_import_graph_cache.py`: identical file sets return the cached graph; a content change invalidates the key; entrypoints are part of the key; the cache stays bounded. Full suite: 948 passed, 13 skipped.