### PR TITLE
Harden scan cap surfacing, artifact writes, and the release gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,29 @@ on:
         type: string
 
 jobs:
+  # Gate: never publish a broken wheel. A tag on a red commit must not reach
+  # PyPI, so the test suite runs here and publish depends on it passing.
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[dev]
+
+      - name: Run tests
+        run: pytest --tb=short -q
+
   publish:
+    needs: test
     runs-on: ubuntu-latest
     # Must match the trusted publisher registered on PyPI
     # (owner/repo + release.yml + environment "pypi").

--- a/redcon/cache/run_history.py
+++ b/redcon/cache/run_history.py
@@ -1,20 +1,23 @@
-from __future__ import annotations
-
 """Local run-history persistence for deterministic score adjustments."""
 
-from dataclasses import asdict, dataclass, field
-from datetime import datetime, timedelta, timezone
+from __future__ import annotations
+
+import contextlib
 import json
 import logging
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
+
+from redcon.io_utils import atomic_write_text
+from redcon.schemas.models import RUN_HISTORY_FILE
 
 logger = logging.getLogger(__name__)
 
 # Maximum history file size to load (10 MB)
 _MAX_HISTORY_FILE_SIZE = 10 * 1024 * 1024
-
-from redcon.schemas.models import RUN_HISTORY_FILE
 
 
 HISTORY_FORMAT_VERSION = 1
@@ -129,6 +132,7 @@ def load_run_history(
     if use_sqlite:
         try:
             from redcon.cache.run_history_sqlite import load_run_history_sqlite
+
             return load_run_history_sqlite(
                 repo_path,
                 enabled=enabled,
@@ -183,6 +187,7 @@ def append_run_history_entry(
     if use_sqlite:
         try:
             from redcon.cache.run_history_sqlite import append_run_history_entry_sqlite
+
             return append_run_history_entry_sqlite(
                 repo_path,
                 entry,
@@ -201,8 +206,7 @@ def append_run_history_entry(
         entries = entries[-max_entries:]
     document["entries"] = entries
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(document, indent=2, sort_keys=True), encoding="utf-8")
+        atomic_write_text(path, json.dumps(document, indent=2, sort_keys=True))
     except OSError:
         return False
     return True
@@ -226,6 +230,7 @@ def update_run_history_artifacts(
     if use_sqlite:
         try:
             from redcon.cache.run_history_sqlite import update_run_history_artifacts_sqlite
+
             return update_run_history_artifacts_sqlite(
                 repo_path,
                 generated_at=generated_at,
@@ -265,8 +270,7 @@ def update_run_history_artifacts(
     if not updated:
         return False
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(document, indent=2, sort_keys=True), encoding="utf-8")
+        atomic_write_text(path, json.dumps(document, indent=2, sort_keys=True))
     except OSError:
         return False
     return True
@@ -305,8 +309,9 @@ def prune(
     # --- SQLite path ---
     if use_sqlite:
         try:
-            from redcon.cache.run_history_sqlite import _db_path, _ensure_schema
             import sqlite3
+
+            from redcon.cache.run_history_sqlite import _db_path, _ensure_schema
 
             resolved = repo_path.resolve()
             db = _db_path(resolved, history_db)
@@ -343,9 +348,6 @@ def prune(
         kept.append(item)
     if removed > 0:
         document["entries"] = kept
-        try:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(json.dumps(document, indent=2, sort_keys=True), encoding="utf-8")
-        except OSError:
-            pass
+        with contextlib.suppress(OSError):
+            atomic_write_text(path, json.dumps(document, indent=2, sort_keys=True))
     return removed

--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -58,12 +58,18 @@ def _resolve_config_path(path: str | None) -> Path | None:
 
 
 def _render_scan_summary(prefix: str, tracked_repo: Path, summary: ScanRefreshSummary) -> str:
-    return (
+    line = (
         f"{prefix}: repo={tracked_repo} "
         f"tracked={summary.tracked_files} included={summary.included_files} "
         f"reused={summary.reused_count} added={summary.added_count} "
         f"updated={summary.updated_count} removed={summary.removed_count}"
     )
+    if summary.file_count_capped:
+        line += (
+            f" [CAPPED at {summary.file_count_limit} files - scan is incomplete; "
+            f"raise [scan].max_file_count to include more]"
+        )
+    return line
 
 
 def _render_scan_change_paths(summary: ScanRefreshSummary, limit: int = 5) -> str:

--- a/redcon/config.py
+++ b/redcon/config.py
@@ -42,6 +42,10 @@ class ScanSettings:
     # scan by default so a pack can never leak secrets to an LLM. Turn off only
     # if you deliberately need to pack such a file.
     exclude_secrets: bool = True
+    # Hard cap on how many files the scan walk will visit before stopping. Large
+    # monorepos may need this raised; when the cap is hit the run reports it so
+    # the truncation is never silent.
+    max_file_count: int = 50_000
 
 
 @dataclass(slots=True)
@@ -301,6 +305,8 @@ class RedconConfig:
             )
         if self.scan.preview_chars < 0:
             warnings.append(f"[scan].preview_chars must be >= 0, got {self.scan.preview_chars}")
+        if self.scan.max_file_count <= 0:
+            warnings.append(f"[scan].max_file_count must be > 0, got {self.scan.max_file_count}")
 
         # Cache backend
         valid_cache_backends = {"local_file", "redis", "sqlite", "memory"}
@@ -427,6 +433,8 @@ def _apply_scan_overrides(settings: ScanSettings, data: Mapping[str, Any]) -> No
         settings.preview_chars = int(data["preview_chars"])
     if "exclude_secrets" in data:
         settings.exclude_secrets = bool(data["exclude_secrets"])
+    if "max_file_count" in data:
+        settings.max_file_count = int(data["max_file_count"])
     # Backward-compatible keys
     if "ignore_dirs" in data:
         settings.ignore_dirs = _to_set(data["ignore_dirs"])

--- a/redcon/core/pipeline.py
+++ b/redcon/core/pipeline.py
@@ -32,6 +32,7 @@ from redcon.stages.workflow import (
     run_cache_stage,
     run_pack_stage,
     run_render_stage,
+    run_scan_refresh_stage,
     run_scan_stage,
     run_scan_workspace_stage,
     run_score_stage,
@@ -400,10 +401,13 @@ def run_pack(
         repo_count=len(workspace.repos) if workspace is not None else 1,
     )
 
+    scan_summary = None
     if workspace is not None:
         files, scanned_repos = run_scan_workspace_stage(workspace, prepared_cfg)
     else:
-        files = run_scan_stage(repo, prepared_cfg)
+        scan_result = run_scan_refresh_stage(repo, prepared_cfg)
+        files = scan_result.records
+        scan_summary = scan_result.summary
         scanned_repos = []
     telemetry.emit("scan_completed", scanned_files=len(files), scanned_repos=len(scanned_repos))
     ranked = run_score_stage(task, files, prepared_cfg, repo=target_repo, plugins=resolved_plugins)
@@ -470,6 +474,7 @@ def run_pack(
         implementations=resolved_plugins.pack_implementations(),
         token_estimator=resolved_plugins.token_estimator_report,
         model_profile=model_profile,
+        scan_summary=scan_summary,
     )
     if record_history:
         # Mirror the full report into .redcon/runs/ so editor

--- a/redcon/io_utils.py
+++ b/redcon/io_utils.py
@@ -1,0 +1,38 @@
+"""Filesystem helpers shared across redcon."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+from pathlib import Path
+
+
+def atomic_write_text(path: Path | str, text: str, *, encoding: str = "utf-8") -> None:
+    """Write ``text`` to ``path`` atomically.
+
+    The content is written to a temporary file in the same directory, flushed
+    and fsynced, then ``os.replace``-d over the target. A concurrent reader -
+    another agent packing the same repo, or the VS Code panel tailing the run
+    feed - therefore sees either the previous file or the new one in full,
+    never a half-written truncated file.
+
+    The temp file is created alongside the target because ``os.replace`` is only
+    atomic when source and destination share a filesystem; it is atomic on both
+    POSIX and Windows in that case. On any failure the temp file is removed so
+    interrupted writes do not litter ``.redcon/``.
+    """
+    target = Path(path)
+    directory = target.parent
+    directory.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=str(directory), prefix=f".{target.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding=encoding) as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, target)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise

--- a/redcon/scanners/incremental.py
+++ b/redcon/scanners/incremental.py
@@ -13,6 +13,7 @@ from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+from redcon.io_utils import atomic_write_text
 from redcon.schemas.models import (
     BINARY_EXTENSIONS,
     CACHE_FILE,
@@ -86,6 +87,12 @@ class ScanRefreshSummary:
     added_paths: list[str] = field(default_factory=list)
     updated_paths: list[str] = field(default_factory=list)
     removed_paths: list[str] = field(default_factory=list)
+    # True when the walk hit the file-count cap and stopped early, so callers
+    # can tell the user the scan is incomplete instead of silently dropping the
+    # alphabetically-last files.
+    file_count_capped: bool = False
+    file_count_limit: int = 0
+    files_seen: int = 0
 
 
 @dataclass(slots=True)
@@ -465,7 +472,7 @@ def _save_scan_index(path: Path, state: ScanIndexState, settings: dict[str, Any]
         "settings": settings,
         "entries": [asdict(state.entries[key]) for key in sorted(state.entries)],
     }
-    path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+    atomic_write_text(path, json.dumps(data, indent=2, sort_keys=True))
 
 
 def _build_file_record(
@@ -615,6 +622,7 @@ def refresh_scan_index(
     repo_label: str | None = None,
     use_sqlite: bool = True,
     exclude_secrets: bool = True,
+    max_file_count: int = MAX_FILE_COUNT,
 ) -> ScanRefreshResult:
     """Refresh the on-disk scan index and reuse unchanged file metadata."""
 
@@ -666,6 +674,7 @@ def refresh_scan_index(
     seen_paths: set[str] = set()
 
     total_file_count = 0
+    file_count_capped = False
     resolved_symlinks: set[str] = set()
 
     for root, dirnames, filenames in os.walk(repo_path):
@@ -701,12 +710,14 @@ def refresh_scan_index(
 
             # File count limit guard
             total_file_count += 1
-            if total_file_count > MAX_FILE_COUNT:
-                if total_file_count == MAX_FILE_COUNT + 1:
+            if total_file_count > max_file_count:
+                if total_file_count == max_file_count + 1:
                     logger.warning(
-                        "File count exceeds %d limit - capping scan results",
-                        MAX_FILE_COUNT,
+                        "File count exceeds %d limit - capping scan results. "
+                        "Raise [scan].max_file_count to include more files.",
+                        max_file_count,
                     )
+                file_count_capped = True
                 break
 
             try:
@@ -780,5 +791,8 @@ def refresh_scan_index(
         added_paths=sorted(added_paths),
         updated_paths=sorted(updated_paths),
         removed_paths=removed_paths,
+        file_count_capped=file_count_capped,
+        file_count_limit=max_file_count,
+        files_seen=total_file_count,
     )
     return ScanRefreshResult(records=records, summary=summary, index_path=str(index_path))

--- a/redcon/scanners/workspace.py
+++ b/redcon/scanners/workspace.py
@@ -43,6 +43,7 @@ def scan_workspace(
             internal_paths=internal_paths,
             repo_label=repo.label,
             exclude_secrets=config.scan.exclude_secrets,
+            max_file_count=config.scan.max_file_count,
         )
         repo_files = refresh.records
         files.extend(repo_files)

--- a/redcon/schemas/models.py
+++ b/redcon/schemas/models.py
@@ -306,6 +306,10 @@ class RunReport:
     delta: dict[str, str | int | float] = field(default_factory=dict)
     degraded_files: list[str] = field(default_factory=list)
     degradation_savings: int = 0
+    # Scan-level facts for this run. Populated with file_count_capped /
+    # file_count_limit / files_seen when the walk hit the file cap, so a
+    # truncated monorepo scan is visible in run.json instead of silent.
+    scan: dict[str, int | bool] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if self.max_tokens <= 0:

--- a/redcon/stages/workflow.py
+++ b/redcon/stages/workflow.py
@@ -15,7 +15,7 @@ from redcon.core.agent_planning import AgentWorkflowPlan
 from redcon.core.model_profiles import normalize_model_profile_report
 from redcon.core.tokens import normalize_token_estimator_report
 from redcon.plugins import ResolvedPlugins, resolve_plugins
-from redcon.scanners.incremental import ScanRefreshResult, refresh_scan_index
+from redcon.scanners.incremental import ScanRefreshResult, ScanRefreshSummary, refresh_scan_index
 from redcon.scanners.workspace import ScannedWorkspaceRepo, scan_workspace
 from redcon.schemas.models import (
     DEFAULT_TOP_FILES,
@@ -124,6 +124,7 @@ def run_scan_refresh_stage(repo: Path, config: RedconConfig) -> ScanRefreshResul
         binary_extensions=config.scan.binary_extensions,
         internal_paths=_scan_internal_paths(config),
         exclude_secrets=config.scan.exclude_secrets,
+        max_file_count=config.scan.max_file_count,
     )
 
 
@@ -244,12 +245,20 @@ def run_render_stage(
     implementations: dict[str, str] | None = None,
     token_estimator: dict[str, object] | None = None,
     model_profile: dict[str, object] | None = None,
+    scan_summary: ScanRefreshSummary | None = None,
 ) -> RunReport:
     """Render pipeline stage data into stable run report schema."""
 
     effective_top_files = top_files if top_files is not None else config.budget.top_files
     if effective_top_files is None:
         effective_top_files = DEFAULT_TOP_FILES
+    scan_meta: dict[str, int | bool] = {}
+    if scan_summary is not None and scan_summary.file_count_capped:
+        scan_meta = {
+            "file_count_capped": True,
+            "file_count_limit": scan_summary.file_count_limit,
+            "files_seen": scan_summary.files_seen,
+        }
     return RunReport(
         command="pack",
         task=task,
@@ -294,6 +303,7 @@ def run_render_stage(
         implementations=dict(implementations or {}),
         degraded_files=compressed.degraded_files,
         degradation_savings=compressed.degradation_savings,
+        scan=scan_meta,
     )
 
 

--- a/redcon/telemetry/store.py
+++ b/redcon/telemetry/store.py
@@ -13,6 +13,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from redcon.io_utils import atomic_write_text
+
 OBSERVE_HISTORY_FILE = ".redcon/observe-history.json"
 OBSERVE_HISTORY_FORMAT_VERSION = 1
 OBSERVE_HISTORY_DEFAULT_MAX = 500
@@ -56,8 +58,7 @@ def _load_document(path: Path) -> dict[str, Any]:
 
 def _save_document(path: Path, document: dict[str, Any]) -> bool:
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(document, indent=2, sort_keys=True), encoding="utf-8")
+        atomic_write_text(path, json.dumps(document, indent=2, sort_keys=True))
         return True
     except OSError:
         return False

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -1,0 +1,40 @@
+"""Tests for redcon.io_utils.atomic_write_text."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from redcon.io_utils import atomic_write_text
+
+
+def test_atomic_write_creates_file_and_parents(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "dir" / "out.json"
+    atomic_write_text(target, '{"a": 1}')
+    assert target.read_text(encoding="utf-8") == '{"a": 1}'
+
+
+def test_atomic_write_overwrites_existing(tmp_path: Path) -> None:
+    target = tmp_path / "out.txt"
+    atomic_write_text(target, "old content")
+    atomic_write_text(target, "new content")
+    assert target.read_text(encoding="utf-8") == "new content"
+
+
+def test_atomic_write_leaves_no_temp_files(tmp_path: Path) -> None:
+    target = tmp_path / "out.txt"
+    atomic_write_text(target, "hello")
+    # Only the target should remain - the temp file is replaced, not left behind.
+    assert [p.name for p in tmp_path.iterdir()] == ["out.txt"]
+
+
+def test_atomic_write_failure_removes_temp_and_raises(tmp_path: Path) -> None:
+    # A directory where the target name already exists as a directory makes the
+    # final os.replace fail; the temp file must be cleaned up, not orphaned.
+    target = tmp_path / "collision"
+    target.mkdir()
+    with pytest.raises(OSError):
+        atomic_write_text(target, "data")
+    # No leftover temp files: the directory 'collision' is the only entry.
+    assert [p.name for p in tmp_path.iterdir()] == ["collision"]

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,24 @@
+"""The release workflow must gate PyPI publish on the test suite.
+
+A tag pushed to a red commit must never publish a broken wheel, so the publish
+job depends on a test job that runs pytest. Parsing is kept dependency-free
+(plain text assertions) so the guard runs in the default dev environment.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_RELEASE_YML = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "release.yml"
+
+
+def test_release_workflow_gates_publish_on_tests() -> None:
+    text = _RELEASE_YML.read_text(encoding="utf-8")
+
+    # A dedicated test job exists and the publish job depends on it.
+    assert "\n  test:\n" in text, "release workflow must define a test job"
+    assert "\n  publish:\n" in text, "release workflow must define a publish job"
+    assert "needs: test" in text, "publish must not run unless the test job passes"
+
+    # The gate must actually run the test suite, not just exist.
+    assert "pytest" in text, "the release gate must run pytest"

--- a/tests/test_scan_file_cap.py
+++ b/tests/test_scan_file_cap.py
@@ -1,0 +1,64 @@
+"""The file-count cap is configurable and surfaced instead of silent.
+
+A monorepo scan that hits the cap used to drop the alphabetically-last files
+without any signal. These guard that the cap is reported on the scan summary,
+propagated into run.json, and adjustable via [scan].max_file_count.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from redcon.config import default_config
+from redcon.core.pipeline import as_json_dict, run_pack
+from redcon.scanners.incremental import refresh_scan_index
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_scan_reports_cap_when_limit_hit(tmp_path: Path) -> None:
+    for index in range(10):
+        _write(tmp_path / f"file_{index}.py", "x = 1\n")
+
+    result = refresh_scan_index(tmp_path, max_file_count=5)
+
+    assert result.summary.file_count_capped is True
+    assert result.summary.file_count_limit == 5
+
+
+def test_scan_does_not_report_cap_under_limit(tmp_path: Path) -> None:
+    for index in range(5):
+        _write(tmp_path / f"file_{index}.py", "x = 1\n")
+
+    result = refresh_scan_index(tmp_path, max_file_count=1000)
+
+    assert result.summary.file_count_capped is False
+
+
+def test_run_pack_surfaces_cap_in_report(tmp_path: Path) -> None:
+    for index in range(8):
+        _write(tmp_path / f"mod_{index}.py", "def f():\n    return 1\n")
+
+    config = default_config()
+    config.scan.max_file_count = 3
+    report = run_pack("touch modules", repo=tmp_path, max_tokens=1000, config=config)
+
+    scan = as_json_dict(report)["scan"]
+    assert scan["file_count_capped"] is True
+    assert scan["file_count_limit"] == 3
+
+
+def test_run_pack_has_no_cap_metadata_when_under_limit(tmp_path: Path) -> None:
+    _write(tmp_path / "a.py", "def f():\n    return 1\n")
+    _write(tmp_path / "b.py", "def g():\n    return 2\n")
+
+    report = run_pack("touch modules", repo=tmp_path, max_tokens=1000)
+
+    assert as_json_dict(report)["scan"] == {}
+
+
+def test_default_config_file_cap_is_50k() -> None:
+    assert default_config().scan.max_file_count == 50_000


### PR DESCRIPTION
## What

Three P1 robustness fixes for large monorepos and concurrent agents.

### Surface the file-count cap
The scan walk stops at a hard file limit, and because it walks in sorted order it silently dropped the alphabetically-last files.

- Limit is now configurable via `[scan].max_file_count` (default 50k, validated `> 0`).
- When the cap is hit it is reported on the scan summary, in `redcon scan` output, and in `run.json` under a new `scan` block.

### Atomic artifact writes
The scan index, run history, and telemetry store were full-overwritten in place, so two agents packing the same repo at once could read a half-written file.

- New shared `redcon/io_utils.py::atomic_write_text` (temp file in the same dir, flush, fsync, then `os.replace`).
- Routed the JSON state writes through it. SQLite already uses WAL + a busy timeout.

### Gate the release on green tests
`release.yml` published to PyPI on a tag with no dependency on the test suite. `publish` now `needs: test`.

## Tests

- `tests/test_io_utils.py`, `tests/test_scan_file_cap.py`, `tests/test_release_workflow.py`.

Full suite: 954 passed, 13 skipped. Ruff clean.