### PR TITLE
Add commit-freshness and test/source pairing ranking signals

### DIFF
--- a/redcon/config.py
+++ b/redcon/config.py
@@ -78,6 +78,14 @@ class ScoreSettings:
     graph_entrypoint_adjacency_bonus: float = 0.45
     graph_bonus_cap: float = 2.5
     git_dirty_boost: float = 3.0
+    # Recently committed files are likely still in play even once clean, so
+    # boost them on a recency curve over the last git_recent_commits commits
+    # (most recent commit gets the full boost, older ones decay linearly).
+    git_recent_boost: float = 1.5
+    git_recent_commits: int = 10
+    # Pull a file's test/source counterpart along when its pair scores well
+    # (foo.py <-> test_foo.py, foo.ts <-> foo.test.ts, ...).
+    test_pair_boost: float = 2.0
     history_selected_file_boost: float = 1.25
     history_ignored_file_penalty: float = 0.35
     history_score_cap: float = 3.0
@@ -483,6 +491,12 @@ def _apply_score_overrides(settings: ScoreSettings, data: Mapping[str, Any]) -> 
         settings.symbol_name_weight = float(data["symbol_name_weight"])
     if "git_dirty_boost" in data:
         settings.git_dirty_boost = float(data["git_dirty_boost"])
+    if "git_recent_boost" in data:
+        settings.git_recent_boost = float(data["git_recent_boost"])
+    if "git_recent_commits" in data:
+        settings.git_recent_commits = int(data["git_recent_commits"])
+    if "test_pair_boost" in data:
+        settings.test_pair_boost = float(data["test_pair_boost"])
     if "code_extension_bonus" in data:
         settings.code_extension_bonus = float(data["code_extension_bonus"])
     if "test_path_bonus" in data:

--- a/redcon/plugins/builtins.py
+++ b/redcon/plugins/builtins.py
@@ -1,20 +1,22 @@
-from __future__ import annotations
-
 """Built-in plugin registrations that preserve current Redcon behavior."""
 
-from typing import Any, Mapping
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
 
 from redcon.compressors.context_compressor import compress_ranked_files
 from redcon.config import TokenEstimationSettings
 from redcon.core.tokens import (
     DEFAULT_MODEL_ALIGNED_MODEL,
     describe_builtin_token_estimator,
-    estimate_tokens as builtin_estimate_tokens,
     estimate_with_builtin_backend,
 )
-from redcon.scorers.relevance import score_files
-
+from redcon.core.tokens import (
+    estimate_tokens as builtin_estimate_tokens,
+)
 from redcon.plugins.api import CompressorPlugin, ScorerPlugin, TokenEstimatorPlugin
+from redcon.scorers.relevance import score_files
 
 
 def _builtin_relevance_score(
@@ -33,6 +35,7 @@ def _builtin_relevance_score(
         history_entries=options.get("history_entries"),
         similarity=options.get("task_similarity"),
         dirty_paths=options.get("dirty_paths"),
+        recent_paths=options.get("recent_paths"),
     )
 
 
@@ -185,7 +188,9 @@ def _token_estimator_options(settings: TokenEstimationSettings | None) -> dict[s
     }
 
 
-def register_builtin_plugins(registry, *, token_settings: TokenEstimationSettings | None = None) -> None:
+def register_builtin_plugins(
+    registry, *, token_settings: TokenEstimationSettings | None = None
+) -> None:
     """Register built-in plugins on a registry instance."""
 
     registry.register_scorer(builtin_relevance_scorer)

--- a/redcon/scorers/relevance.py
+++ b/redcon/scorers/relevance.py
@@ -1,9 +1,10 @@
-from __future__ import annotations
-
 """Relevance scoring stage for repository files."""
+
+from __future__ import annotations
 
 import logging
 import re
+from collections import defaultdict
 
 from redcon.config import ScoreSettings
 from redcon.core.text import task_keywords
@@ -34,6 +35,55 @@ def _format_graph_reason(prefix: str, related: set[str]) -> str:
     return f"{prefix}: {sorted_related[0]} (+{len(sorted_related) - 1} more)"
 
 
+_PY_TEST_PREFIX_RE = re.compile(r"^test_(.+)\.py$")
+_PY_TEST_SUFFIX_RE = re.compile(r"^(.+)_test\.py$")
+_GO_TEST_RE = re.compile(r"^(.+)_test\.go$")
+_JS_TEST_RE = re.compile(r"^(.+)\.(?:test|spec)\.(?:ts|tsx|js|jsx|mjs|cjs)$")
+
+
+def _test_base_name(filename: str) -> str | None:
+    """Return the source stem a test filename refers to, or None if not a test."""
+    for pattern in (_PY_TEST_PREFIX_RE, _PY_TEST_SUFFIX_RE, _GO_TEST_RE, _JS_TEST_RE):
+        match = pattern.match(filename)
+        if match:
+            return match.group(1)
+    return None
+
+
+def _build_test_source_pairs(files: list[FileRecord]) -> dict[str, set[str]]:
+    """Map each file to its test/source counterparts by filename.
+
+    Pairs ``test_foo.py``/``foo_test.py``/``foo_test.go``/``foo.test.ts`` with a
+    same-repo source file whose stem is ``foo``. Bidirectional, so a relevant
+    source pulls in its test and vice versa.
+    """
+    tests_by_base: dict[tuple[str, str], set[str]] = defaultdict(set)
+    sources_by_base: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for record in files:
+        filename = record.path.rsplit("/", 1)[-1].lower()
+        key_repo = record.repo_label or ""
+        base = _test_base_name(filename)
+        if base is not None:
+            tests_by_base[(key_repo, base)].add(record.path)
+        elif "." in filename:
+            stem = filename.rsplit(".", 1)[0]
+            if stem:
+                sources_by_base[(key_repo, stem)].add(record.path)
+
+    pairs: dict[str, set[str]] = defaultdict(set)
+    for key, test_paths in tests_by_base.items():
+        source_paths = sources_by_base.get(key)
+        if not source_paths:
+            continue
+        for test_path in test_paths:
+            for source_path in source_paths:
+                if test_path == source_path:
+                    continue
+                pairs[test_path].add(source_path)
+                pairs[source_path].add(test_path)
+    return pairs
+
+
 def score_files(
     task: str,
     files: list[FileRecord],
@@ -42,6 +92,7 @@ def score_files(
     history_entries=None,
     similarity: TaskSimilarityCallable | None = None,
     dirty_paths: set[str] | None = None,
+    recent_paths: dict[str, float] | None = None,
 ) -> list[RankedFile]:
     """Score files for a task using deterministic keyword and import-graph heuristics."""
 
@@ -68,7 +119,9 @@ def score_files(
         for critical_keyword in cfg.critical_path_keywords:
             if critical_keyword and critical_keyword in path_lower:
                 score += cfg.critical_path_bonus
-                breakdown["critical_path"] = breakdown.get("critical_path", 0) + cfg.critical_path_bonus
+                breakdown["critical_path"] = (
+                    breakdown.get("critical_path", 0) + cfg.critical_path_bonus
+                )
                 _add_reason(reasons, f"critical path keyword '{critical_keyword}'")
 
         path_tokens = _path_tokens(path_lower)
@@ -86,7 +139,9 @@ def score_files(
                 delta = cfg.path_keyword_weight * 0.6
                 score += delta
                 breakdown["path_keyword"] = breakdown.get("path_keyword", 0) + delta
-                _add_reason(reasons, f"path abbreviation '{tokens_matching[0]}' matches '{keyword}'")
+                _add_reason(
+                    reasons, f"path abbreviation '{tokens_matching[0]}' matches '{keyword}'"
+                )
             if preview_hits:
                 delta = min(cfg.content_keyword_cap, cfg.content_keyword_weight * preview_hits)
                 score += delta
@@ -123,6 +178,14 @@ def score_files(
             breakdown["git_dirty"] = cfg.git_dirty_boost
             _add_reason(reasons, "has uncommitted changes")
 
+        if recent_paths and cfg.git_recent_boost > 0:
+            recency = recent_paths.get(record.relative_path or "", 0.0)
+            if recency > 0:
+                delta = round(cfg.git_recent_boost * recency, 3)
+                score += delta
+                breakdown["git_recent"] = delta
+                _add_reason(reasons, "recently committed")
+
         heuristic_scores[record.path] = score
         reasons_by_path[record.path] = reasons
         breakdowns[record.path] = breakdown
@@ -153,6 +216,27 @@ def score_files(
                 _add_reason(reasons, f"role={role} (x{multiplier:.1f})")
                 breakdowns[record.path]["role_multiplier"] = multiplier
 
+    if cfg.test_pair_boost > 0 and files:
+        pairs = _build_test_source_pairs(files)
+        if pairs:
+            # Seed on genuine keyword/path relevance (before graph propagation)
+            # so a relevant file pulls its test/source counterpart along.
+            pair_seed = {
+                path
+                for path, score in heuristic_scores.items()
+                if score >= cfg.graph_seed_score_threshold
+            }
+            for record in files:
+                path = record.path
+                relevant_pair = pairs.get(path, set()) & pair_seed
+                if relevant_pair:
+                    heuristic_scores[path] += cfg.test_pair_boost
+                    breakdowns.setdefault(path, {})["test_pair"] = cfg.test_pair_boost
+                    _add_reason(
+                        reasons_by_path[path],
+                        _format_graph_reason("paired with relevant file", relevant_pair),
+                    )
+
     if cfg.enable_import_graph_signals and files:
         graph = build_import_graph(files, entrypoint_filenames=cfg.entrypoint_filenames)
 
@@ -160,7 +244,11 @@ def score_files(
         # 1) Find seed files from high base scores.
         # 2) Award deterministic bonuses to one-hop neighbors.
         # 3) Keep explanations tied to specific graph relationships.
-        seed_paths = {path for path, score in heuristic_scores.items() if score >= cfg.graph_seed_score_threshold}
+        seed_paths = {
+            path
+            for path, score in heuristic_scores.items()
+            if score >= cfg.graph_seed_score_threshold
+        }
         if not seed_paths:
             # Fallback seed for sparse tasks: top positive base score only.
             positive = sorted(
@@ -180,23 +268,36 @@ def score_files(
 
             inbound_from_seed = graph.incoming.get(path, set()) & seed_paths
             if inbound_from_seed:
-                bonus = min(cfg.graph_bonus_cap, cfg.graph_imported_by_relevant_bonus * len(inbound_from_seed))
+                bonus = min(
+                    cfg.graph_bonus_cap,
+                    cfg.graph_imported_by_relevant_bonus * len(inbound_from_seed),
+                )
                 score += bonus
                 graph_total += bonus
-                _add_reason(reasons, _format_graph_reason("imported by relevant file", inbound_from_seed))
+                _add_reason(
+                    reasons, _format_graph_reason("imported by relevant file", inbound_from_seed)
+                )
 
             outbound_to_seed = graph.outgoing.get(path, set()) & seed_paths
             if outbound_to_seed:
-                bonus = min(cfg.graph_bonus_cap, cfg.graph_depends_on_relevant_bonus * len(outbound_to_seed))
+                bonus = min(
+                    cfg.graph_bonus_cap, cfg.graph_depends_on_relevant_bonus * len(outbound_to_seed)
+                )
                 score += bonus
                 graph_total += bonus
-                _add_reason(reasons, _format_graph_reason("depends on relevant module", outbound_to_seed))
+                _add_reason(
+                    reasons, _format_graph_reason("depends on relevant module", outbound_to_seed)
+                )
 
-            adjacent_entrypoints = (graph.incoming.get(path, set()) | graph.outgoing.get(path, set())) & graph.entrypoints
+            adjacent_entrypoints = (
+                graph.incoming.get(path, set()) | graph.outgoing.get(path, set())
+            ) & graph.entrypoints
             if adjacent_entrypoints:
                 score += cfg.graph_entrypoint_adjacency_bonus
                 graph_total += cfg.graph_entrypoint_adjacency_bonus
-                _add_reason(reasons, _format_graph_reason("adjacent to entrypoint", adjacent_entrypoints))
+                _add_reason(
+                    reasons, _format_graph_reason("adjacent to entrypoint", adjacent_entrypoints)
+                )
 
             if graph_total > 0:
                 bd["import_graph"] = round(graph_total, 3)

--- a/redcon/stages/workflow.py
+++ b/redcon/stages/workflow.py
@@ -161,6 +161,43 @@ def _get_git_dirty_paths(repo: Path) -> set[str]:
     return set()
 
 
+def _get_git_recent_paths(repo: Path, commits: int) -> dict[str, float]:
+    """Return files touched in the last ``commits`` commits with a recency weight.
+
+    The most recent commit's files get weight 1.0 and older commits decay
+    linearly to 1/commits, so a freshly committed (but now clean) file still
+    gets a boost. Weights are the max across commits a file appears in.
+    """
+    if commits <= 0:
+        return {}
+    try:
+        result = subprocess.run(
+            ["git", "log", f"-n{commits}", "--name-only", "--format=%x1e"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except Exception:  # noqa: BLE001
+        return {}
+    if result.returncode != 0:
+        return {}
+
+    # \x1e (record separator) precedes each commit; its files follow on their
+    # own lines until the next separator.
+    chunks = [chunk for chunk in result.stdout.split("\x1e") if chunk.strip()]
+    total = len(chunks)
+    recent: dict[str, float] = {}
+    for index, chunk in enumerate(chunks):
+        weight = (total - index) / total
+        for line in chunk.splitlines():
+            path = line.strip()
+            if path:
+                recent[path] = max(recent.get(path, 0.0), weight)
+    return recent
+
+
 def run_score_stage(
     task: str,
     files: list[FileRecord],
@@ -183,6 +220,10 @@ def run_score_stage(
         dirty = _get_git_dirty_paths(repo)
         if dirty:
             scorer_options["dirty_paths"] = dirty
+    if repo is not None and config.score.git_recent_boost > 0:
+        recent = _get_git_recent_paths(repo, config.score.git_recent_commits)
+        if recent:
+            scorer_options["recent_paths"] = recent
     return resolved.scorer.score(
         task=task,
         files=files,

--- a/tests/test_ranking_signals.py
+++ b/tests/test_ranking_signals.py
@@ -1,0 +1,136 @@
+"""Ranking signals: commit freshness and test/source pairing.
+
+Guards the two signals added for #9 - a recently committed (now clean) file
+still gets a boost, and a relevant source file pulls in its test counterpart
+(and vice versa).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from redcon.config import ScoreSettings
+from redcon.scanners.repository import scan_repository
+from redcon.scorers.relevance import (
+    _build_test_source_pairs,
+    _test_base_name,
+    score_files,
+)
+from redcon.stages.workflow import _get_git_recent_paths
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+# -- commit freshness --------------------------------------------------------
+
+
+def test_recent_commit_boosts_relevance(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "auth.py", "def authenticate():\n    return True\n")
+    records = scan_repository(tmp_path)
+    settings = ScoreSettings()
+
+    without = {r.file.path: r for r in score_files("authenticate", records, settings)}
+    with_recent = {
+        r.file.path: r
+        for r in score_files("authenticate", records, settings, recent_paths={"src/auth.py": 1.0})
+    }
+
+    assert with_recent["src/auth.py"].score > without["src/auth.py"].score
+    assert any("recently committed" in reason for reason in with_recent["src/auth.py"].reasons)
+
+
+def test_recent_paths_ignored_when_boost_zero(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "auth.py", "def authenticate():\n    return True\n")
+    records = scan_repository(tmp_path)
+    settings = ScoreSettings(git_recent_boost=0.0)
+
+    ranked = {
+        r.file.path: r
+        for r in score_files("authenticate", records, settings, recent_paths={"src/auth.py": 1.0})
+    }
+    assert not any("recently committed" in r for r in ranked["src/auth.py"].reasons)
+
+
+def test_get_git_recent_paths_weights_by_recency(tmp_path: Path) -> None:
+    _git(tmp_path, "init")
+    _write(tmp_path / "old.py", "x = 1\n")
+    _git(tmp_path, "add", "old.py")
+    _git(tmp_path, "commit", "-m", "old")
+    _write(tmp_path / "new.py", "y = 2\n")
+    _git(tmp_path, "add", "new.py")
+    _git(tmp_path, "commit", "-m", "new")
+
+    recent = _get_git_recent_paths(tmp_path, 10)
+
+    assert recent["new.py"] == 1.0  # most recent commit -> full weight
+    assert 0 < recent["old.py"] < recent["new.py"]  # older commit -> decayed
+
+
+def test_get_git_recent_paths_empty_outside_git(tmp_path: Path) -> None:
+    assert _get_git_recent_paths(tmp_path, 10) == {}
+
+
+# -- test/source pairing -----------------------------------------------------
+
+
+def test_test_base_name_recognizes_conventions() -> None:
+    assert _test_base_name("test_auth.py") == "auth"
+    assert _test_base_name("auth_test.py") == "auth"
+    assert _test_base_name("auth_test.go") == "auth"
+    assert _test_base_name("auth.test.ts") == "auth"
+    assert _test_base_name("auth.spec.tsx") == "auth"
+    assert _test_base_name("auth.py") is None
+
+
+def test_pairs_are_bidirectional(tmp_path: Path) -> None:
+    _write(tmp_path / "billing.py", "def charge():\n    return 1\n")
+    _write(tmp_path / "test_billing.py", "def test_charge():\n    assert True\n")
+    records = scan_repository(tmp_path)
+
+    pairs = _build_test_source_pairs(records)
+    assert "billing.py" in pairs["test_billing.py"]
+    assert "test_billing.py" in pairs["billing.py"]
+
+
+def test_relevant_source_pulls_in_its_test(tmp_path: Path) -> None:
+    # billing.py is strongly relevant to the task via content; test_billing.py
+    # is not relevant on its own (task words never appear in it).
+    _write(
+        tmp_path / "billing.py", "charge card\n" * 20 + "def charge_the_card():\n    return True\n"
+    )
+    _write(tmp_path / "test_billing.py", "def test_it():\n    assert True\n")
+    records = scan_repository(tmp_path)
+
+    ranked = {r.file.path: r for r in score_files("charge card", records)}
+
+    assert "test_billing.py" in ranked
+    assert any("paired with relevant file" in r for r in ranked["test_billing.py"].reasons)
+
+
+def test_pairing_disabled_when_boost_zero(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "billing.py", "charge card\n" * 20 + "def charge_the_card():\n    return True\n"
+    )
+    _write(tmp_path / "test_billing.py", "def test_it():\n    assert True\n")
+    records = scan_repository(tmp_path)
+
+    ranked = {
+        r.file.path: r
+        for r in score_files("charge card", records, ScoreSettings(test_pair_boost=0.0))
+    }
+    if "test_billing.py" in ranked:
+        assert not any("paired with relevant file" in r for r in ranked["test_billing.py"].reasons)


### PR DESCRIPTION
## Why

The only git signal in the scorer was `git diff HEAD`, so a file committed moments ago but now clean scored nothing, and a task that pulled in a source file left its test behind (no source/test link). Both are among the strongest cues people actually use when deciding what's relevant.

## What

- **Commit freshness** - score files touched in the last `git_recent_commits` commits on a recency curve: the most recent commit gets the full `git_recent_boost`, older commits decay linearly.
- **Test/source pairing** - pair `test_foo.py` / `foo_test.py` / `foo_test.go` / `foo.test.ts` / `foo.spec.tsx` with a same-repo source stem `foo`. When one side is relevant, its counterpart gets `test_pair_boost`. Seeded before graph propagation so it doesn't cascade.

Both signals are deterministic, configurable under `[score]`, and no-ops when their boost is `0`.

## Deferred

The open-file-in-editor signal is deferred - it needs the VS Code extension to pass the active file through to the scorer.

## Tests

New `tests/test_ranking_signals.py` (recent-commit boost, `_get_git_recent_paths` recency weighting, `_test_base_name` conventions, bidirectional pairing, disabled at boost 0). Full suite: 966 passed, 13 skipped.