### PR TITLE
Fix first-run correctness bugs (python -m, scan-index scoping, atomic cache, git quoting)

### DIFF
--- a/redcon/__main__.py
+++ b/redcon/__main__.py
@@ -1,0 +1,13 @@
+"""Run the redcon CLI via ``python -m redcon``.
+
+Parity with the ``redcon`` console script, so tooling that can't rely on the
+entry-point being on PATH (e.g. the VS Code extension's setup step) can invoke
+``python -m redcon ...`` instead.
+"""
+
+from __future__ import annotations
+
+from redcon.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/redcon/cache/backends.py
+++ b/redcon/cache/backends.py
@@ -13,6 +13,7 @@ from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
+from redcon.io_utils import atomic_write_text
 from redcon.schemas.models import CACHE_FILE, CacheReport
 
 logger = logging.getLogger(__name__)
@@ -297,10 +298,9 @@ class LocalFileSummaryCacheBackend(SummaryCacheBackend):
 
     def _save(self) -> None:
         try:
-            self.cache_path.parent.mkdir(parents=True, exist_ok=True)
-            self.cache_path.write_text(
+            atomic_write_text(
+                self.cache_path,
                 json.dumps(self._data, indent=2, sort_keys=True),
-                encoding="utf-8",
             )
         except OSError:
             return

--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json as _json_mod
 import logging
 import sys
@@ -3454,7 +3455,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     gateway_cmd = sub.add_parser(
         "gateway",
-        help="Start the Redcon Runtime Gateway (agent → Redcon → LLM middleware)",
+        help="Start the Redcon Runtime Gateway (agent -> Redcon -> LLM middleware)",
     )
     gateway_cmd.add_argument(
         "--host",
@@ -3758,7 +3759,25 @@ def _configure_logging(args: argparse.Namespace) -> None:
     )
 
 
+def _force_utf8_streams() -> None:
+    """Keep redcon from crashing on a legacy Windows console (cp1252).
+
+    Output can contain non-ASCII (file paths, arrows, box drawing); on a
+    cp1252 stdout that raises UnicodeEncodeError and takes the whole command
+    down. Reconfigure stdout/stderr to UTF-8 with a replacement fallback so
+    output degrades gracefully instead of crashing. No-op where the streams
+    don't support reconfigure (e.g. already replaced under capture).
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        with contextlib.suppress(ValueError, OSError):
+            reconfigure(encoding="utf-8", errors="replace")
+
+
 def main() -> int:
+    _force_utf8_streams()
     parser = build_parser()
     args = parser.parse_args()
     _configure_logging(args)

--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -42,7 +42,7 @@ from redcon.core.render import (
 )
 from redcon.engine import BudgetPolicyViolationError, RedconEngine
 from redcon.scanners.incremental import ScanRefreshResult, ScanRefreshSummary
-from redcon.schemas.models import normalize_repo
+from redcon.schemas.models import DEFAULT_MAX_TOKENS, normalize_repo
 from redcon.stages.workflow import run_scan_refresh_stage
 
 
@@ -1686,7 +1686,9 @@ def cmd_init(args: argparse.Namespace) -> int:
     # ── Estimate savings ──────────────────────────────────────────────────────
     # Rough heuristic: 40-60% token savings is typical for well-structured repos
     estimated_savings_pct = 55 if total_files > 50 else (40 if total_files > 10 else 25)
-    default_max_tokens = 64000
+    # Match the code default and the README quickstart so init doesn't emit a
+    # third, different number.
+    default_max_tokens = DEFAULT_MAX_TOKENS
     estimated_baseline = total_files * 300  # ~300 tokens avg per file
     estimated_saved = int(estimated_baseline * estimated_savings_pct / 100)
 

--- a/redcon/scanners/incremental.py
+++ b/redcon/scanners/incremental.py
@@ -228,6 +228,7 @@ def _fingerprint_settings(
     ignore_dirs: set[str],
     binary_extensions: set[str],
     internal_paths: set[str],
+    repo_label: str | None,
 ) -> tuple[str, dict[str, Any]]:
     payload = {
         "include_globs": list(include_globs),
@@ -237,6 +238,10 @@ def _fingerprint_settings(
         "ignore_dirs": sorted(ignore_dirs),
         "binary_extensions": sorted(binary_extensions),
         "internal_paths": sorted(internal_paths),
+        # Part of the key so a repo scanned standalone (label "") and the same
+        # repo scanned inside a workspace (a real label) never reuse each
+        # other's records, which would attribute files to the wrong repo.
+        "repo_label": repo_label or "",
     }
     encoded = json.dumps(payload, sort_keys=True).encode("utf-8")
     return hashlib.sha1(encoded).hexdigest(), payload
@@ -651,6 +656,7 @@ def refresh_scan_index(
         ignore_dirs=ignored_directories,
         binary_extensions=binaries,
         internal_paths=normalized_internal_paths,
+        repo_label=repo_label,
     )
     index_path = _resolve_index_path(repo_path, scan_index_file)
     db_path = repo_path / SCAN_INDEX_DB_FILE if use_sqlite else None

--- a/redcon/stages/workflow.py
+++ b/redcon/stages/workflow.py
@@ -147,7 +147,9 @@ def _get_git_dirty_paths(repo: Path) -> set[str]:
     """Return relative paths of files with uncommitted changes (staged + unstaged)."""
     try:
         result = subprocess.run(
-            ["git", "diff", "--name-only", "HEAD"],
+            # core.quotePath=false keeps non-ASCII paths verbatim, so they match
+            # the scanned relative_path and still get the dirty boost.
+            ["git", "-c", "core.quotePath=false", "diff", "--name-only", "HEAD"],
             cwd=repo,
             capture_output=True,
             text=True,
@@ -172,7 +174,15 @@ def _get_git_recent_paths(repo: Path, commits: int) -> dict[str, float]:
         return {}
     try:
         result = subprocess.run(
-            ["git", "log", f"-n{commits}", "--name-only", "--format=%x1e"],
+            [
+                "git",
+                "-c",
+                "core.quotePath=false",
+                "log",
+                f"-n{commits}",
+                "--name-only",
+                "--format=%x1e",
+            ],
             cwd=repo,
             capture_output=True,
             text=True,

--- a/tests/test_first_run_fixes.py
+++ b/tests/test_first_run_fixes.py
@@ -1,0 +1,63 @@
+"""Regression guards for the first-run correctness fixes (Tier A)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from redcon.scanners.incremental import refresh_scan_index
+from redcon.stages.workflow import _get_git_recent_paths
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def test_python_m_redcon_runs_cli():
+    # The VS Code setup step invokes `python -m redcon`; it must work even when
+    # the console script is not on PATH.
+    result = subprocess.run(
+        [sys.executable, "-m", "redcon", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "usage" in result.stdout.lower()
+
+
+def test_scan_index_keys_on_repo_label(tmp_path: Path):
+    (tmp_path / "auth.py").write_text("value = 1\n", encoding="utf-8")
+
+    standalone = refresh_scan_index(tmp_path)
+    assert standalone.records
+    assert all(r.repo_label == "" for r in standalone.records)
+
+    # Same repo and unchanged files, now scanned under a workspace label. The
+    # records must be re-classified under the new label, not served stale from
+    # the unlabeled index (which would attribute files to the wrong repo).
+    labeled = refresh_scan_index(tmp_path, repo_label="svc")
+    assert labeled.records
+    assert all(r.repo_label == "svc" for r in labeled.records)
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="filesystem unicode normalization varies")
+def test_recent_paths_handle_non_ascii(tmp_path: Path):
+    # With git's default core.quotePath, a Cyrillic path comes back quoted and
+    # never matches the scanned relative_path, silently losing the boost.
+    _git(tmp_path, "init")
+    (tmp_path / "модуль.py").write_text("value = 1\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-m", "unicode")
+
+    recent = _get_git_recent_paths(tmp_path, 10)
+    assert "модуль.py" in recent

--- a/tests/test_first_run_fixes.py
+++ b/tests/test_first_run_fixes.py
@@ -29,6 +29,8 @@ def test_python_m_redcon_runs_cli():
         [sys.executable, "-m", "redcon", "--help"],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         check=False,
     )
     assert result.returncode == 0


### PR DESCRIPTION
## Why

The first batch of the non-monetization backlog from a 4-agent audit: mechanical correctness bugs that hit users on their first run.

## What

- **`python -m redcon`** - added `redcon/__main__.py`. The VS Code extension setup step shells out to `python -m redcon mcp install`, which failed with `No module named redcon.__main__`, so MCP registration silently failed on the recommended install path.
- **Scan-index scoping** - the fingerprint now includes `repo_label`. The same repo scanned standalone and inside a workspace shared one on-disk index, so unchanged files were attributed to the wrong repo. The two now invalidate against each other.
- **Atomic summary cache** - `.redcon_cache.json` was the last JSON state artifact still using a plain `write_text`; now routed through `atomic_write_text`.
- **Git path quoting** - pass `core.quotePath=false` to the dirty/recent git commands so non-ASCII paths come back verbatim and match the scanned `relative_path`.
- **Consistent default budget** - `redcon init` now writes the shared `DEFAULT_MAX_TOKENS` instead of a third number.

## Tests

New `tests/test_first_run_fixes.py`: `python -m redcon --help` runs; the scan index keys on `repo_label`; non-ASCII paths survive the git recency scan. Full suite: 969 passed, 13 skipped.