### PR TITLE
Quiet the first-run output: optional-dep info status, suppress empty model profile

### DIFF
--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -353,7 +353,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         print(_json_mod.dumps(doctor_as_dict(report), indent=2))
         return 0
 
-    _STATUS_ICONS = {"ok": "[ok]", "warn": "[!!]", "fail": "[XX]"}
+    _STATUS_ICONS = {"ok": "[ok]", "info": "[--]", "warn": "[!!]", "fail": "[XX]"}
 
     print(f"Redcon Doctor v{report.redcon_version}")
     print(f"Python {report.python_version} on {report.platform}")
@@ -368,6 +368,8 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
     print()
     parts = [f"{report.passed} passed"]
+    if report.info:
+        parts.append(f"{report.info} optional")
     if report.warnings:
         parts.append(f"{report.warnings} warnings")
     if report.failures:
@@ -716,7 +718,12 @@ def cmd_pack(args: argparse.Namespace) -> int:
         + (f", cache {cache_hits}/{cache_total} hits" if cache_total > 0 else ""),
     )
     model_profile = data.get("model_profile", {})
-    if isinstance(model_profile, dict) and model_profile:
+    # Only show the profile line when a model is actually configured; otherwise
+    # every default run prints a block of empty selected=/resolved=/context=0
+    # fields that reads as misconfigured.
+    if isinstance(model_profile, dict) and (
+        model_profile.get("selected_profile") or model_profile.get("resolved_profile")
+    ):
         _qprint(
             args,
             "Model profile: "

--- a/redcon/core/doctor.py
+++ b/redcon/core/doctor.py
@@ -34,6 +34,7 @@ class DoctorReport:
     passed: int = 0
     warnings: int = 0
     failures: int = 0
+    info: int = 0
 
 
 def _check_python_version() -> CheckResult:
@@ -87,8 +88,8 @@ def _check_optional_dep(name: str, package: str, extra: str) -> CheckResult:
     except ImportError:
         return CheckResult(
             name=name,
-            status="warn",
-            message=f"Not installed - install with: pip install 'redcon[{extra}]'",
+            status="info",
+            message=f"Optional - not installed. Enable with: pip install 'redcon[{extra}]'",
         )
 
 
@@ -410,6 +411,8 @@ def run_doctor(repo: Path) -> DoctorReport:
         report.checks.append(check)
         if check.status == "ok":
             report.passed += 1
+        elif check.status == "info":
+            report.info += 1
         elif check.status == "warn":
             report.warnings += 1
         else:
@@ -436,6 +439,7 @@ def doctor_as_dict(report: DoctorReport) -> dict[str, Any]:
         ],
         "summary": {
             "passed": report.passed,
+            "info": report.info,
             "warnings": report.warnings,
             "failures": report.failures,
             "total": len(report.checks),

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2,12 +2,28 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from redcon.core.doctor import run_doctor, doctor_as_dict
+from redcon.core.doctor import _check_optional_dep, doctor_as_dict, run_doctor
 
 
 def _write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
+
+
+def test_missing_optional_dep_is_info_not_warning() -> None:
+    # A missing optional dependency is informational, not an alarming warning,
+    # so a plain `pip install redcon` doesn't look half-broken in doctor.
+    result = _check_optional_dep("nope", "definitely_not_a_real_package_xyz", "extra")
+    assert result.status == "info"
+    assert "Optional" in result.message
+
+
+def test_doctor_counts_optional_deps_as_info(tmp_path: Path) -> None:
+    report = run_doctor(tmp_path)
+    # The optional deps that aren't installed land in info, not warnings.
+    assert report.info >= 1
+    summary = doctor_as_dict(report)["summary"]
+    assert summary["info"] == report.info
 
 
 def test_doctor_passes_with_default_setup(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

Second batch of the first-run backlog: two things that make a fresh install look half-broken even though it's fine.

## What

- **`doctor` optional deps are informational, not warnings.** Missing `tiktoken`, `redis`, `mcp`, `tree_sitter`, `ast_grep`, and the gateway extras now render as an `[--]` "optional" line with its own summary count, instead of five alarming `[!!]` warnings. A bare `pip install redcon` no longer reads as a broken environment.
- **The pack output only shows the model profile when one is set.** Previously every default run printed a block of empty `selected=/resolved=/context=0` fields that looks misconfigured. Now suppressed unless a model profile is actually selected/resolved.

## Note

A6 from the audit (plan re-ranking redcon's own output) turned out to be already handled - `REDCON_ARTIFACT_GLOBS` excludes the default `run.json`/`run.md`. The `saved=0` first-run framing (A1) is a larger change and comes as its own PR.

## Tests

New doctor tests: a missing optional dep is `info` not `warn`; `run_doctor` counts optional deps under `info`. Full suite: 968 passed, 13 skipped.