### PR TITLE
README: add "punch above your plan" positioning for subscription users

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Redcon solves both. It ranks files by task relevance, compresses them with langu
 
 On a flat subscription - Claude Pro/Max, Cursor, GitHub Copilot - the token bill isn't what stings, the **usage limit** is. Redcon cuts the tokens each task needs, so the same plan covers far more work before you hit the weekly wall. Same subscription, more runway.
 
-It won't unlock a higher tier's models or lift your rate limit - it stretches the budget you already pay for, and reports exactly how much it saved.
+It stretches the budget you already pay for, and reports exactly how much it saved.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ AI coding agents burn tokens on irrelevant context. You either:
 
 Redcon solves both. It ranks files by task relevance, compresses them with language-aware strategies (full, snippet, symbol extraction, summary), and packs the result under your token budget. Deterministic, local-first, no embeddings.
 
+## Punch above your plan
+
+On a flat subscription - Claude Pro/Max, Cursor, GitHub Copilot - the token bill isn't what stings, the **usage limit** is. Redcon cuts the tokens each task needs, so the same plan covers far more work before you hit the weekly wall. Same subscription, more runway.
+
+It won't unlock a higher tier's models or lift your rate limit - it stretches the budget you already pay for, and reports exactly how much it saved.
+
 ## Install
 
 ### Option 1: VS Code Extension (easiest)


### PR DESCRIPTION
## Why

The README pitch was framed around per-token cost, which misses the large and growing segment on flat subscriptions (Claude Pro/Max, Cursor, GitHub Copilot) - where the pain isn't the bill, it's the usage limit.

## What

Adds a short "Punch above your plan" section after "The Problem": redcon stretches the plan you already pay for, so the same subscription covers more work before you hit the weekly wall. It makes the existing budget go further and reports how much.

Docs-only change; no code.