### PR TITLE
Report selection savings so a pack shows its real value

### DIFF
--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -713,6 +713,20 @@ def cmd_pack(args: argparse.Namespace) -> int:
         f"saved={budget['estimated_saved_tokens']} tokens, "
         f"risk={budget['quality_risk_estimate']}",
     )
+    # Selection savings: the honest "value delivered" line. saved= above only
+    # counts in-file compression, which is often 0. Redcon's real win is picking
+    # a subset of files, so show what was sent vs dumping the whole scanned repo.
+    baseline_tokens = int(data.get("context_baseline_tokens", 0) or 0)
+    files_scanned = int(data.get("files_scanned", 0) or 0)
+    sent_tokens = int(budget.get("estimated_input_tokens", 0) or 0)
+    if baseline_tokens > sent_tokens > 0 and files_scanned > files_included:
+        pct_less = round((baseline_tokens - sent_tokens) / baseline_tokens * 100)
+        _qprint(
+            args,
+            f"Context: sent {files_included} of {files_scanned} files "
+            f"(~{sent_tokens} tokens) vs ~{baseline_tokens} for the whole repo "
+            f"- {pct_less}% less",
+        )
     _qprint(
         args,
         f"Files: {files_included} included, {files_skipped} skipped"

--- a/redcon/core/pipeline.py
+++ b/redcon/core/pipeline.py
@@ -464,6 +464,12 @@ def run_pack(
             fragment_hits=cache_snap.fragment_hits or 0,
             fragment_misses=cache_snap.fragment_misses or 0,
         )
+    # Honest selection baseline: what dumping every scanned file into context
+    # would cost (char/4 heuristic, matching the default token estimator). The
+    # pack sends only the ranked subset, so baseline minus what was actually
+    # sent is the value redcon delivered by choosing files - visible even when
+    # no in-file compression happened (estimated_saved_tokens == 0).
+    baseline_tokens = sum(f.size_bytes for f in files) // 4
     report = run_render_stage(
         task,
         target_repo,
@@ -478,6 +484,8 @@ def run_pack(
         token_estimator=resolved_plugins.token_estimator_report,
         model_profile=model_profile,
         scan_summary=scan_summary,
+        baseline_tokens=baseline_tokens,
+        files_scanned=len(files),
     )
     if record_history:
         # Mirror the full report into .redcon/runs/ so editor

--- a/redcon/core/render.py
+++ b/redcon/core/render.py
@@ -530,6 +530,26 @@ def render_agent_plan_markdown(data: dict) -> str:
     return "\n".join(lines)
 
 
+def _selection_savings_md_lines(data: dict, budget: dict) -> list[str]:
+    """Budget-section lines describing selection savings, when meaningful.
+
+    Empty when the pack sent the whole scanned universe (no subset was chosen)
+    or the baseline is not larger than what was actually sent - in those cases
+    there is no honest selection saving to report.
+    """
+    baseline = int(data.get("context_baseline_tokens", 0) or 0)
+    files_scanned = int(data.get("files_scanned", 0) or 0)
+    files_included = len(data.get("files_included") or [])
+    sent = int(budget.get("estimated_input_tokens", 0) or 0)
+    if not (baseline > sent > 0 and files_scanned > files_included):
+        return []
+    pct_less = round((baseline - sent) / baseline * 100)
+    return [
+        f"- Context sent: {files_included} of {files_scanned} files "
+        f"(~{sent} tokens) vs ~{baseline} for the whole repo - {pct_less}% less",
+    ]
+
+
 def render_pack_markdown(data: dict) -> str:
     """Render pack run payload to Markdown."""
 
@@ -556,6 +576,7 @@ def render_pack_markdown(data: dict) -> str:
             "## Budget",
             f"- Estimated input tokens: {budget.get('estimated_input_tokens', 0)}",
             f"- Estimated saved tokens: {budget.get('estimated_saved_tokens', 0)}",
+            *_selection_savings_md_lines(data, budget),
             f"- Duplicate reads prevented: {budget.get('duplicate_reads_prevented', 0)}",
             f"- Quality risk estimate: {budget.get('quality_risk_estimate', 'unknown')}",
             f"- Cache backend: {cache.get('backend', 'unknown')}",

--- a/redcon/schemas/models.py
+++ b/redcon/schemas/models.py
@@ -310,6 +310,15 @@ class RunReport:
     # file_count_limit / files_seen when the walk hit the file cap, so a
     # truncated monorepo scan is visible in run.json instead of silent.
     scan: dict[str, int | bool] = field(default_factory=dict)
+    # Selection savings. context_baseline_tokens is what the whole scanned file
+    # universe would cost if dumped into context (char/4 heuristic);
+    # files_scanned is how many files that universe held. The pack sends only a
+    # ranked subset, so the honest saving is this baseline minus the tokens
+    # actually sent - reported so a run that does no in-file compression
+    # (estimated_saved_tokens == 0) still shows the value redcon delivered by
+    # picking the right files.
+    context_baseline_tokens: int = 0
+    files_scanned: int = 0
 
     def __post_init__(self) -> None:
         if self.max_tokens <= 0:

--- a/redcon/stages/workflow.py
+++ b/redcon/stages/workflow.py
@@ -297,6 +297,8 @@ def run_render_stage(
     token_estimator: dict[str, object] | None = None,
     model_profile: dict[str, object] | None = None,
     scan_summary: ScanRefreshSummary | None = None,
+    baseline_tokens: int = 0,
+    files_scanned: int = 0,
 ) -> RunReport:
     """Render pipeline stage data into stable run report schema."""
 
@@ -355,6 +357,8 @@ def run_render_stage(
         degraded_files=compressed.degraded_files,
         degradation_savings=compressed.degradation_savings,
         scan=scan_meta,
+        context_baseline_tokens=max(0, baseline_tokens),
+        files_scanned=max(0, files_scanned),
     )
 
 

--- a/tests/test_selection_savings.py
+++ b/tests/test_selection_savings.py
@@ -16,7 +16,10 @@ from redcon.core.render import _selection_savings_md_lines, render_pack_markdown
 
 def _write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(content, encoding="utf-8")
+    # Pin newline="\n" so the on-disk byte count matches len(content.encode())
+    # on every platform. Without it, Windows text mode rewrites "\n" to "\r\n",
+    # inflating the scanned size_bytes and breaking the exact baseline check.
+    path.write_text(content, encoding="utf-8", newline="\n")
 
 
 def _repo_with_many_files(root: Path, count: int = 30) -> int:

--- a/tests/test_selection_savings.py
+++ b/tests/test_selection_savings.py
@@ -1,0 +1,98 @@
+"""Selection-savings reporting (A1).
+
+The "saved" budget number only counts in-file compression, which is frequently
+zero. Redcon's real win is picking a subset of files, so a run reports a
+selection baseline - what dumping the whole scanned universe would cost - so the
+value delivered is visible even when no in-file compression happened.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from redcon.core.pipeline import as_json_dict, run_pack
+from redcon.core.render import _selection_savings_md_lines, render_pack_markdown
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _repo_with_many_files(root: Path, count: int = 30) -> int:
+    total_bytes = 0
+    for i in range(count):
+        body = (
+            f"def feature_{i}(payload):\n"
+            + "    # gateway auth and rate limiting logic\n" * 20
+            + f"    return process_{i}(payload)\n"
+        )
+        path = root / "src" / f"mod_{i:02d}.py"
+        _write(path, body)
+        total_bytes += len(body.encode("utf-8"))
+    return total_bytes
+
+
+def test_run_pack_reports_selection_baseline(tmp_path: Path) -> None:
+    total_bytes = _repo_with_many_files(tmp_path, count=30)
+
+    report = run_pack("refactor feature_01 auth", repo=tmp_path, max_tokens=500)
+    data = as_json_dict(report)
+
+    # The whole scanned universe is accounted for by the char/4 heuristic.
+    assert data["files_scanned"] == 30
+    assert data["context_baseline_tokens"] == total_bytes // 4
+
+    # A tight budget forces a subset, so the baseline is strictly larger than
+    # what was actually sent - a real, honest saving.
+    sent = data["budget"]["estimated_input_tokens"]
+    assert data["context_baseline_tokens"] > sent
+    assert len(data["files_included"]) < data["files_scanned"]
+
+
+def test_selection_savings_line_in_markdown(tmp_path: Path) -> None:
+    _repo_with_many_files(tmp_path, count=30)
+    data = as_json_dict(run_pack("refactor feature_01 auth", repo=tmp_path, max_tokens=500))
+
+    markdown = render_pack_markdown(data)
+    assert "Context sent:" in markdown
+    assert "% less" in markdown
+
+
+def test_savings_lines_reported_when_subset_chosen() -> None:
+    data = {
+        "context_baseline_tokens": 10_000,
+        "files_scanned": 40,
+        "files_included": ["a.py", "b.py"],
+    }
+    lines = _selection_savings_md_lines(data, {"estimated_input_tokens": 2_000})
+    assert len(lines) == 1
+    # 2000 of 10000 sent -> 80% less.
+    assert "80% less" in lines[0]
+    assert "2 of 40 files" in lines[0]
+
+
+def test_no_savings_line_when_nothing_was_dropped() -> None:
+    # Every scanned file was included: there is no selection saving to claim.
+    data = {
+        "context_baseline_tokens": 5_000,
+        "files_scanned": 3,
+        "files_included": ["a.py", "b.py", "c.py"],
+    }
+    assert _selection_savings_md_lines(data, {"estimated_input_tokens": 4_000}) == []
+
+
+def test_no_savings_line_when_baseline_not_larger() -> None:
+    # Baseline is not above what was sent (tiny repo): no honest saving.
+    data = {
+        "context_baseline_tokens": 100,
+        "files_scanned": 5,
+        "files_included": ["a.py"],
+    }
+    assert _selection_savings_md_lines(data, {"estimated_input_tokens": 100}) == []
+
+
+def test_no_savings_line_when_baseline_absent() -> None:
+    # Older run.json without the fields must not raise or fabricate a saving.
+    data = {"files_included": ["a.py"]}
+    assert _selection_savings_md_lines(data, {"estimated_input_tokens": 200}) == []


### PR DESCRIPTION
## Summary

Record a selection baseline on every run and show, in the CLI and the run markdown, how many tokens the pack saved by choosing a subset of files instead of dumping the whole scanned repo. Visible even when in-file compression is 0.

## Problem

The pack summary only surfaced `saved=` tokens, which counts in-file compression and is frequently 0. On many repos a first-time user sees `saved=0` and concludes redcon did nothing, when it actually delivered by sending a few files instead of the whole repo. The real win (file selection) was invisible.

## Approach

- Compute a selection baseline on every run: what dumping the entire scanned file universe into context would cost (char/4 heuristic, matching the default estimator), plus how many files that universe held.
- New `RunReport` fields (`context_baseline_tokens`, `files_scanned`), both default 0 so older `run.json` still deserializes.
- When the pack sent a strict subset for fewer tokens, the CLI and run markdown show `Context: sent N of M files (~Y tokens) vs ~X for the whole repo - Z% less`. Omitted when nothing was dropped or the baseline is not larger than what was sent.

## Test Coverage

- Added `tests/test_selection_savings.py`; all existing tests pass.

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression