### PR TITLE
Add Pro entitlement gate and license command (monetization foundation)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,11 @@ Repository = "https://github.com/natiixnt/redcon"
 Issues = "https://github.com/natiixnt/redcon/issues"
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0", "fakeredis>=2.0", "redis>=5.0"]
+dev = ["pytest>=8.0", "fakeredis>=2.0", "redis>=5.0", "cryptography>=42"]
+# Offline verification of Pro license keys. Free installs never need this;
+# the core stays dependency-free and only imports cryptography when a license
+# is actually present.
+pro = ["cryptography>=42"]
 tokenizers = ["tiktoken>=0.7"]
 redis = ["redis>=5.0"]
 gateway = ["fastapi>=0.110", "uvicorn[standard]>=0.29"]

--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -380,6 +380,62 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     return 1 if report.failures > 0 else 0
 
 
+def _home_license_path() -> Path:
+    return Path.home() / ".redcon" / "license"
+
+
+def cmd_license(args: argparse.Namespace) -> int:
+    from redcon.entitlements import load_entitlement
+    from redcon.io_utils import atomic_write_text
+
+    if getattr(args, "activate", None):
+        path = _home_license_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_text(path, args.activate.strip() + "\n")
+        _qprint(args, f"Saved license to {path}")
+    elif getattr(args, "deactivate", False):
+        path = _home_license_path()
+        try:
+            path.unlink()
+            _qprint(args, f"Removed license at {path}")
+        except FileNotFoundError:
+            _qprint(args, "No license was installed.")
+
+    ent = load_entitlement(Path(args.repo).resolve() if getattr(args, "repo", None) else None)
+
+    if getattr(args, "json", False):
+        print(
+            _json_mod.dumps(
+                {
+                    "tier": ent.tier,
+                    "status": ent.status,
+                    "is_pro": ent.is_pro,
+                    "email": ent.email,
+                    "expires_at": ent.expires_at,
+                    "source": ent.source,
+                    "hint": ent.hint,
+                },
+                indent=2,
+            )
+        )
+        return 0
+
+    plan = "Pro" if ent.is_pro else "Free"
+    print(f"Plan: {plan} (status: {ent.status})")
+    if ent.email:
+        print(f"Licensed to: {ent.email}")
+    if ent.expires_at:
+        expiry = time.strftime("%Y-%m-%d", time.gmtime(ent.expires_at))
+        print(f"Expires: {expiry}")
+    if ent.source != "none":
+        print(f"Source: {ent.source}")
+    if ent.hint:
+        print(f"Note: {ent.hint}")
+    if not ent.is_pro and not ent.hint:
+        print("Upgrade to Pro to unlock the savings dashboard and cross-agent history.")
+    return 0
+
+
 def cmd_plan(args: argparse.Namespace) -> int:
     err = _validate_positive_int(args.top_files, "--top-files")
     if err:
@@ -2560,6 +2616,34 @@ def build_parser() -> argparse.ArgumentParser:
         help="Print raw JSON to stdout (shorthand for --format json).",
     )
     doctor.set_defaults(func=cmd_doctor)
+
+    license_parser = sub.add_parser(
+        "license", help="Show, activate, or remove your redcon Pro license"
+    )
+    license_parser.add_argument(
+        "--repo",
+        default=".",
+        help="Repository to resolve a repo-local license from (default: current directory).",
+    )
+    license_parser.add_argument(
+        "--activate",
+        metavar="KEY",
+        default=None,
+        help="Install a Pro license key (saved to ~/.redcon/license).",
+    )
+    license_parser.add_argument(
+        "--deactivate",
+        action="store_true",
+        default=False,
+        help="Remove the installed license from ~/.redcon/license.",
+    )
+    license_parser.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help="Print the entitlement as JSON.",
+    )
+    license_parser.set_defaults(func=cmd_license)
 
     completion = sub.add_parser(
         "completion",

--- a/redcon/entitlements.py
+++ b/redcon/entitlements.py
@@ -1,0 +1,203 @@
+"""Pro entitlement resolution and feature gating (open-core).
+
+The redcon core is free and stays dependency-free. Paid ("Pro") features - the
+savings dashboard, cross-agent history, prompt-optimization insights - are
+unlocked by a signed license key that redcon-cloud issues on purchase.
+
+Design:
+
+- Verification is OFFLINE. The core embeds only the Ed25519 *public* key; the
+  private key never leaves redcon-cloud, so Pro works on a plane and never
+  phones home.
+- A license is UNFORGEABLE without the private key, so "holds a valid license"
+  is proof of purchase - even though the local gate itself, being open source,
+  can always be patched out by a determined user. The real paid value lives
+  server-side in redcon-cloud; the local gate only stops casual bypass, which
+  is the honest ceiling for any open-core license.
+- Signature verification needs ``cryptography``, shipped in the optional
+  ``pro`` extra. Free installs never pull it. If a license is present but the
+  library is missing, we degrade to free and tell the user how to fix it
+  rather than granting an unverifiable Pro.
+- Until redcon-cloud mints the production keypair, the embedded public key is
+  empty. With no key configured, every license is treated as unverified and
+  the user stays free - the correct pre-launch state.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+
+TIER_FREE = "free"
+TIER_PRO = "pro"
+
+# Feature slugs gated behind Pro. Anything not listed here is free and always
+# available. Keep the slugs stable - the dashboard, extension, and cloud all
+# check them by name.
+PRO_FEATURES: frozenset[str] = frozenset(
+    {
+        "dashboard.savings",  # the savings / cross-agent history dashboard
+        "history.unlimited",  # run history beyond the free retention window
+        "insights.prompt",  # prompt-optimization suggestions
+    }
+)
+
+# Ed25519 public key (base64url of the raw 32 bytes) used to verify license
+# signatures. The matching private key lives ONLY in redcon-cloud and signs
+# licenses on purchase. Empty means "no key configured yet": every license is
+# treated as unverified and the user stays free. Override for tests or a
+# self-hosted signer via REDCON_LICENSE_PUBKEY.
+_EMBEDDED_PUBLIC_KEY_B64 = ""
+
+_ENV_LICENSE = "REDCON_LICENSE_KEY"
+_ENV_PUBKEY = "REDCON_LICENSE_PUBKEY"
+_LICENSE_FILENAMES = ("license", "license.key")
+
+_PRO_HINT = "License found but verification needs cryptography - run: pip install 'redcon[pro]'"
+
+
+@dataclass(frozen=True, slots=True)
+class Entitlement:
+    """The resolved plan for the current environment.
+
+    ``status`` is the machine-readable outcome:
+
+    - ``free``       - no license present (or a valid free-tier license)
+    - ``active``     - a valid, unexpired Pro license
+    - ``expired``    - a Pro license whose term has passed
+    - ``invalid``    - a malformed license or a signature that did not verify
+    - ``unverified`` - a license we could not check (no public key configured,
+      or the ``pro`` extra is not installed)
+    """
+
+    tier: str = TIER_FREE
+    email: str = ""
+    expires_at: int = 0  # unix seconds; 0 = no expiry
+    features: frozenset[str] = field(default_factory=frozenset)
+    source: str = "none"  # none | env | file
+    status: str = "free"
+    hint: str = ""
+
+    @property
+    def is_pro(self) -> bool:
+        """True only for a verified, unexpired Pro license."""
+        return self.tier == TIER_PRO and self.status == "active"
+
+    def has(self, feature: str) -> bool:
+        """Whether ``feature`` is available under this entitlement.
+
+        Free (ungated) features are available to everyone; Pro features only
+        when this entitlement actually grants them.
+        """
+        return feature not in PRO_FEATURES or feature in self.features
+
+
+def _b64d(value: str) -> bytes:
+    """Decode unpadded/padded base64url text to bytes."""
+    pad = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + pad)
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _public_key_b64() -> str:
+    return os.environ.get(_ENV_PUBKEY, "").strip() or _EMBEDDED_PUBLIC_KEY_B64
+
+
+def _read_license_token(repo: Path | None) -> tuple[str, str]:
+    """Return ``(token, source)`` from the env var, then a repo-local or
+    home ``.redcon`` license file. Empty token means no license."""
+    env = os.environ.get(_ENV_LICENSE, "").strip()
+    if env:
+        return env, "env"
+
+    candidates: list[Path] = []
+    if repo is not None:
+        candidates += [repo / ".redcon" / name for name in _LICENSE_FILENAMES]
+    home = Path.home() / ".redcon"
+    candidates += [home / name for name in _LICENSE_FILENAMES]
+    for path in candidates:
+        try:
+            text = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if text:
+            return text, "file"
+    return "", "none"
+
+
+def _verify_token(token: str) -> Entitlement:
+    """Verify a license token and return the entitlement it grants.
+
+    Never raises: any failure resolves to a free/invalid/unverified
+    entitlement so the CLI keeps working no matter what the user pastes.
+    """
+    parts = token.split(".")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        return Entitlement(status="invalid", hint="License key is malformed.")
+    payload_b64, sig_b64 = parts
+
+    pub_b64 = _public_key_b64()
+    if not pub_b64:
+        return Entitlement(status="unverified", hint="Pro licenses are not enabled in this build.")
+
+    try:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+    except Exception:  # noqa: BLE001 - any import/runtime failure means "cannot verify"
+        return Entitlement(status="unverified", hint=_PRO_HINT)
+
+    try:
+        public_key = Ed25519PublicKey.from_public_bytes(_b64d(pub_b64))
+        public_key.verify(_b64d(sig_b64), payload_b64.encode("ascii"))
+    except InvalidSignature:
+        return Entitlement(status="invalid", hint="License signature did not verify.")
+    except (ValueError, TypeError):
+        return Entitlement(status="invalid", hint="License key is malformed.")
+
+    try:
+        data = json.loads(_b64d(payload_b64))
+    except (ValueError, json.JSONDecodeError):
+        return Entitlement(status="invalid", hint="License payload is unreadable.")
+
+    tier = str(data.get("tier", TIER_FREE))
+    email = str(data.get("email", ""))
+    exp = int(data.get("exp", 0) or 0)
+
+    if tier != TIER_PRO:
+        return Entitlement(tier=TIER_FREE, email=email, status="free")
+    if exp and exp < _now():
+        return Entitlement(
+            tier=TIER_PRO,
+            email=email,
+            expires_at=exp,
+            status="expired",
+            hint="License expired - renew to restore Pro.",
+        )
+    return Entitlement(
+        tier=TIER_PRO,
+        email=email,
+        expires_at=exp,
+        features=PRO_FEATURES,
+        status="active",
+    )
+
+
+def load_entitlement(repo: str | Path | None = None) -> Entitlement:
+    """Resolve the current entitlement from env or a ``.redcon`` license file.
+
+    Returns a free entitlement when no license is present. A present-but-
+    unusable license (invalid, expired, unverifiable) also resolves to free
+    for feature purposes, with ``status``/``hint`` explaining why.
+    """
+    repo_path = Path(repo) if repo is not None else None
+    token, source = _read_license_token(repo_path)
+    if not token:
+        return Entitlement()
+    return replace(_verify_token(token), source=source)

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -1,0 +1,195 @@
+"""Pro entitlement resolution and offline license verification."""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+crypto_ed = pytest.importorskip("cryptography.hazmat.primitives.asymmetric.ed25519")
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat  # noqa: E402
+
+from redcon import entitlements  # noqa: E402
+from redcon.entitlements import _PRO_HINT, Entitlement, load_entitlement  # noqa: E402
+
+# A fixed far-future expiry (2100-01-01) so tests never race the clock.
+FUTURE = 4_102_444_800
+PAST = 100
+
+
+def _b64e(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _make_key() -> tuple[crypto_ed.Ed25519PrivateKey, str]:
+    priv = crypto_ed.Ed25519PrivateKey.generate()
+    pub_b64 = _b64e(priv.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw))
+    return priv, pub_b64
+
+
+def _sign(priv: crypto_ed.Ed25519PrivateKey, **payload: object) -> str:
+    payload_b64 = _b64e(json.dumps(payload).encode("utf-8"))
+    sig_b64 = _b64e(priv.sign(payload_b64.encode("ascii")))
+    return f"{payload_b64}.{sig_b64}"
+
+
+@pytest.fixture
+def iso(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Isolate license resolution: empty home, no ambient env license."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(entitlements.Path, "home", staticmethod(lambda: home))
+    monkeypatch.delenv("REDCON_LICENSE_KEY", raising=False)
+    monkeypatch.delenv("REDCON_LICENSE_PUBKEY", raising=False)
+    return tmp_path
+
+
+def test_no_license_is_free(iso: Path):
+    ent = load_entitlement(iso)
+    assert ent.status == "free"
+    assert not ent.is_pro
+    assert ent.has("pack")  # a free (ungated) feature
+    assert not ent.has("dashboard.savings")  # a Pro feature
+
+
+def test_valid_pro_license_unlocks_features(iso: Path, monkeypatch: pytest.MonkeyPatch):
+    priv, pub = _make_key()
+    monkeypatch.setenv("REDCON_LICENSE_PUBKEY", pub)
+    monkeypatch.setenv("REDCON_LICENSE_KEY", _sign(priv, tier="pro", email="a@b.c", exp=FUTURE))
+
+    ent = load_entitlement(iso)
+    assert ent.is_pro
+    assert ent.status == "active"
+    assert ent.email == "a@b.c"
+    assert ent.source == "env"
+    assert ent.has("dashboard.savings")
+    assert ent.has("history.unlimited")
+
+
+def test_expired_license_does_not_grant_pro(iso: Path, monkeypatch: pytest.MonkeyPatch):
+    priv, pub = _make_key()
+    monkeypatch.setenv("REDCON_LICENSE_PUBKEY", pub)
+    monkeypatch.setenv("REDCON_LICENSE_KEY", _sign(priv, tier="pro", email="a@b.c", exp=PAST))
+
+    ent = load_entitlement(iso)
+    assert ent.status == "expired"
+    assert not ent.is_pro
+    assert not ent.has("dashboard.savings")
+
+
+def test_tampered_payload_is_invalid(iso: Path, monkeypatch: pytest.MonkeyPatch):
+    priv, pub = _make_key()
+    good = _sign(priv, tier="pro", email="a@b.c", exp=FUTURE)
+    # Swap in a payload that claims pro but was never signed.
+    forged_payload = _b64e(json.dumps({"tier": "pro", "email": "evil@x", "exp": FUTURE}).encode())
+    tampered = f"{forged_payload}.{good.split('.')[1]}"
+    monkeypatch.setenv("REDCON_LICENSE_PUBKEY", pub)
+    monkeypatch.setenv("REDCON_LICENSE_KEY", tampered)
+
+    ent = load_entitlement(iso)
+    assert ent.status == "invalid"
+    assert not ent.is_pro
+
+
+def test_license_signed_by_other_key_is_invalid(iso: Path, monkeypatch: pytest.MonkeyPatch):
+    priv, _ = _make_key()
+    _, other_pub = _make_key()
+    monkeypatch.setenv("REDCON_LICENSE_PUBKEY", other_pub)
+    monkeypatch.setenv("REDCON_LICENSE_KEY", _sign(priv, tier="pro", email="a@b.c", exp=FUTURE))
+
+    ent = load_entitlement(iso)
+    assert ent.status == "invalid"
+    assert not ent.is_pro
+
+
+def test_free_tier_license_stays_free(iso: Path, monkeypatch: pytest.MonkeyPatch):
+    priv, pub = _make_key()
+    monkeypatch.setenv("REDCON_LICENSE_PUBKEY", pub)
+    monkeypatch.setenv("REDCON_LICENSE_KEY", _sign(priv, tier="free", email="a@b.c"))
+
+    ent = load_entitlement(iso)
+    assert ent.status == "free"
+    assert not ent.is_pro
+
+
+@pytest.mark.parametrize("bad", ["garbage", "onlyonepart", "a.b.c", ".", "a.", ".b"])
+def test_malformed_key_is_invalid(iso: Path, monkeypatch: pytest.MonkeyPatch, bad: str):
+    _, pub = _make_key()
+    monkeypatch.setenv("REDCON_LICENSE_PUBKEY", pub)
+    monkeypatch.setenv("REDCON_LICENSE_KEY", bad)
+
+    ent = load_entitlement(iso)
+    assert ent.status == "invalid"
+    assert not ent.is_pro
+
+
+def test_no_pubkey_configured_treats_license_as_unverified(
+    iso: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # Pre-launch state: a key is pasted but the build ships no public key.
+    priv, _ = _make_key()
+    monkeypatch.setenv("REDCON_LICENSE_KEY", _sign(priv, tier="pro", email="a@b.c", exp=FUTURE))
+    monkeypatch.setattr(entitlements, "_EMBEDDED_PUBLIC_KEY_B64", "")
+
+    ent = load_entitlement(iso)
+    assert ent.status == "unverified"
+    assert not ent.is_pro
+
+
+def test_degrades_to_unverified_without_cryptography(iso: Path, monkeypatch: pytest.MonkeyPatch):
+    priv, pub = _make_key()
+    monkeypatch.setenv("REDCON_LICENSE_PUBKEY", pub)
+    monkeypatch.setenv("REDCON_LICENSE_KEY", _sign(priv, tier="pro", email="a@b.c", exp=FUTURE))
+    # Simulate the `pro` extra not being installed: the submodules
+    # _verify_token imports resolve to None in sys.modules, so `from ... import`
+    # raises ImportError just as a missing package would.
+    monkeypatch.setitem(sys.modules, "cryptography.exceptions", None)
+    monkeypatch.setitem(
+        sys.modules, "cryptography.hazmat.primitives.asymmetric.ed25519", None
+    )
+
+    ent = load_entitlement(iso)
+    assert ent.status == "unverified"
+    assert ent.hint == _PRO_HINT
+    assert not ent.is_pro
+
+
+def test_license_read_from_repo_file(iso: Path, monkeypatch: pytest.MonkeyPatch):
+    priv, pub = _make_key()
+    monkeypatch.setenv("REDCON_LICENSE_PUBKEY", pub)
+    redcon_dir = iso / ".redcon"
+    redcon_dir.mkdir()
+    (redcon_dir / "license").write_text(
+        _sign(priv, tier="pro", email="a@b.c", exp=FUTURE) + "\n", encoding="utf-8"
+    )
+
+    ent = load_entitlement(iso)
+    assert ent.is_pro
+    assert ent.source == "file"
+
+
+def test_env_license_beats_file(iso: Path, monkeypatch: pytest.MonkeyPatch):
+    priv, pub = _make_key()
+    monkeypatch.setenv("REDCON_LICENSE_PUBKEY", pub)
+    redcon_dir = iso / ".redcon"
+    redcon_dir.mkdir()
+    (redcon_dir / "license").write_text(
+        _sign(priv, tier="free", email="file@x"), encoding="utf-8"
+    )
+    monkeypatch.setenv("REDCON_LICENSE_KEY", _sign(priv, tier="pro", email="env@x", exp=FUTURE))
+
+    ent = load_entitlement(iso)
+    assert ent.is_pro
+    assert ent.email == "env@x"
+    assert ent.source == "env"
+
+
+def test_entitlement_has_is_permissive_for_ungated_features():
+    # A bare free entitlement grants everything that is not a Pro feature.
+    ent = Entitlement()
+    assert ent.has("pack")
+    assert ent.has("plan")
+    assert not ent.has("insights.prompt")

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -147,9 +147,7 @@ def test_degrades_to_unverified_without_cryptography(iso: Path, monkeypatch: pyt
     # _verify_token imports resolve to None in sys.modules, so `from ... import`
     # raises ImportError just as a missing package would.
     monkeypatch.setitem(sys.modules, "cryptography.exceptions", None)
-    monkeypatch.setitem(
-        sys.modules, "cryptography.hazmat.primitives.asymmetric.ed25519", None
-    )
+    monkeypatch.setitem(sys.modules, "cryptography.hazmat.primitives.asymmetric.ed25519", None)
 
     ent = load_entitlement(iso)
     assert ent.status == "unverified"
@@ -176,9 +174,7 @@ def test_env_license_beats_file(iso: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("REDCON_LICENSE_PUBKEY", pub)
     redcon_dir = iso / ".redcon"
     redcon_dir.mkdir()
-    (redcon_dir / "license").write_text(
-        _sign(priv, tier="free", email="file@x"), encoding="utf-8"
-    )
+    (redcon_dir / "license").write_text(_sign(priv, tier="free", email="file@x"), encoding="utf-8")
     monkeypatch.setenv("REDCON_LICENSE_KEY", _sign(priv, tier="pro", email="env@x", exp=FUTURE))
 
     ent = load_entitlement(iso)


### PR DESCRIPTION
## Summary

First brick of the paid tier: the core can recognize a signed Pro license and gate features behind it, without giving up its zero-dependency, offline-first properties. Nothing is gated yet - this is the foundation.

## Approach

- `redcon/entitlements.py` resolves an entitlement from `REDCON_LICENSE_KEY` or a `.redcon/license` file. Verification is offline against an embedded Ed25519 public key; the private key lives only in redcon-cloud and signs licenses on purchase, so a valid key proves purchase and Pro works with no network.
- The core stays dependency-free. `cryptography` ships in a new optional `pro` extra and is imported lazily, only when a license is present. A license present without the extra degrades to free with a clear install hint - never an unverifiable Pro.
- Until the production keypair is minted, the embedded public key is empty, so every license resolves to free. That is the correct pre-launch state and keeps this safe to merge now.
- `redcon license` shows, activates (`--activate KEY`), or removes (`--deactivate`) the license, in human or `--json` form.
- Feature slugs (`dashboard.savings`, `history.unlimited`, `insights.prompt`) are reserved so the dashboard and extension can gate against stable names.

Honest tradeoff: the local gate is open source, so it only stops casual bypass; the real paid value lives server-side. Asymmetric signing still matters so "holds a valid key" equals "paid".

## Test Coverage

- Added `tests/test_entitlements.py` (17 cases); all existing tests pass.

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added (cryptography is an optional `pro` extra; the core keeps `dependencies = []`)
- [x] Deterministic behavior preserved in core scoring/compression