### PR TITLE
Add 'redcon insights': prompt-optimization as the first Pro feature

### DIFF
--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -436,6 +436,57 @@ def cmd_license(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_insights(args: argparse.Namespace) -> int:
+    from redcon.cache.run_history import load_run_history
+    from redcon.core.insights import build_insights, insights_as_dict
+    from redcon.entitlements import load_entitlement
+
+    repo = Path(args.repo).resolve()
+    entries = load_run_history(repo)
+    report = build_insights(entries)
+    ent = load_entitlement(repo)
+    is_pro = ent.has("insights.prompt")
+
+    if getattr(args, "json", False):
+        data = insights_as_dict(report)
+        data["pro"] = is_pro
+        if not is_pro:
+            # Free tier gets the aggregate, not the per-prompt detail.
+            data["opportunities"] = []
+            data["locked"] = len(report.opportunities)
+        print(_json_mod.dumps(data, indent=2))
+        return 0
+
+    if report.note and not report.opportunities:
+        print(report.note)
+        return 0
+
+    count = len(report.opportunities)
+    total = report.total_potential_savings_tokens
+    headline = (
+        f"Found {count} prompt-optimization "
+        f"{'opportunity' if count == 1 else 'opportunities'} across {report.runs_analyzed} runs, "
+        f"~{total} tokens you could stop re-sending."
+    )
+    print(headline)
+
+    if not is_pro:
+        print()
+        print("Unlock the per-prompt breakdown and suggestions with Pro:")
+        print("  redcon license --activate <key>")
+        if ent.hint:
+            print(f"  ({ent.hint})")
+        return 0
+
+    for item in report.opportunities:
+        print()
+        print(f"- {item.title}")
+        print(f"  {item.detail}")
+        print(f"  ~{item.potential_savings_tokens} tokens above your typical run.")
+        print(f"  Fix: {item.suggestion}")
+    return 0
+
+
 def cmd_plan(args: argparse.Namespace) -> int:
     err = _validate_positive_int(args.top_files, "--top-files")
     if err:
@@ -2658,6 +2709,23 @@ def build_parser() -> argparse.ArgumentParser:
         help="Print the entitlement as JSON.",
     )
     license_parser.set_defaults(func=cmd_license)
+
+    insights = sub.add_parser(
+        "insights",
+        help="Find prompts that keep pulling large contexts (Pro)",
+    )
+    insights.add_argument(
+        "--repo",
+        default=".",
+        help="Repository whose run history to analyze (default: current directory).",
+    )
+    insights.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help="Print the insights report as JSON.",
+    )
+    insights.set_defaults(func=cmd_insights)
 
     completion = sub.add_parser(
         "completion",

--- a/redcon/core/insights.py
+++ b/redcon/core/insights.py
@@ -1,0 +1,225 @@
+"""Prompt-optimization insights (Pro feature, fully local and deterministic).
+
+Reads the run history redcon already records and surfaces patterns worth
+acting on: recurring prompts that keep pulling large contexts, and single
+prompts that pack most of the repo. Every number comes from the local history
+- there is no LLM call and no network, so the feature costs nothing to run.
+
+The estimates are deliberately conservative and honest: a run's "potential
+savings" is how many tokens it spent ABOVE the user's own median run. That is
+a real, computable quantity ("this prompt is X tokens heavier than your typical
+one"), not a fabricated promise. Everything user-facing is prefixed with "~".
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+from redcon.cache.run_history import RunHistoryEntry
+
+# Below this many runs there is not enough signal to say anything useful.
+MIN_RUNS = 5
+# A prompt must recur at least this many times to count as "recurring".
+MIN_REPEATS = 3
+# Ignore trivially small runs - they are not where the tokens go.
+MIN_INPUT_TOKENS = 2_000
+# A run is "broad" when it sits in the heaviest fifth of the user's runs.
+BROAD_PERCENTILE = 0.8
+# ...and, when we know the scan size, when it also kept most of what it saw.
+BROAD_SELECTION_RATIO = 0.5
+
+
+@dataclass(slots=True)
+class InsightItem:
+    """One actionable pattern found in the run history."""
+
+    kind: str  # "recurring_prompt" | "broad_context"
+    title: str
+    detail: str
+    suggestion: str
+    run_count: int
+    tokens_total: int
+    potential_savings_tokens: int
+
+
+@dataclass(slots=True)
+class InsightsReport:
+    """Deterministic summary of prompt-optimization opportunities."""
+
+    runs_analyzed: int
+    opportunities: list[InsightItem] = field(default_factory=list)
+    total_potential_savings_tokens: int = 0
+    note: str = ""
+
+
+@dataclass(slots=True)
+class _Run:
+    index: int
+    task: str
+    norm_task: str
+    input_tokens: int
+    selected: int
+    scanned: int
+
+
+def _norm_task(task: str) -> str:
+    return " ".join(task.lower().split())
+
+
+def _int(value: object) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _collect_runs(entries: list[RunHistoryEntry]) -> list[_Run]:
+    runs: list[_Run] = []
+    for index, entry in enumerate(entries):
+        usage = entry.token_usage or {}
+        input_tokens = _int(usage.get("estimated_input_tokens"))
+        if input_tokens <= 0:
+            continue
+        runs.append(
+            _Run(
+                index=index,
+                task=entry.task.strip(),
+                norm_task=_norm_task(entry.task),
+                input_tokens=input_tokens,
+                selected=len(entry.selected_files or []),
+                scanned=_int(usage.get("files_scanned")),
+            )
+        )
+    return runs
+
+
+def _percentile(sorted_values: list[int], fraction: float) -> int:
+    if not sorted_values:
+        return 0
+    idx = min(len(sorted_values) - 1, int(fraction * (len(sorted_values) - 1)))
+    return sorted_values[idx]
+
+
+def _truncate(task: str, limit: int = 60) -> str:
+    task = task or "(empty prompt)"
+    return task if len(task) <= limit else task[: limit - 3] + "..."
+
+
+def build_insights(entries: list[RunHistoryEntry]) -> InsightsReport:
+    """Analyze run history and return prompt-optimization opportunities.
+
+    Pure and deterministic: no clock, no IO, no network. The same history
+    always yields the same report.
+    """
+    runs = _collect_runs(entries)
+    if len(runs) < MIN_RUNS:
+        return InsightsReport(
+            runs_analyzed=len(runs),
+            note=f"Need at least {MIN_RUNS} recorded runs to find patterns - keep using redcon.",
+        )
+
+    inputs = sorted(r.input_tokens for r in runs)
+    median = int(statistics.median(inputs))
+    broad_threshold = max(_percentile(inputs, BROAD_PERCENTILE), MIN_INPUT_TOKENS)
+
+    # Per-run excess over the median run - the honest "addressable" amount.
+    def excess(run: _Run) -> int:
+        return max(0, run.input_tokens - median)
+
+    opportunities: list[InsightItem] = []
+    contributing: dict[int, int] = {}  # run index -> excess, deduped across items
+
+    # 1) Recurring prompts: the same phrasing run many times, each pulling a
+    #    large context. A saved, narrower phrasing compounds every repeat.
+    groups: dict[str, list[_Run]] = defaultdict(list)
+    for run in runs:
+        if run.norm_task:
+            groups[run.norm_task].append(run)
+    for group in groups.values():
+        if len(group) < MIN_REPEATS:
+            continue
+        avg = int(statistics.mean(r.input_tokens for r in group))
+        if avg < MIN_INPUT_TOKENS:
+            continue
+        total = sum(r.input_tokens for r in group)
+        potential = sum(excess(r) for r in group)
+        for run in group:
+            contributing[run.index] = excess(run)
+        opportunities.append(
+            InsightItem(
+                kind="recurring_prompt",
+                title=f'Recurring prompt: "{_truncate(group[0].task)}"',
+                detail=(
+                    f"Run {len(group)} times, averaging ~{avg} tokens each (~{total} tokens total)."
+                ),
+                suggestion=(
+                    "Save a narrower, reusable phrasing for this task (name the "
+                    "subsystem or files) so every repeat packs less."
+                ),
+                run_count=len(group),
+                tokens_total=total,
+                potential_savings_tokens=potential,
+            )
+        )
+
+    # 2) Broad contexts: a single prompt that is both heavy and, when we know
+    #    the scan size, kept most of the files it saw.
+    for run in runs:
+        if run.input_tokens < broad_threshold:
+            continue
+        if run.scanned > 0 and run.selected / run.scanned < BROAD_SELECTION_RATIO:
+            continue  # heavy but already well-scoped - not a scoping problem
+        if run.index in contributing:
+            continue  # already surfaced as part of a recurring group
+        scope = f" ({run.selected} of {run.scanned} files)" if run.scanned > 0 else ""
+        contributing[run.index] = excess(run)
+        opportunities.append(
+            InsightItem(
+                kind="broad_context",
+                title=f'Broad context: "{_truncate(run.task)}"',
+                detail=f"Packed ~{run.input_tokens} tokens{scope} - heavier than your typical run.",
+                suggestion=(
+                    "Scope this prompt to the specific area you are changing so "
+                    "redcon packs fewer files."
+                ),
+                run_count=1,
+                tokens_total=run.input_tokens,
+                potential_savings_tokens=excess(run),
+            )
+        )
+
+    # Heaviest opportunities first; total dedups runs shared across items.
+    opportunities.sort(key=lambda item: item.potential_savings_tokens, reverse=True)
+    total_potential = sum(contributing.values())
+
+    note = "" if opportunities else "No obvious prompt-scoping opportunities - nice and lean."
+    return InsightsReport(
+        runs_analyzed=len(runs),
+        opportunities=opportunities,
+        total_potential_savings_tokens=total_potential,
+        note=note,
+    )
+
+
+def insights_as_dict(report: InsightsReport) -> dict:
+    """JSON-serializable view of an insights report."""
+    return {
+        "command": "insights",
+        "runs_analyzed": report.runs_analyzed,
+        "total_potential_savings_tokens": report.total_potential_savings_tokens,
+        "opportunities": [
+            {
+                "kind": item.kind,
+                "title": item.title,
+                "detail": item.detail,
+                "suggestion": item.suggestion,
+                "run_count": item.run_count,
+                "tokens_total": item.tokens_total,
+                "potential_savings_tokens": item.potential_savings_tokens,
+            }
+            for item in report.opportunities
+        ],
+        "note": report.note,
+    }

--- a/redcon/core/pipeline.py
+++ b/redcon/core/pipeline.py
@@ -517,6 +517,10 @@ def run_pack(
                     "quality_risk_estimate": str(
                         report.budget.get("quality_risk_estimate", "unknown")
                     ),
+                    # Selection baseline (see RunReport) so `redcon insights` can
+                    # reason about how broadly each prompt pulled files.
+                    "context_baseline_tokens": int(report.context_baseline_tokens or 0),
+                    "files_scanned": int(report.files_scanned or 0),
                 },
                 result_artifacts={
                     "run_json": str(feed_path) if feed_path else "",

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -1,0 +1,134 @@
+"""Prompt-optimization insights (deterministic, local-only Pro feature)."""
+
+from __future__ import annotations
+
+from redcon.cache.run_history import RunHistoryEntry
+from redcon.core.insights import (
+    MIN_RUNS,
+    build_insights,
+    insights_as_dict,
+)
+
+
+def _entry(task: str, input_tokens: int, *, selected: int = 1, scanned: int = 0) -> RunHistoryEntry:
+    return RunHistoryEntry(
+        generated_at="2026-01-01T00:00:00+00:00",
+        task=task,
+        selected_files=[f"f{i}.py" for i in range(selected)],
+        token_usage={"estimated_input_tokens": input_tokens, "files_scanned": scanned},
+    )
+
+
+def test_not_enough_history_is_reported_gently():
+    report = build_insights([_entry("do a thing", 5000) for _ in range(MIN_RUNS - 1)])
+    assert report.opportunities == []
+    assert "at least" in report.note
+    assert report.total_potential_savings_tokens == 0
+
+
+def test_recurring_prompt_is_flagged():
+    # One heavy prompt repeated, plus lighter distinct runs to set a low median.
+    entries = [_entry("refactor the whole auth system", 12000) for _ in range(3)]
+    entries += [_entry(f"tiny task {i}", 800) for i in range(4)]
+
+    report = build_insights(entries)
+    kinds = [o.kind for o in report.opportunities]
+    assert "recurring_prompt" in kinds
+    recurring = next(o for o in report.opportunities if o.kind == "recurring_prompt")
+    assert recurring.run_count == 3
+    assert recurring.tokens_total == 36000
+    # Each of the 3 heavy runs is well above the ~800 median, so there is real
+    # excess to recover.
+    assert recurring.potential_savings_tokens > 0
+    assert report.total_potential_savings_tokens > 0
+
+
+def test_recurring_normalizes_whitespace_and_case():
+    entries = [
+        _entry("Fix   the LOGIN bug", 9000),
+        _entry("fix the login bug", 9000),
+        _entry("fix the login   bug  ", 9000),
+    ]
+    entries += [_entry(f"small {i}", 500) for i in range(4)]
+    report = build_insights(entries)
+    recurring = [o for o in report.opportunities if o.kind == "recurring_prompt"]
+    assert len(recurring) == 1
+    assert recurring[0].run_count == 3
+
+
+def test_broad_context_flagged_when_selection_is_wide():
+    # A distinct heavy run that kept most of the files it scanned.
+    entries = [_entry(f"small task {i}", 700) for i in range(6)]
+    entries.append(_entry("do everything everywhere", 20000, selected=45, scanned=50))
+
+    report = build_insights(entries)
+    broad = [o for o in report.opportunities if o.kind == "broad_context"]
+    assert len(broad) == 1
+    assert "45 of 50 files" in broad[0].detail
+    assert broad[0].potential_savings_tokens > 0
+
+
+def test_heavy_but_well_scoped_run_is_not_flagged_as_broad():
+    # Heavy, but it kept only a small fraction of what it scanned - already
+    # scoped, so scoping advice would be noise.
+    entries = [_entry(f"small task {i}", 700) for i in range(6)]
+    entries.append(_entry("targeted heavy change", 20000, selected=3, scanned=200))
+
+    report = build_insights(entries)
+    assert not any(o.kind == "broad_context" for o in report.opportunities)
+
+
+def test_lean_history_reports_no_opportunities():
+    entries = [_entry(f"distinct small task {i}", 900) for i in range(MIN_RUNS + 2)]
+    report = build_insights(entries)
+    assert report.opportunities == []
+    assert "lean" in report.note.lower()
+
+
+def test_a_run_is_not_double_counted_across_items():
+    # A recurring heavy prompt that is ALSO broad must contribute its excess
+    # to the total only once.
+    entries = [_entry("massive sweeping change", 15000, selected=60, scanned=70) for _ in range(3)]
+    entries += [_entry(f"lil {i}", 600) for i in range(4)]
+
+    report = build_insights(entries)
+    per_run_excess = sum(
+        max(0, o.potential_savings_tokens)
+        for o in report.opportunities
+        if o.kind == "broad_context"
+    )
+    # The recurring group already claimed those runs, so no separate broad item.
+    assert per_run_excess == 0
+    # Total equals the recurring group's excess, not double.
+    recurring = next(o for o in report.opportunities if o.kind == "recurring_prompt")
+    assert report.total_potential_savings_tokens == recurring.potential_savings_tokens
+
+
+def test_opportunities_sorted_by_potential_desc():
+    entries = [_entry("heavy recurring prompt", 18000) for _ in range(3)]
+    entries += [_entry(f"other {i}", 500) for i in range(4)]
+    entries.append(_entry("one broad distinct prompt", 9000, selected=30, scanned=40))
+
+    report = build_insights(entries)
+    potentials = [o.potential_savings_tokens for o in report.opportunities]
+    assert potentials == sorted(potentials, reverse=True)
+
+
+def test_insights_as_dict_shape():
+    entries = [_entry("recurring heavy", 11000) for _ in range(3)]
+    entries += [_entry(f"x {i}", 700) for i in range(4)]
+    data = insights_as_dict(build_insights(entries))
+    assert data["command"] == "insights"
+    assert data["runs_analyzed"] == 7
+    assert isinstance(data["opportunities"], list)
+    assert data["opportunities"]
+    first = data["opportunities"][0]
+    assert {"kind", "title", "detail", "suggestion", "potential_savings_tokens"} <= set(first)
+
+
+def test_runs_with_zero_input_are_ignored():
+    entries = [_entry("real", 8000) for _ in range(3)]
+    entries += [_entry(f"real small {i}", 600) for i in range(3)]
+    entries.append(_entry("ghost run", 0))  # dropped
+    report = build_insights(entries)
+    assert report.runs_analyzed == 6


### PR DESCRIPTION
## Summary

The first thing behind the Pro gate: `redcon insights`, a prompt-optimization view that reads the run history redcon already records and flags prompts worth rewording to save tokens. Fully local and deterministic - no LLM call, no network - so it costs nothing to run.

## Problem

Step 2 of monetization was "the savings dashboard as the first gated feature", but the local savings dashboard already exists and is free. Gating it would take something away from current users. We need a first Pro feature that only adds value and never incurs an API cost the founder has to pay for.

## Approach

- New `redcon insights` command, gated behind the `insights.prompt` entitlement.
- `redcon/core/insights.py` analyzes the run history for two patterns: recurring prompts (same phrasing run many times, each pulling a large context) and broad contexts (a single heavy prompt that kept most of the files it saw). A heavy-but-scoped prompt is deliberately not flagged.
- Estimates are honest: a run's potential saving is how many tokens it spent above the user's own median run - a real, computable quantity, never a fabricated promise. A run is counted once even if it matches both patterns.
- Free users get the aggregate headline and a prompt to unlock the detail; Pro users get the per-prompt breakdown and suggestions.
- `token_usage` in run history now also records the selection baseline so insights can tell how broadly a prompt pulled files. Older entries degrade gracefully.

## Test Coverage

- Added `tests/test_insights.py` (10 cases); all existing tests pass.

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression