### PR TITLE
Price out the selection saving in dollars for the editor nudge

### DIFF
--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -834,6 +834,15 @@ def cmd_pack(args: argparse.Namespace) -> int:
             f"(~{sent_tokens} tokens) vs ~{baseline_tokens} for the whole repo "
             f"- {pct_less}% less",
         )
+    # Dollar translation for anyone paying per token. On a flat plan the win is
+    # runway (the Context line above); this is the same saving priced out.
+    pack_cost = data.get("cost", {})
+    if isinstance(pack_cost, dict) and float(pack_cost.get("savings_usd", 0) or 0) > 0:
+        _qprint(
+            args,
+            f"Cost: ~${float(pack_cost['savings_usd']):.4f} saved this task if you pay "
+            f"per token ({pack_cost.get('display_name', 'default')} input rates)",
+        )
     _qprint(
         args,
         f"Files: {files_included} included, {files_skipped} skipped"

--- a/redcon/core/render.py
+++ b/redcon/core/render.py
@@ -550,6 +550,21 @@ def _selection_savings_md_lines(data: dict, budget: dict) -> list[str]:
     ]
 
 
+def _cost_savings_md_lines(data: dict) -> list[str]:
+    """Budget-section line pricing out the selection saving, when non-zero.
+
+    Independent of the selection line: shows whenever the run saved dollars vs
+    dumping the whole repo, even if every scanned file happened to be included.
+    """
+    cost = data.get("cost", {})
+    if not isinstance(cost, dict) or float(cost.get("savings_usd", 0) or 0) <= 0:
+        return []
+    return [
+        f"- Saved if paying per token: ~${float(cost['savings_usd']):.4f} "
+        f"({cost.get('display_name', 'default')} input rates)"
+    ]
+
+
 def render_pack_markdown(data: dict) -> str:
     """Render pack run payload to Markdown."""
 
@@ -577,6 +592,7 @@ def render_pack_markdown(data: dict) -> str:
             f"- Estimated input tokens: {budget.get('estimated_input_tokens', 0)}",
             f"- Estimated saved tokens: {budget.get('estimated_saved_tokens', 0)}",
             *_selection_savings_md_lines(data, budget),
+            *_cost_savings_md_lines(data),
             f"- Duplicate reads prevented: {budget.get('duplicate_reads_prevented', 0)}",
             f"- Quality risk estimate: {budget.get('quality_risk_estimate', 'unknown')}",
             f"- Cache backend: {cache.get('backend', 'unknown')}",

--- a/redcon/schemas/models.py
+++ b/redcon/schemas/models.py
@@ -319,6 +319,13 @@ class RunReport:
     # picking the right files.
     context_baseline_tokens: int = 0
     files_scanned: int = 0
+    # Dollar translation of the selection saving, for the "if you pay per token"
+    # framing (redcon.telemetry.pricing.compute_run_costs). Empty when there is
+    # no baseline to compare against. On a flat plan the value delivered is
+    # runway (see context_baseline_tokens); this is that same saving priced out
+    # at a model's input rate, labeled with the model assumed. Read by the
+    # editor nudge and the savings dashboard.
+    cost: dict[str, str | int | float] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if self.max_tokens <= 0:

--- a/redcon/stages/workflow.py
+++ b/redcon/stages/workflow.py
@@ -27,6 +27,7 @@ from redcon.schemas.models import (
     RunReport,
     TokenEstimatorReport,
 )
+from redcon.telemetry.pricing import DEFAULT_MODEL, compute_run_costs
 
 
 @dataclass(slots=True)
@@ -299,12 +300,23 @@ def run_render_stage(
     scan_summary: ScanRefreshSummary | None = None,
     baseline_tokens: int = 0,
     files_scanned: int = 0,
+    pricing_model: str | None = None,
 ) -> RunReport:
     """Render pipeline stage data into stable run report schema."""
 
     effective_top_files = top_files if top_files is not None else config.budget.top_files
     if effective_top_files is None:
         effective_top_files = DEFAULT_TOP_FILES
+    # Price out the selection saving so the "if you pay per token" number is
+    # available to the CLI, the run markdown, and the editor nudge. Empty when
+    # there is no whole-repo baseline to compare against.
+    cost: dict[str, str | int | float] = {}
+    if baseline_tokens > 0:
+        cost = compute_run_costs(
+            baseline_tokens=max(0, baseline_tokens),
+            optimized_tokens=compressed.estimated_input_tokens,
+            model=pricing_model or DEFAULT_MODEL,
+        )
     scan_meta: dict[str, int | bool] = {}
     if scan_summary is not None and scan_summary.file_count_capped:
         scan_meta = {
@@ -359,6 +371,7 @@ def run_render_stage(
         scan=scan_meta,
         context_baseline_tokens=max(0, baseline_tokens),
         files_scanned=max(0, files_scanned),
+        cost=cost,
     )
 
 

--- a/tests/test_cost_savings.py
+++ b/tests/test_cost_savings.py
@@ -1,0 +1,69 @@
+"""Dollar translation of the selection saving in pack output."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from redcon.core.pipeline import as_json_dict, run_pack
+from redcon.core.render import _cost_savings_md_lines, render_pack_markdown
+from redcon.telemetry.pricing import DEFAULT_MODEL, get_pricing
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8", newline="\n")
+
+
+def _repo(root: Path, count: int = 20) -> None:
+    for i in range(count):
+        body = (
+            f"def feature_{i}(payload):\n"
+            + "    # gateway auth billing rate-limit logic line\n" * 25
+            + f"    return process_{i}(payload)\n"
+        )
+        _write(root / "src" / f"mod_{i:02d}.py", body)
+
+
+def test_run_pack_prices_out_the_selection_saving(tmp_path: Path) -> None:
+    _repo(tmp_path)
+    data = as_json_dict(run_pack("refactor feature_01 auth", repo=tmp_path, max_tokens=500))
+
+    cost = data["cost"]
+    assert cost["model"] == DEFAULT_MODEL
+    # Priced at the default model's input rate against the same baseline the
+    # Context line uses.
+    baseline = data["context_baseline_tokens"]
+    sent = data["budget"]["estimated_input_tokens"]
+    assert cost["baseline_tokens"] == baseline
+    assert cost["optimized_tokens"] == sent
+    assert cost["tokens_saved"] == baseline - sent
+    rate = get_pricing(DEFAULT_MODEL)["input_per_million"]
+    assert cost["savings_usd"] > 0
+    assert abs(cost["savings_usd"] - (baseline - sent) / 1_000_000 * rate) < 1e-9
+
+
+def test_cost_line_in_markdown(tmp_path: Path) -> None:
+    _repo(tmp_path)
+    data = as_json_dict(run_pack("refactor feature_01 auth", repo=tmp_path, max_tokens=500))
+    markdown = render_pack_markdown(data)
+    assert "Saved if paying per token:" in markdown
+
+
+def test_cost_md_line_present_when_savings_positive() -> None:
+    lines = _cost_savings_md_lines({"cost": {"savings_usd": 0.0123, "display_name": "GPT-4o"}})
+    assert len(lines) == 1
+    assert "$0.0123" in lines[0]
+    assert "GPT-4o" in lines[0]
+
+
+def test_cost_md_line_absent_when_no_savings() -> None:
+    assert _cost_savings_md_lines({"cost": {"savings_usd": 0.0}}) == []
+    assert _cost_savings_md_lines({"cost": {}}) == []
+    assert _cost_savings_md_lines({}) == []  # older run.json without the field
+
+
+def test_cost_empty_when_no_baseline(tmp_path: Path) -> None:
+    # An empty repo has no scanned universe, so there is nothing to price out.
+    (tmp_path / "src").mkdir(parents=True)
+    data = as_json_dict(run_pack("do a thing", repo=tmp_path, max_tokens=500))
+    assert data.get("cost", {}) == {}


### PR DESCRIPTION
## Summary

Every pack now carries a dollar translation of the selection saving - the "if you pay per token" number - so the value lands for per-token users and, more importantly, so the editor nudge (monetization step 4) and the savings dashboard have a figure to display. Nothing here is gated; the per-run dollar figure is the free conversion hook.

## Problem

The pack reports how many files and tokens it saved (from the A1 selection baseline), but never what that is worth. The upcoming editor nudge needs a concrete "$ saved" number to show, and per-token users respond to dollars, not token counts.

## Approach

- Every run now carries a `cost` block, computed by the existing pricing table's `compute_run_costs`, pricing the selection baseline (`context_baseline_tokens`) against what was actually sent (`estimated_input_tokens`) at a model's input rate.
- The CLI and the run markdown show a cost line only when the saving is positive; `run.json` always carries the `cost` block so the extension and dashboard can read `cost.savings_usd`.
- The model assumed is labeled (defaults to Claude Sonnet input rates) so the number is transparent rather than a black box; a `pricing_model` param on `run_render_stage` leaves the door open to per-model rates later.
- Honest framing preserved: on a flat plan the value delivered is runway (the existing Context line); this is that same saving priced out for the per-token framing. Older `run.json` without the field degrades cleanly - the renderers omit the line.

## Test Coverage

- [x] Added/updated unit tests (`tests/test_cost_savings.py`: run_pack prices the saving at the default model's rate against the same baseline the Context line uses, markdown line present on a saving, and the line is omitted for zero-saving / missing-field / empty-repo runs)
- [x] All existing tests pass (1039 passed; the 11 `test_gateway.py` HTTP failures are the pre-existing sandbox env issue, identical on the base commit, unrelated to this change)
- [x] Before/after sample report included

Pack output now:
```
Budget: input=415 tokens, saved=3800 tokens, risk=high
Context: sent 4 of 12 files (~415 tokens) vs ~4210 for the whole repo - 90% less
Cost: ~$0.0114 saved this task if you pay per token (Claude Sonnet 4.6 input rates)
Files: 4 included, 8 skipped
```
`run.json` gains a `cost` block with `model`, `savings_usd`, `tokens_saved`, `baseline_tokens`, `optimized_tokens`, and the rate used.

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression