### PR TITLE
Contain symlink targets to the repo so the scanner cannot read host files

### DIFF
--- a/redcon/scanners/incremental.py
+++ b/redcon/scanners/incremental.py
@@ -682,6 +682,8 @@ def refresh_scan_index(
     total_file_count = 0
     file_count_capped = False
     resolved_symlinks: set[str] = set()
+    # Real path of the repo root, used to keep symlink targets contained.
+    repo_real = repo_path.resolve()
 
     for root, dirnames, filenames in os.walk(repo_path):
         dirnames[:] = sorted(
@@ -690,13 +692,27 @@ def refresh_scan_index(
         for name in sorted(filenames):
             path = Path(root) / name
 
-            # Handle symlinks - resolve and skip circular links
+            # Handle symlinks - resolve, keep the target inside the repo, and
+            # skip broken or circular links.
             if path.is_symlink():
                 try:
-                    resolved = str(path.resolve(strict=True))
-                except OSError:
-                    logger.debug("Skipping broken symlink: %s", path)
+                    resolved_path = path.resolve(strict=True)
+                except (OSError, RuntimeError):
+                    # OSError: broken link. RuntimeError: pathlib wraps an ELOOP
+                    # (a true a->b->a cycle) as a RuntimeError, so catch both.
+                    logger.debug("Skipping unresolvable symlink: %s", path)
                     continue
+                # Default-closed containment. A repo-supplied symlink whose real
+                # target lives outside the repo (../../etc/passwd, ~/.ssh/id_rsa,
+                # a cloud-credentials file) must never be read and packed into
+                # LLM-bound context. is_relative_to is a lexical prefix check on
+                # two already-resolved absolute paths.
+                if not resolved_path.is_relative_to(repo_real):
+                    logger.debug(
+                        "Skipping symlink escaping repo root: %s -> %s", path, resolved_path
+                    )
+                    continue
+                resolved = str(resolved_path)
                 if resolved in resolved_symlinks:
                     logger.debug("Skipping circular symlink: %s -> %s", path, resolved)
                     continue

--- a/tests/test_scanner_symlink_safety.py
+++ b/tests/test_scanner_symlink_safety.py
@@ -1,0 +1,103 @@
+"""The scanner must never follow a symlink whose target escapes the repo.
+
+A repository is untrusted input. A symlink inside it that points at a host file
+(SSH keys, cloud credentials, /etc/passwd) must not be read and packed into
+LLM-bound context. Broken and circular links must be skipped without crashing.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from redcon.scanners.incremental import refresh_scan_index
+
+
+def _symlink(src: Path, dst: Path) -> None:
+    try:
+        os.symlink(src, dst)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation not permitted on this platform")
+
+
+def _previews(records) -> str:
+    return "\n".join(r.content_preview for r in records)
+
+
+def _rel_paths(records) -> set[str]:
+    return {r.relative_path for r in records}
+
+
+def test_symlink_escaping_repo_is_not_read(tmp_path: Path):
+    repo = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    repo.mkdir()
+    outside.mkdir()
+    (outside / "secret.txt").write_text("TOP_SECRET_SSH_KEY_MARKER\n", encoding="utf-8")
+    (repo / "real.py").write_text("value = 1\n", encoding="utf-8")
+    # A repo-supplied symlink pointing at a file outside the repo root.
+    _symlink(outside / "secret.txt", repo / "leak.txt")
+
+    result = refresh_scan_index(repo)
+    rels = _rel_paths(result.records)
+
+    assert "real.py" in rels  # the genuine file is scanned
+    assert "leak.txt" not in rels  # the escaping symlink is not
+    assert "TOP_SECRET" not in _previews(result.records)  # its content never read
+
+
+def test_relative_dotdot_symlink_escape_is_blocked(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (tmp_path / "host_secret").write_text("HOST_SECRET_MARKER\n", encoding="utf-8")
+    (repo / "keep.py").write_text("x = 1\n", encoding="utf-8")
+    # ../host_secret climbs out of the repo via a relative link.
+    _symlink(Path("..") / "host_secret", repo / "escape.txt")
+
+    result = refresh_scan_index(repo)
+
+    assert "HOST_SECRET" not in _previews(result.records)
+    assert "escape.txt" not in _rel_paths(result.records)
+    assert "keep.py" in _rel_paths(result.records)
+
+
+def test_broken_symlink_is_skipped(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "real.py").write_text("value = 1\n", encoding="utf-8")
+    _symlink(repo / "does_not_exist.txt", repo / "dangling.txt")
+
+    result = refresh_scan_index(repo)  # must not raise
+
+    assert "real.py" in _rel_paths(result.records)
+    assert "dangling.txt" not in _rel_paths(result.records)
+
+
+def test_circular_symlinks_terminate(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "real.py").write_text("value = 1\n", encoding="utf-8")
+    _symlink(repo / "b.txt", repo / "a.txt")
+    _symlink(repo / "a.txt", repo / "b.txt")  # a -> b -> a
+
+    result = refresh_scan_index(repo)  # must terminate, not hang or crash
+
+    assert "real.py" in _rel_paths(result.records)
+    assert "a.txt" not in _rel_paths(result.records)
+    assert "b.txt" not in _rel_paths(result.records)
+
+
+def test_internal_symlink_is_still_followed(tmp_path: Path):
+    # The containment check must not block a legitimate symlink whose target
+    # stays inside the repo.
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / "src" / "target.py").write_text("INSIDE_REPO_MARKER = 1\n", encoding="utf-8")
+    _symlink(repo / "src" / "target.py", repo / "alias.py")
+
+    result = refresh_scan_index(repo)
+
+    # The real target is scanned; the content is available either way.
+    assert "INSIDE_REPO_MARKER" in _previews(result.records)


### PR DESCRIPTION
## Summary

Closes a high-severity path-escape: the scanner followed a repo-supplied file symlink to its target without checking the target stayed inside the repo, so a symlink to a host file (SSH keys, cloud credentials, `/etc/passwd`) was read and packed into LLM-bound context.

## Problem

A repository is untrusted input. In `refresh_scan_index`, the symlink handling resolved a link and skipped broken/circular ones, but never verified the resolved target was contained in the repo root. A file named e.g. `leak.txt` symlinked to `~/.ssh/id_rsa` (or `../../etc/passwd`) was therefore read like any repo file and its contents surfaced to the agent. This directly violates the tool's own threat model. The workspace scanner shares this code path, so it was affected too.

## Approach

- After resolving a file symlink, verify the real target is contained within the resolved repo root (`resolved.is_relative_to(repo_root)`), a lexical prefix check on two already-resolved absolute paths. If it escapes, skip the link (default-closed). Legitimate in-repo symlinks are still followed.
- Widen the `resolve()` catch to `RuntimeError`: a true `a->b->a` cycle raises `ELOOP` wrapped as `RuntimeError`, which previously crashed the scan instead of being skipped.

## Test Coverage

- [x] Added `tests/test_scanner_symlink_safety.py`: symlink escaping the repo (absolute and relative `..`) is not read and its content never appears; broken link skipped; circular link terminates without crashing; a legitimate in-repo symlink is still followed. Tests skip where symlink creation is not permitted.
- [x] All existing tests pass (1044 passed; the 11 `test_gateway.py` HTTP failures are the pre-existing sandbox env issue, identical on the base commit, unrelated to this change)

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression