### PR TITLE
Fix the FastAPI gateway returning 422 on every request and cover auth

### DIFF
--- a/redcon/gateway/server.py
+++ b/redcon/gateway/server.py
@@ -47,7 +47,7 @@ def _build_fastapi_app(config: GatewayConfig, handlers: GatewayHandlers):
     if fastapi is None:
         return None, None
 
-    from fastapi import Depends, FastAPI, HTTPException, Request
+    from fastapi import Depends, FastAPI, Header, HTTPException, Request
     from fastapi.responses import JSONResponse
 
     app = FastAPI(title="Redcon Gateway", version="1.0.0-alpha", docs_url=None, redoc_url=None)
@@ -58,10 +58,16 @@ def _build_fastapi_app(config: GatewayConfig, handlers: GatewayHandlers):
 
     # ── Auth middleware ────────────────────────────────────────────────────────
 
-    async def _verify_api_key(request: Request):
+    # The Authorization header is injected via Header() rather than the whole
+    # Request. This module uses ``from __future__ import annotations``, so every
+    # annotation is a string that FastAPI resolves against the module globals -
+    # where the locally-imported ``Request`` is not visible. A parameter typed
+    # ``Request`` therefore gets misread as a query field and every request 422s.
+    # ``authorization: str | None`` resolves from builtins and sidesteps that.
+    async def _verify_api_key(authorization: str | None = Header(default=None)):
         if config.api_key is None:
             return  # auth disabled
-        auth_header = request.headers.get("Authorization", "")
+        auth_header = authorization or ""
         if not auth_header.startswith("Bearer "):
             raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
         token = auth_header[len("Bearer ") :]
@@ -69,6 +75,24 @@ def _build_fastapi_app(config: GatewayConfig, handlers: GatewayHandlers):
             raise HTTPException(status_code=401, detail="Invalid API key")
 
     # ── Exception handlers ─────────────────────────────────────────────────────
+    # Keep the error contract identical to the stdlib fallback so a client sees
+    # the same status codes and ``{"error": ...}`` body regardless of which
+    # server implementation is installed.
+
+    from fastapi.exceptions import RequestValidationError
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    @app.exception_handler(RequestValidationError)
+    async def _validation_error_handler(request: Request, exc: RequestValidationError):
+        # A malformed JSON body (or a body that is not a JSON object) is a bad
+        # request, not a 422 - the stdlib path returns 400 here.
+        return JSONResponse(status_code=400, content={"error": "invalid request body"})
+
+    @app.exception_handler(StarletteHTTPException)
+    async def _http_exception_handler(request: Request, exc: StarletteHTTPException):
+        # Unknown endpoints (and any other HTTPException) report under "error",
+        # matching the stdlib handler's response shape.
+        return JSONResponse(status_code=exc.status_code, content={"error": exc.detail})
 
     @app.exception_handler(Exception)
     async def _unhandled_exception_handler(request: Request, exc: Exception):
@@ -107,7 +131,7 @@ def _build_fastapi_app(config: GatewayConfig, handlers: GatewayHandlers):
     # ── POST /prepare-context ─────────────────────────────────────────────────
 
     @app.post("/prepare-context", dependencies=[Depends(_verify_api_key)])
-    async def prepare_context(body: dict, request: Request):
+    async def prepare_context(body: dict):
         with _stats_lock:
             _stats["requests_total"] += 1
             _stats["requests_active"] += 1
@@ -121,14 +145,14 @@ def _build_fastapi_app(config: GatewayConfig, handlers: GatewayHandlers):
         except HTTPException:
             raise
         except KeyError as exc:
-            raise HTTPException(status_code=422, detail=f"Missing required field: {exc}") from exc
+            raise HTTPException(status_code=400, detail=f"Missing required field: {exc}") from exc
         finally:
             with _stats_lock:
                 _stats["requests_active"] -= 1
 
     @app.post("/run-agent-step", dependencies=[Depends(_verify_api_key)])
     @app.post("/run-step", dependencies=[Depends(_verify_api_key)])
-    async def run_agent_step(body: dict, request: Request):
+    async def run_agent_step(body: dict):
         with _stats_lock:
             _stats["requests_total"] += 1
             _stats["requests_active"] += 1
@@ -142,13 +166,13 @@ def _build_fastapi_app(config: GatewayConfig, handlers: GatewayHandlers):
         except HTTPException:
             raise
         except KeyError as exc:
-            raise HTTPException(status_code=422, detail=f"Missing required field: {exc}") from exc
+            raise HTTPException(status_code=400, detail=f"Missing required field: {exc}") from exc
         finally:
             with _stats_lock:
                 _stats["requests_active"] -= 1
 
     @app.post("/report-run", dependencies=[Depends(_verify_api_key)])
-    async def report_run(body: dict, request: Request):
+    async def report_run(body: dict):
         with _stats_lock:
             _stats["requests_total"] += 1
             _stats["requests_active"] += 1
@@ -162,7 +186,7 @@ def _build_fastapi_app(config: GatewayConfig, handlers: GatewayHandlers):
         except HTTPException:
             raise
         except KeyError as exc:
-            raise HTTPException(status_code=422, detail=f"Missing required field: {exc}") from exc
+            raise HTTPException(status_code=400, detail=f"Missing required field: {exc}") from exc
         finally:
             with _stats_lock:
                 _stats["requests_active"] -= 1

--- a/tests/test_gateway_auth.py
+++ b/tests/test_gateway_auth.py
@@ -1,0 +1,238 @@
+"""Bearer-token authentication for the Redcon Runtime Gateway.
+
+Auth is enforced identically on both server implementations: FastAPI + uvicorn
+when the ``[gateway]`` extra is installed, and the stdlib HTTP fallback (which
+is what default CI runs, since ``[dev]`` does not pull FastAPI). Handlers are
+mocked at the boundary so these tests exercise only routing and auth.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.request
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from redcon.gateway import GatewayConfig, GatewayServer
+
+_CANNED_PREPARE = {
+    "optimized_context": {"files": [], "prompt_text": "", "files_included": []},
+    "token_estimate": 0,
+    "cache_hits": 0,
+}
+
+
+def _free_port() -> int:
+    import socket
+
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _canned_handlers() -> MagicMock:
+    """A handlers double whose responses serialize to a fixed dict."""
+    handlers = MagicMock()
+    handlers.handle_prepare_context.return_value.as_dict.return_value = dict(_CANNED_PREPARE)
+    handlers.handle_run_agent_step.return_value.as_dict.return_value = dict(_CANNED_PREPARE)
+    handlers.handle_report_run.return_value.as_dict.return_value = {"acknowledged": True}
+    return handlers
+
+
+def _post(
+    url: str, body: dict[str, Any], headers: dict[str, str] | None = None
+) -> tuple[int, dict[str, Any]]:
+    raw = json.dumps(body).encode()
+    hdrs = {"Content-Type": "application/json", "Content-Length": str(len(raw))}
+    if headers:
+        hdrs.update(headers)
+    req = urllib.request.Request(url, data=raw, headers=hdrs, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read())
+
+
+def _wait_ready(base: str, timeout: float = 8.0) -> None:
+    """Poll GET /health (unauthenticated on both paths) until the server binds."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(f"{base}/health", timeout=1) as resp:
+                if resp.status == 200:
+                    return
+        except (urllib.error.URLError, OSError):
+            time.sleep(0.05)
+    raise RuntimeError(f"gateway did not become ready within {timeout}s")
+
+
+@contextmanager
+def _running_gateway(config: GatewayConfig):
+    """Start a live gateway with mocked handlers; yield its base URL.
+
+    Exercises whichever implementation is installed (FastAPI when present, the
+    stdlib fallback otherwise), so the auth path is validated end-to-end.
+    """
+    srv = GatewayServer(config, handlers=_canned_handlers())
+    srv.start(block=False)
+    try:
+        base = f"http://127.0.0.1:{config.port}"
+        _wait_ready(base)
+        yield base
+    finally:
+        srv.stop()
+
+
+@contextmanager
+def _fastapi_client(config: GatewayConfig):
+    """Build the FastAPI app in-process (ASGI TestClient); skip without the extra."""
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+
+    from redcon.gateway.server import _build_fastapi_app
+
+    app, _ = _build_fastapi_app(config, _canned_handlers())
+    assert app is not None
+    yield TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Live server: auth enforced when api_key is set
+# ---------------------------------------------------------------------------
+
+_API_KEY = "s3cret-gateway-token"
+
+
+class TestGatewayAuthLive:
+    @pytest.fixture(autouse=True)
+    def server(self):
+        config = GatewayConfig(
+            host="127.0.0.1", port=_free_port(), api_key=_API_KEY, log_requests=False
+        )
+        with _running_gateway(config) as base:
+            self._base = base
+            yield
+
+    def test_missing_authorization_header_is_401(self):
+        status, _ = _post(f"{self._base}/prepare-context", {"task": "x"})
+        assert status == 401
+
+    def test_non_bearer_scheme_is_401(self):
+        # The right secret under the wrong scheme is still rejected.
+        status, _ = _post(
+            f"{self._base}/prepare-context",
+            {"task": "x"},
+            {"Authorization": f"Basic {_API_KEY}"},
+        )
+        assert status == 401
+
+    def test_wrong_bearer_token_is_401(self):
+        status, _ = _post(
+            f"{self._base}/prepare-context",
+            {"task": "x"},
+            {"Authorization": "Bearer wrong-token"},
+        )
+        assert status == 401
+
+    def test_trailing_space_token_is_401(self):
+        # Locks in exact (constant-time) comparison: a one-char near-miss fails.
+        status, _ = _post(
+            f"{self._base}/prepare-context",
+            {"task": "x"},
+            {"Authorization": f"Bearer {_API_KEY} "},
+        )
+        assert status == 401
+
+    def test_correct_bearer_token_is_200(self):
+        status, body = _post(
+            f"{self._base}/prepare-context",
+            {"task": "x"},
+            {"Authorization": f"Bearer {_API_KEY}"},
+        )
+        assert status == 200
+        assert "optimized_context" in body
+
+    def test_auth_gates_run_step_endpoint_too(self):
+        no_key, _ = _post(f"{self._base}/run-step", {"task": "x"})
+        assert no_key == 401
+        ok, _ = _post(
+            f"{self._base}/run-step",
+            {"task": "x"},
+            {"Authorization": f"Bearer {_API_KEY}"},
+        )
+        assert ok == 200
+
+
+class TestGatewayAuthDisabledLive:
+    def test_no_api_key_allows_unauthenticated_request(self):
+        config = GatewayConfig(host="127.0.0.1", port=_free_port(), log_requests=False)
+        with _running_gateway(config) as base:
+            status, body = _post(f"{base}/prepare-context", {"task": "x"})
+            assert status == 200
+            assert "optimized_context" in body
+
+
+# ---------------------------------------------------------------------------
+# FastAPI path, in-process (deterministic; skipped without the [gateway] extra)
+# ---------------------------------------------------------------------------
+
+
+class TestGatewayFastAPIAuth:
+    def test_valid_body_is_accepted_without_auth(self):
+        # Regression guard: a param the annotation namespace cannot resolve makes
+        # FastAPI 422 every POST before auth even runs. This pins that shut.
+        config = GatewayConfig(api_key=None, log_requests=False)
+        with _fastapi_client(config) as client:
+            resp = client.post("/prepare-context", json={"task": "x"})
+            assert resp.status_code == 200
+            assert "optimized_context" in resp.json()
+
+    def test_missing_header_is_401(self):
+        config = GatewayConfig(api_key=_API_KEY, log_requests=False)
+        with _fastapi_client(config) as client:
+            assert client.post("/prepare-context", json={"task": "x"}).status_code == 401
+
+    def test_wrong_token_is_401(self):
+        config = GatewayConfig(api_key=_API_KEY, log_requests=False)
+        with _fastapi_client(config) as client:
+            resp = client.post(
+                "/prepare-context",
+                json={"task": "x"},
+                headers={"Authorization": "Bearer wrong-token"},
+            )
+            assert resp.status_code == 401
+
+    def test_correct_token_is_200(self):
+        config = GatewayConfig(api_key=_API_KEY, log_requests=False)
+        with _fastapi_client(config) as client:
+            resp = client.post(
+                "/prepare-context",
+                json={"task": "x"},
+                headers={"Authorization": f"Bearer {_API_KEY}"},
+            )
+            assert resp.status_code == 200
+            assert "optimized_context" in resp.json()
+
+    def test_invalid_json_body_is_400(self):
+        # Error contract matches the stdlib path: malformed body -> 400, not 422.
+        config = GatewayConfig(api_key=None, log_requests=False)
+        with _fastapi_client(config) as client:
+            resp = client.post(
+                "/prepare-context",
+                content=b"not-json",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status_code == 400
+
+    def test_unknown_endpoint_is_404_with_error_body(self):
+        config = GatewayConfig(api_key=None, log_requests=False)
+        with _fastapi_client(config) as client:
+            resp = client.post("/does-not-exist", json={"task": "x"})
+            assert resp.status_code == 404
+            assert "error" in resp.json()


### PR DESCRIPTION
## Summary

Fixes a bug that made the FastAPI gateway (`pip install 'redcon[gateway]'`) return **422 on every POST**, and adds the previously-missing Bearer-token authentication test coverage.

## Problem

`redcon/gateway/server.py` uses `from __future__ import annotations`, so every parameter annotation is a string that FastAPI resolves against the module globals. `Request` is imported only *inside* `_build_fastapi_app`, so FastAPI could not resolve the `request: Request` parameters and misread `request` as a required **query** field. Result: every POST to `/prepare-context`, `/run-agent-step`/`/run-step`, and `/report-run` failed request validation with 422 before auth or the handlers ever ran, so the production ASGI gateway was non-functional.

The stdlib HTTP fallback was unaffected, and default CI installs only `.[dev]` (no `gateway` extra), so CI always exercised the stdlib path and never caught this. Separately, `_verify_api_key` (Bearer-token auth) had **no test coverage**: the 401 path was never exercised.

## Approach

- Inject the `Authorization` header via `Header()` in `_verify_api_key` instead of taking the whole `Request`, so the auth dependency needs no unresolvable annotation.
- Drop the unused `request: Request` parameter from the three POST routes.
- Harmonize the FastAPI error contract with the stdlib fallback so a client sees the same responses regardless of which implementation is installed: `400` for a malformed or missing body, and an `{"error": ...}` body shape for HTTP errors (e.g. unknown endpoint 404).

No behavior change to the stdlib path, and no new runtime dependencies.

## Test Coverage

- [x] Added/updated unit tests in a new `tests/test_gateway_auth.py`: Bearer-token checks (missing header, non-Bearer scheme, wrong token, near-miss with a trailing space to lock in constant-time exact match, correct token gives 200) run against both the **live server** and the **in-process FastAPI app** (`TestClient`, skipped when the extra is absent). Includes a regression guard that a normal POST body is accepted at all, plus the auth-disabled path and the 400/404 error contract.
- [x] All existing tests pass: full suite 1068 passed, 12 skipped. This change also repairs the 11 `test_gateway.py` HTTP tests that previously failed locally against the FastAPI path (same root cause).

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression