### PR TITLE
Merge the local_file summary cache on save so concurrent agents keep writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ htmlcov/
 # Redcon artifacts
 .redcon/
 .redcon_cache.json
+.redcon_cache.json.lock
 .redcon_cache.db
 run.json
 run.md

--- a/redcon/cache/backends.py
+++ b/redcon/cache/backends.py
@@ -212,6 +212,38 @@ class SummaryCacheBackend(ABC):
         """Optional persistence hook."""
 
 
+@contextlib.contextmanager
+def _cache_file_lock(lock_path: Path):
+    """Serialize the read-merge-write of the JSON cache across processes.
+
+    Uses ``fcntl.flock`` on POSIX so several agent processes packing the same
+    repo take turns writing the cache file. Where ``fcntl`` is unavailable
+    (Windows), the lock degrades to a no-op: the per-key merge in ``_save``
+    still prevents whole-file clobbering, leaving only the narrow read/write
+    interleaving window unguarded rather than losing an entire process's work.
+    """
+    try:
+        import fcntl
+    except ImportError:
+        yield
+        return
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = open(lock_path, "w")  # noqa: SIM115 - closed in finally
+    except OSError:
+        # If the lock file itself cannot be created, proceed unlocked rather
+        # than fail the save; the merge still protects against total loss.
+        yield
+        return
+    try:
+        fcntl.flock(handle, fcntl.LOCK_EX)
+        yield
+    finally:
+        with contextlib.suppress(OSError):
+            fcntl.flock(handle, fcntl.LOCK_UN)
+        handle.close()
+
+
 class LocalFileSummaryCacheBackend(SummaryCacheBackend):
     """Persistent local summary cache backed by a JSON file."""
 
@@ -296,12 +328,49 @@ class LocalFileSummaryCacheBackend(SummaryCacheBackend):
     def _clear(self) -> None:
         self._data = {"summaries": {}, "fragments": {}, "slices": {}}
 
-    def _save(self) -> None:
+    def _merge_with_disk(self) -> dict[str, Any]:
+        """Fold this process's in-memory entries into whatever is on disk now.
+
+        A concurrent agent may have written entries after we loaded the file, so
+        we re-read it and overlay our own entries on top: last-writer-wins per
+        key instead of the whole file being clobbered. The stores are
+        content-addressed and append-only in practice, so a union is safe.
+        Unreadable or malformed on-disk data is treated as empty so a corrupt
+        file can never discard this process's work.
+        """
+        disk: dict[str, Any] = {}
         try:
-            atomic_write_text(
-                self.cache_path,
-                json.dumps(self._data, indent=2, sort_keys=True),
-            )
+            raw = json.loads(self.cache_path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                disk = raw
+        except (OSError, json.JSONDecodeError):
+            disk = {}
+
+        merged: dict[str, Any] = {}
+        for store in ("summaries", "fragments", "slices"):
+            combined: dict[str, str] = {}
+            disk_store = disk.get(store)
+            if isinstance(disk_store, dict):
+                combined.update(disk_store)
+            mem_store = self._data.get(store)
+            if isinstance(mem_store, dict):
+                combined.update(mem_store)  # in-memory wins per key
+            merged[store] = combined
+        # Carry over any extra top-level keys this process holds (forward-compat).
+        for key, value in self._data.items():
+            merged.setdefault(key, value)
+        return merged
+
+    def _save(self) -> None:
+        lock_path = self.cache_path.with_name(self.cache_path.name + ".lock")
+        try:
+            with _cache_file_lock(lock_path):
+                merged = self._merge_with_disk()
+                atomic_write_text(
+                    self.cache_path,
+                    json.dumps(merged, indent=2, sort_keys=True),
+                )
+                self._data = merged
         except OSError:
             return
 

--- a/tests/test_summary_cache_concurrency.py
+++ b/tests/test_summary_cache_concurrency.py
@@ -1,0 +1,103 @@
+"""Concurrent agents must not clobber each other's summary-cache writes.
+
+Each agent process loads the JSON cache into memory, adds its own entries, and
+flushes the whole file on ``save()``. Without a merge the last writer overwrote
+everyone else's keys (last-writer-wins per *file*). ``_save`` now re-reads the
+file and merges per key under a lock, so every process's entries survive.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from redcon.cache.backends import LocalFileSummaryCacheBackend
+from redcon.schemas.models import CACHE_FILE
+
+_HAS_FCNTL = importlib.util.find_spec("fcntl") is not None
+
+
+def _summaries_on_disk(repo: Path) -> dict[str, str]:
+    return json.loads((repo / CACHE_FILE).read_text(encoding="utf-8"))["summaries"]
+
+
+def test_concurrent_backends_do_not_clobber_each_other(tmp_path: Path) -> None:
+    # Both processes load the (empty) cache, then each writes a distinct key.
+    a = LocalFileSummaryCacheBackend(tmp_path)
+    b = LocalFileSummaryCacheBackend(tmp_path)
+    a.put_summary("key-a", "value-a")
+    b.put_summary("key-b", "value-b")
+
+    a.save()
+    b.save()  # b loaded before a saved, yet must not drop key-a
+
+    assert _summaries_on_disk(tmp_path) == {"key-a": "value-a", "key-b": "value-b"}
+
+    fresh = LocalFileSummaryCacheBackend(tmp_path)
+    assert fresh.get_summary("key-a") == "value-a"
+    assert fresh.get_summary("key-b") == "value-b"
+
+
+def test_last_writer_wins_per_key(tmp_path: Path) -> None:
+    a = LocalFileSummaryCacheBackend(tmp_path)
+    a.put_summary("shared", "from-a")
+    a.save()
+
+    b = LocalFileSummaryCacheBackend(tmp_path)  # loads {shared: from-a}
+    b.put_summary("shared", "from-b")
+    b.save()
+
+    assert _summaries_on_disk(tmp_path)["shared"] == "from-b"
+
+
+def test_merge_covers_fragments_and_slices(tmp_path: Path) -> None:
+    a = LocalFileSummaryCacheBackend(tmp_path)
+    b = LocalFileSummaryCacheBackend(tmp_path)
+    a.put_fragment("frag-a", "ref-a")
+    a.put_slice("slice-a", "data-a")
+    b.put_fragment("frag-b", "ref-b")
+    b.put_slice("slice-b", "data-b")
+
+    a.save()
+    b.save()
+
+    data = json.loads((tmp_path / CACHE_FILE).read_text(encoding="utf-8"))
+    assert data["fragments"] == {"frag-a": "ref-a", "frag-b": "ref-b"}
+    assert data["slices"] == {"slice-a": "data-a", "slice-b": "data-b"}
+
+
+def test_corrupt_cache_file_does_not_lose_writes(tmp_path: Path) -> None:
+    # A half-written or corrupt file must not discard this process's entries.
+    (tmp_path / CACHE_FILE).write_text("{ not valid json", encoding="utf-8")
+
+    backend = LocalFileSummaryCacheBackend(tmp_path)
+    backend.put_summary("k", "v")
+    backend.save()
+
+    assert _summaries_on_disk(tmp_path) == {"k": "v"}
+
+
+@pytest.mark.skipif(not _HAS_FCNTL, reason="requires fcntl file locking (POSIX)")
+def test_concurrent_saves_under_thread_contention(tmp_path: Path) -> None:
+    # Each thread is a separate backend racing to save at the same instant; the
+    # file lock must serialize the read-merge-write so no key is lost.
+    n = 16
+    ready = threading.Barrier(n)
+
+    def worker(i: int) -> None:
+        backend = LocalFileSummaryCacheBackend(tmp_path)
+        backend.put_summary(f"k{i}", f"v{i}")
+        ready.wait()  # maximize overlap of the save window
+        backend.save()
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert set(_summaries_on_disk(tmp_path)) == {f"k{i}" for i in range(n)}


### PR DESCRIPTION
## Summary

The default `local_file` summary cache lost writes when several agent processes packed the same repo at once. Each process now merges its entries into the file on save instead of overwriting it.

## Problem

`LocalFileSummaryCacheBackend` loads the whole JSON cache into memory at startup and, on `_save`, rewrites the entire file from that in-memory snapshot. Two agents A and B both load the cache, A adds a summary and saves, then B (whose snapshot predates A's write) saves and clobbers A's entry: last-writer-wins **per file**. Cached summaries from all but the last process were silently dropped, turning cache hits back into misses (and re-summarization work) under concurrency. `save()` is called once per run (`core/pipeline.py`), so the whole run's cache contribution could vanish.

## Approach

- `_save` now re-reads the on-disk file and folds this process's in-memory entries in **per key** (last-writer-wins per key), under an `fcntl` exclusive lock held across the read-merge-write so simultaneous savers take turns.
- The stores are content-addressed and append-only in practice (a changed file yields a new key; `invalidate`/`clear` are unused in the run path), so a union merge is safe.
- A corrupt or half-written on-disk file is treated as empty, so it can never discard this process's work.
- Where `fcntl` is unavailable (Windows), the lock degrades to a no-op: the per-key merge still prevents whole-file clobbering; only the narrow read/write interleaving window is left unguarded.

No API change, no new runtime dependency (`fcntl` is stdlib on POSIX). The `sqlite` backend already handles concurrency via WAL and is unaffected.

## Test Coverage

- [x] Added/updated unit tests in a new `tests/test_summary_cache_concurrency.py`: two backends writing distinct keys both survive; per-key last-writer-wins; fragment and slice stores merge too; a corrupt file does not lose in-memory writes; 16-way threaded save contention keeps every key (POSIX, skipped without `fcntl`).
- [x] All existing tests pass: full suite green (the only local flakes are the pre-existing uvicorn slow-bind timing in `test_gateway.py`, which pass in isolation and use the stdlib fast-bind path in CI).

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression