### PR TITLE
Derive shell completion from the parser so it can't advertise stale commands

### DIFF
--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -152,42 +152,24 @@ def _setup_no_color(args: argparse.Namespace) -> None:
     _NO_COLOR = getattr(args, "no_color", False) or os.environ.get("NO_COLOR", "") != ""
 
 
+def _completion_commands() -> list[str]:
+    """Subcommands to advertise in shell completion, read from the real parser.
+
+    Deriving the list from :func:`build_parser` keeps completion in lockstep with
+    the CLI - a hardcoded list drifts, advertising removed commands and omitting
+    new ones.
+    """
+    parser = build_parser()
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return sorted(action.choices)
+    return []
+
+
 def cmd_completion(args: argparse.Namespace) -> int:
     """Generate shell completion script."""
     shell = args.shell
-    commands = [
-        "doctor",
-        "plan",
-        "plan-agent",
-        "simulate-agent",
-        "pack",
-        "export",
-        "profile",
-        "pipeline",
-        "read-profiler",
-        "report",
-        "diff",
-        "pr-audit",
-        "benchmark",
-        "dataset",
-        "context-dataset",
-        "heatmap",
-        "watch",
-        "advise",
-        "observe",
-        "visualize",
-        "prepare-context",
-        "enforce",
-        "policy",
-        "drift",
-        "cost-analysis",
-        "gateway",
-        "control-plane",
-        "init",
-        "roi",
-        "benchmark-report",
-        "hooks",
-    ]
+    commands = _completion_commands()
     if shell == "bash":
         print(f"""# Redcon bash completion - add to ~/.bashrc or ~/.bash_completion
 _redcon_completions() {{

--- a/tests/test_cli_completion.py
+++ b/tests/test_cli_completion.py
@@ -1,0 +1,44 @@
+"""Shell completion must advertise exactly the CLI's real subcommands.
+
+The command list is derived from the parser rather than hardcoded, so this
+pins it to the parser and fails if the two ever drift apart.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from redcon.cli import _completion_commands, build_parser, cmd_completion
+
+
+def _parser_subcommands() -> set[str]:
+    parser = build_parser()
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return set(action.choices)
+    return set()
+
+
+def test_completion_matches_parser_subcommands() -> None:
+    assert set(_completion_commands()) == _parser_subcommands()
+
+
+def test_completion_list_is_sorted_and_nonempty() -> None:
+    commands = _completion_commands()
+    assert commands  # the CLI defines subcommands
+    assert commands == sorted(commands)
+
+
+def test_completion_bash_output_names_real_commands(capsys) -> None:
+    cmd_completion(argparse.Namespace(shell="bash"))
+    out = capsys.readouterr().out
+    assert "compgen" in out
+    # A command that the old hardcoded list omitted is now advertised.
+    assert "license" in out
+
+
+def test_completion_fish_output_lists_every_command(capsys) -> None:
+    cmd_completion(argparse.Namespace(shell="fish"))
+    out = capsys.readouterr().out
+    for command in _completion_commands():
+        assert f"-a '{command}'" in out


### PR DESCRIPTION
## Summary

`redcon completion` advertised a hardcoded command list that had drifted from the real CLI. It now derives the list from the parser, so it always matches.

## Problem

`cmd_completion` (`redcon/cli.py`) hardcoded the subcommand list used to build the bash/zsh/fish completion scripts. That list was stale: it advertised commands that no longer exist (`policy`, `context-dataset`) and omitted ten real ones (`license`, `insights`, `mcp`, `completion`, `dashboard`, `run`, `repo-map`, `build-dataset`, `cmd-bench`, `cmd-quality`). Users got completions for commands that error out, and no completion for commands that work.

## Approach

Read the subcommand names from `build_parser()`'s `_SubParsersAction.choices` (sorted) instead of maintaining a duplicate list by hand. Completion now reflects exactly what the CLI accepts, and stays correct automatically as commands are added or removed. No public behavior change beyond a correct, complete command list: 39 real commands now, vs 31 hardcoded (2 of which were phantom).

## Test Coverage

- [x] Added/updated unit tests in a new `tests/test_cli_completion.py`: the derived list equals the parser's subcommand set (anti-drift guard), the list is sorted and non-empty, the bash script names a previously-omitted real command, and the fish script lists every command.
- [x] All existing tests pass: full suite green (the only local flakes are the pre-existing uvicorn slow-bind timing in `test_gateway.py`, which pass in isolation and use the stdlib fast-bind path in CI).

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression