### PR TITLE
Test the bundle-stats compressor and add it to the adversarial fuzz matrix

### DIFF
--- a/tests/test_bundle_stats_compressor.py
+++ b/tests/test_bundle_stats_compressor.py
@@ -1,0 +1,116 @@
+"""Behavioral tests for the bundle-stats compressor.
+
+Feeds a representative webpack ``stats.json`` and an esbuild metafile through
+``BundleStatsCompressor`` and checks that the summary keeps the top assets and
+modules (with sizes) while cutting tokens versus the raw JSON.
+"""
+
+from __future__ import annotations
+
+import json
+
+from redcon.cmd.budget import BudgetHint
+from redcon.cmd.compressors.base import CompressorContext
+from redcon.cmd.compressors.bundle_stats_compressor import BundleStatsCompressor
+
+
+def _ctx(argv: tuple[str, ...]) -> CompressorContext:
+    # A generous budget so the formatter emits the full (verbose) summary; the
+    # raw JSON still dwarfs it, so the reduction assertions hold.
+    return CompressorContext(
+        argv=argv,
+        cwd=".",
+        returncode=0,
+        hint=BudgetHint(remaining_tokens=100_000, max_output_tokens=10_000),
+    )
+
+
+def _webpack_stats(n_modules: int = 60) -> bytes:
+    modules = [
+        {
+            "id": i,
+            "identifier": f"/abs/project/node_modules/pkg{i:02d}/dist/index.js",
+            "name": f"./node_modules/pkg{i:02d}/index.js",
+            "size": 1000 + i * 137,
+            "chunks": [0],
+            "reasons": [{"moduleName": "./src/index.js", "type": "harmony side effect"}],
+        }
+        for i in range(n_modules)
+    ]
+    stats = {
+        "assets": [
+            {"name": "main.js", "size": 250_000, "chunks": [0], "emitted": True},
+            {"name": "vendor.js", "size": 900_000, "chunks": [1], "emitted": True},
+        ],
+        "modules": modules,
+        "warnings": ["asset size limit: vendor.js exceeds the recommended limit"],
+        "errors": [],
+        "time": 4200,
+    }
+    return json.dumps(stats).encode("utf-8")
+
+
+def _esbuild_metafile(n_inputs: int = 60) -> bytes:
+    inputs = {
+        f"src/module{i:02d}.ts": {"bytes": 500 + i * 11, "imports": []} for i in range(n_inputs)
+    }
+    meta = {
+        "inputs": inputs,
+        "outputs": {
+            "dist/main.js": {
+                "bytes": 320_000,
+                "inputs": {
+                    f"src/module{i:02d}.ts": {"bytesInOutput": 400 + i * 7} for i in range(n_inputs)
+                },
+                "imports": [],
+                "exports": [],
+            }
+        },
+    }
+    return json.dumps(meta).encode("utf-8")
+
+
+def test_webpack_stats_summarized_and_reduced() -> None:
+    raw = _webpack_stats()
+    out = BundleStatsCompressor().compress(raw, b"", _ctx(("webpack", "--json")))
+
+    # Real reduction versus the raw JSON.
+    assert out.original_tokens > 0
+    assert out.compressed_tokens < out.original_tokens
+
+    text = out.text
+    assert "webpack" in text  # the tool is named
+    assert "vendor.js" in text and "main.js" in text  # both assets kept
+    assert "pkg" in text  # top modules listed
+    # The largest asset is surfaced first.
+    assert text.index("vendor.js") < text.index("main.js")
+    # Asset names are must-preserve patterns and the formatter emitted them.
+    assert out.must_preserve_ok is True
+
+
+def test_esbuild_metafile_summarized_and_reduced() -> None:
+    raw = _esbuild_metafile()
+    out = BundleStatsCompressor().compress(raw, b"", _ctx(("esbuild", "--analyze")))
+
+    assert out.original_tokens > 0
+    assert out.compressed_tokens < out.original_tokens
+
+    text = out.text
+    assert "esbuild" in text
+    assert "dist/main.js" in text  # the output bundle is named
+    assert "src/module" in text  # input modules listed
+    assert out.must_preserve_ok is True
+
+
+def test_compressor_matches_bundle_argv() -> None:
+    comp = BundleStatsCompressor()
+    assert comp.matches(("webpack", "--json")) is True
+    assert comp.matches(("git", "status")) is False
+
+
+def test_non_json_output_does_not_crash_or_inflate() -> None:
+    # Adversarial: plain text is not bundle stats; the compressor must not crash
+    # and must not blow the output up.
+    raw = b"just some build log line\nanother line\n"
+    out = BundleStatsCompressor().compress(raw, b"", _ctx(("webpack", "--json")))
+    assert out.compressed_tokens <= out.original_tokens

--- a/tests/test_cmd_quality_adversarial.py
+++ b/tests/test_cmd_quality_adversarial.py
@@ -25,29 +25,30 @@ from __future__ import annotations
 
 import os
 import random
-from dataclasses import dataclass, field
-from typing import Callable
+from collections.abc import Callable
+from dataclasses import dataclass
 
 import pytest
 
 from redcon.cmd.budget import BudgetHint
 from redcon.cmd.compressors.base import Compressor, CompressorContext
+from redcon.cmd.compressors.bundle_stats_compressor import BundleStatsCompressor
 from redcon.cmd.compressors.cargo_test_compressor import CargoTestCompressor
+from redcon.cmd.compressors.coverage_compressor import CoverageCompressor
+from redcon.cmd.compressors.docker_compressor import DockerCompressor
 from redcon.cmd.compressors.git_diff import GitDiffCompressor
 from redcon.cmd.compressors.git_log import GitLogCompressor
 from redcon.cmd.compressors.git_status import GitStatusCompressor
 from redcon.cmd.compressors.go_test_compressor import GoTestCompressor
 from redcon.cmd.compressors.grep_compressor import GrepCompressor
+from redcon.cmd.compressors.json_log_compressor import JsonLogCompressor
+from redcon.cmd.compressors.kubectl_compressor import KubectlGetCompressor
+from redcon.cmd.compressors.lint_compressor import LintCompressor
 from redcon.cmd.compressors.listing_compressor import (
     FindCompressor,
     LsCompressor,
     TreeCompressor,
 )
-from redcon.cmd.compressors.coverage_compressor import CoverageCompressor
-from redcon.cmd.compressors.docker_compressor import DockerCompressor
-from redcon.cmd.compressors.json_log_compressor import JsonLogCompressor
-from redcon.cmd.compressors.kubectl_compressor import KubectlGetCompressor
-from redcon.cmd.compressors.lint_compressor import LintCompressor
 from redcon.cmd.compressors.npm_test_compressor import NpmTestCompressor
 from redcon.cmd.compressors.pkg_install_compressor import (
     PackageInstallCompressor,
@@ -56,7 +57,6 @@ from redcon.cmd.compressors.profiler_compressor import ProfilerCompressor
 from redcon.cmd.compressors.pytest_compressor import PytestCompressor
 from redcon.cmd.compressors.sql_explain_compressor import SqlExplainCompressor
 from redcon.cmd.types import CompressionLevel
-
 
 # --- knobs ---
 
@@ -109,9 +109,7 @@ def _eval_one(
       - lost-pres   -> 20 + (1 - red_pct)
       - low-red     -> max(0, floor - red_frac) * 10  (only if >= 80 raw tokens)
     """
-    ctx = CompressorContext(
-        argv=argv, cwd=".", returncode=0, hint=_force_compact_hint()
-    )
+    ctx = CompressorContext(argv=argv, cwd=".", returncode=0, hint=_force_compact_hint())
     # (a) crash check
     try:
         first = compressor.compress(raw, b"", ctx)
@@ -195,19 +193,16 @@ def _eval_one(
 
 
 def _first_diff(a: str, b: str, n: int = 60) -> str:
-    for i, (x, y) in enumerate(zip(a, b)):
+    for i, (x, y) in enumerate(zip(a, b, strict=False)):
         if x != y:
-            return f"@{i} {a[i:i+n]!r} vs {b[i:i+n]!r}"
+            return f"@{i} {a[i : i + n]!r} vs {b[i : i + n]!r}"
     return f"len {len(a)} vs {len(b)}"
 
 
 # --- mutation operators ---
 
 
-_PRINTABLE = (
-    b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    b"0123456789 \n\t/.:-_+@()=[]{}<>"
-)
+_PRINTABLE = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 \n\t/.:-_+@()=[]{}<>"
 
 
 def _mutate(seed: bytes, rng: random.Random) -> bytes:
@@ -356,9 +351,7 @@ def _seed_corpus_for(schema: str) -> tuple[bytes, ...]:
             b"========================= 1 failed, 1 passed in 0.01s ==========================\n",
         )
     if schema == "grep":
-        return (
-            b"src/a.py:1:def f():\nsrc/a.py:2:    return 1\nsrc/b.py:1:def g():\n",
-        )
+        return (b"src/a.py:1:def f():\nsrc/a.py:2:    return 1\nsrc/b.py:1:def g():\n",)
     if schema == "ls":
         return (b"./d:\nfoo.py\nbar.py\n",)
     if schema == "tree":
@@ -378,16 +371,25 @@ def _seed_corpus_for(schema: str) -> tuple[bytes, ...]:
         )
     if schema == "npm_test":
         return (
-            b"PASS src/a.test.js\nFAIL src/b.test.js\n"
-            b"Tests:       1 failed, 1 passed, 2 total\n",
+            b"PASS src/a.test.js\nFAIL src/b.test.js\nTests:       1 failed, 1 passed, 2 total\n",
         )
     return (b"hello\n",)
 
 
 _CORPUS: tuple[bytes, ...] = _TOKENS + tuple(
-    s for k in (
-        "git_diff", "git_status", "git_log", "pytest", "grep",
-        "ls", "tree", "find", "cargo_test", "go_test", "npm_test",
+    s
+    for k in (
+        "git_diff",
+        "git_status",
+        "git_log",
+        "pytest",
+        "grep",
+        "ls",
+        "tree",
+        "find",
+        "cargo_test",
+        "go_test",
+        "npm_test",
     )
     for s in _seed_corpus_for(k)
 )
@@ -482,6 +484,7 @@ COMPRESSOR_TARGETS: list[tuple[str, Callable[[], Compressor], tuple[str, ...]]] 
         SqlExplainCompressor,
         ("psql", "-c", "EXPLAIN ANALYZE SELECT 1"),
     ),
+    ("bundle_stats", BundleStatsCompressor, ("webpack", "--json")),
 ]
 
 
@@ -513,8 +516,7 @@ def test_v85_genetic_hunt(name, factory, argv, capsys):
     import hashlib
 
     rng = random.Random(
-        0x85_85
-        + int(hashlib.sha1(name.encode("utf-8")).hexdigest()[:8], 16) % 10_000
+        0x85_85 + int(hashlib.sha1(name.encode("utf-8")).hexdigest()[:8], 16) % 10_000
     )
     compressor = factory()
     findings = genetic_hunt(
@@ -537,7 +539,7 @@ def test_v85_genetic_hunt(name, factory, argv, capsys):
 # confirms the harness itself doesn't crash. Cheap to keep in CI.
 def test_v85_smoke():
     rng = random.Random(0xC0FFEE)
-    for name, factory, argv in COMPRESSOR_TARGETS[:3]:
+    for _name, factory, argv in COMPRESSOR_TARGETS[:3]:
         findings = genetic_hunt(
             factory(),
             argv,


### PR DESCRIPTION
## Summary

`BundleStatsCompressor` had no behavioral test and was missing from the V85 adversarial fuzz matrix. This adds both.

## Problem

The bundle-stats compressor (webpack `stats.json` / esbuild metafile into a compact summary) shipped without a test exercising its actual output, and it was the only compressor absent from `COMPRESSOR_TARGETS`, so the genetic fuzzer never probed it for crashes, non-determinism, or must-preserve violations.

## Approach

- New `tests/test_bundle_stats_compressor.py`: feeds a representative webpack `stats.json` (60 modules, two assets, a warning) and an esbuild metafile, and asserts the summary names the tool, keeps the top assets/modules, surfaces the largest asset first, reports `must_preserve_ok`, and cuts tokens versus the raw JSON. Adds a `matches()` check and a non-JSON input that must neither crash nor inflate.
- Registers `('bundle_stats', BundleStatsCompressor, ('webpack','--json'))` in the adversarial `COMPRESSOR_TARGETS`. The genetic hunt reports **0 findings** for it, so it is robust under the fuzzer.
- Cleans that file's pre-existing lint (import order, unused `field` import, `zip(strict=)`, unused loop variable) so the whole module passes `ruff` now that it is a changed file.

## Test Coverage

- [x] Added/updated unit tests: 4 behavioral tests plus the new adversarial matrix entry.
- [x] All existing tests pass: full suite green (the only local flakes are the pre-existing uvicorn slow-bind timing in `test_gateway.py`, which pass in isolation and use the stdlib fast-bind path in CI).

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression