### PR TITLE
Gate compressor robustness in CI with the adversarial fuzzer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,3 +94,27 @@ jobs:
 
       - name: Run pip-audit
         run: pip-audit
+
+  adversarial:
+    # Gate compressor robustness: the V85 genetic fuzzer must find no crash,
+    # non-determinism, must-preserve, or below-floor finding on the fixed seed.
+    # Without REDCON_V85_ENFORCE=1 the fuzzer only reports; this job makes it fail.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[dev]
+
+      - name: Run adversarial compressor gate
+        env:
+          REDCON_V85_ENFORCE: "1"
+        run: pytest tests/test_cmd_quality_adversarial.py --tb=short -q


### PR DESCRIPTION
## Summary

The V85 adversarial genetic fuzzer never failed CI, so compressor robustness wasn't actually gated. This adds a CI job that enforces it.

## Problem

`tests/test_cmd_quality_adversarial.py` runs a genetic fuzzer that hunts for inputs where a compressor crashes, becomes non-deterministic, drops a must-preserve pattern, or falls below the reduction floor. By design it only *reports* findings unless `REDCON_V85_ENFORCE=1` is set, and nothing in CI set it. A regression that broke one of those properties would pass CI silently.

## Approach

Add a dedicated `adversarial` job to `.github/workflows/test.yml` that installs `.[dev]` and runs the fuzzer with `REDCON_V85_ENFORCE=1`, turning any finding on the fixed (seeded, stable-hash) input into a hard CI failure.

All 20 compressors, including the newly-added `bundle_stats` target, currently report **zero findings** at the default seed and generation count, so `_NOT_YET_ENFORCED` stays empty and the gate is green on day one while catching future robustness regressions. The job is fast (~1s of fuzzing) and independent of the existing test matrix.

## Test Coverage

- [x] Verified locally: `REDCON_V85_ENFORCE=1 pytest tests/test_cmd_quality_adversarial.py` passes (21 passed, 0 findings across all compressors).
- [x] The new workflow YAML parses and defines the `adversarial` job with `REDCON_V85_ENFORCE=1`.

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression