### PR TITLE
Cache import specs in the scan index so the graph stops re-reading files

### DIFF
--- a/redcon/scanners/incremental.py
+++ b/redcon/scanners/incremental.py
@@ -23,6 +23,7 @@ from redcon.schemas.models import (
     SCAN_INDEX_FILE,
     FileRecord,
 )
+from redcon.scorers.import_graph import extract_import_specs
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +33,9 @@ _SYMBOL_DEF_RE = re.compile(r"^(?:async\s+)?(?:def|class)\s+([A-Za-z_]\w*)", re.
 
 SCAN_INDEX_DB_FILE = ".redcon/scan-index.db"
 
-INDEX_FORMAT_VERSION = 1
+# v2 added FileRecord.import_specs; bumping discards v1 indexes so they rebuild
+# with import specs populated instead of serving records that lack them.
+INDEX_FORMAT_VERSION = 2
 
 _VENV_PREFIXES = (".venv", "venv-")
 
@@ -280,6 +283,7 @@ def _load_scan_index(path: Path, *, settings_fingerprint: str) -> ScanIndexState
                     content_hash=str(record_raw.get("content_hash", "")),
                     content_preview=str(record_raw.get("content_preview", "")),
                     symbol_names=str(record_raw.get("symbol_names", "")),
+                    import_specs=str(record_raw.get("import_specs", "")),
                     relative_path=str(record_raw.get("relative_path", "")),
                     repo_label=str(record_raw.get("repo_label", "")),
                     repo_root=str(record_raw.get("repo_root", "")),
@@ -380,6 +384,7 @@ def _load_scan_index_sqlite(db_path: Path, *, settings_fingerprint: str) -> Scan
                         content_hash=str(rd.get("content_hash", "")),
                         content_preview=str(rd.get("content_preview", "")),
                         symbol_names=str(rd.get("symbol_names", "")),
+                        import_specs=str(rd.get("import_specs", "")),
                         relative_path=str(rd.get("relative_path", "")),
                         repo_label=str(rd.get("repo_label", "")),
                         repo_root=str(rd.get("repo_root", "")),
@@ -495,15 +500,21 @@ def _build_file_record(
         return None
     digest = hashlib.sha1(text.encode("utf-8", errors="ignore")).hexdigest()
     symbol_names = " ".join(m.lower() for m in _SYMBOL_DEF_RE.findall(text))
+    extension = path.suffix.lower()
+    # Extract import specs now, while the file text is already in memory, so the
+    # import graph reuses them from the scan index instead of re-reading the
+    # file in every process.
+    import_specs = json.dumps(extract_import_specs(extension, text))
     return FileRecord(
         path=_scoped_path(rel, repo_label),
         absolute_path=str(path),
-        extension=path.suffix.lower(),
+        extension=extension,
         size_bytes=file_size,
         line_count=_count_lines(text),
         content_hash=digest,
         content_preview=text[:preview_chars],
         symbol_names=symbol_names,
+        import_specs=import_specs,
         relative_path=rel,
         repo_label=repo_label or "",
         repo_root=str(repo_path),

--- a/redcon/schemas/models.py
+++ b/redcon/schemas/models.py
@@ -19,6 +19,9 @@ class FileRecord:
     content_hash: str
     content_preview: str
     symbol_names: str = ""
+    # JSON list of raw import specifiers extracted at scan time (empty string =
+    # not extracted, so the import graph falls back to reading the file).
+    import_specs: str = ""
     relative_path: str = ""
     repo_label: str = ""
     repo_root: str = ""

--- a/redcon/scorers/import_graph.py
+++ b/redcon/scorers/import_graph.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import posixpath
 import re
 from collections import defaultdict
@@ -109,6 +110,119 @@ def _resolve_python_module_spec(
     return None
 
 
+def _python_specs(text: str) -> list[str]:
+    """Raw import specs from Python source (module names + expanded from-imports).
+
+    Extraction only - resolution to repo paths happens later against the module
+    map. Depends solely on the file's content, so the result is cacheable by
+    content hash.
+    """
+    specs: list[str] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        import_match = PY_IMPORT_RE.match(raw_line)
+        if import_match:
+            for token in import_match.group(1).split(","):
+                module = token.strip().split(" as ")[0].strip()
+                if module:
+                    specs.append(module)
+            continue
+
+        from_match = PY_FROM_RE.match(raw_line)
+        if not from_match:
+            continue
+
+        module_spec = from_match.group(1).strip()
+        imported_items = [
+            token.strip().split(" as ")[0].strip() for token in from_match.group(2).split(",")
+        ]
+        specs.append(module_spec)
+        for imported in imported_items:
+            if imported in {"", "*"}:
+                continue
+            if module_spec.startswith("."):
+                specs.append(f"{module_spec}{imported}")
+            else:
+                specs.append(f"{module_spec}.{imported}")
+    return specs
+
+
+def _js_ts_specs(text: str) -> list[str]:
+    """Raw module specifiers from JS/TS source (import-from, side-effect, require)."""
+    specs: set[str] = set(JS_IMPORT_FROM_RE.findall(text))
+    specs.update(JS_SIDE_EFFECT_IMPORT_RE.findall(text))
+    specs.update(JS_REQUIRE_RE.findall(text))
+    return sorted(specs)
+
+
+def _go_specs(text: str) -> list[str]:
+    """Raw import paths from Go source (single and block imports)."""
+    specs: list[str] = []
+    in_block = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("//"):
+            continue
+        single = GO_IMPORT_SINGLE_RE.match(line)
+        if single:
+            specs.append(single.group(1))
+            continue
+        if GO_IMPORT_BLOCK_START_RE.match(line):
+            in_block = True
+            continue
+        if in_block:
+            if line == ")":
+                in_block = False
+                continue
+            block_match = GO_IMPORT_RE.match(line)
+            if block_match:
+                specs.append(block_match.group(1))
+    return specs
+
+
+def extract_import_specs(extension: str, text: str) -> list[str]:
+    """Extract raw import specs for a file, dispatched by extension.
+
+    Content-only: the scanner calls this while it already has the file text in
+    memory, and the result is stored in the scan index so later import-graph
+    builds reuse it instead of re-reading unchanged files.
+    """
+    ext = extension.lower()
+    if ext == ".py":
+        return _python_specs(text)
+    if ext in JS_TS_EXTENSIONS:
+        return _js_ts_specs(text)
+    if ext == ".go":
+        return _go_specs(text)
+    return []
+
+
+def _record_specs(record: FileRecord, extractor) -> list[str] | None:
+    """Return a record's import specs, preferring the scan-index cache.
+
+    ``record.import_specs`` is a JSON list populated by the scanner. When it is
+    set (including an empty list for a file with no imports) it is used as-is,
+    avoiding a disk read. An empty string means "not cached" - fall back to
+    reading and extracting from disk so behaviour is never wrong, only slower.
+    Returns ``None`` only when the file was meant to be read but could not be.
+    """
+    if record.import_specs:
+        try:
+            data = json.loads(record.import_specs)
+        except (ValueError, TypeError):
+            data = None
+        if isinstance(data, list):
+            return [str(spec) for spec in data]
+    try:
+        text = Path(record.absolute_path).read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return None
+    return extractor(text)
+
+
 def _extract_python_import_edges(files: list[FileRecord]) -> dict[str, set[str]]:
     edges: dict[str, set[str]] = defaultdict(set)
     repo_groups: dict[str, list[FileRecord]] = defaultdict(list)
@@ -122,52 +236,15 @@ def _extract_python_import_edges(files: list[FileRecord]) -> dict[str, set[str]]
         for record in repo_files:
             if record.extension != ".py":
                 continue
-            try:
-                source = Path(record.absolute_path).read_text(encoding="utf-8", errors="ignore")
-            except OSError:
+            specs = _record_specs(record, _python_specs)
+            if specs is None:
                 continue
 
             current_path = record.relative_path or record.path
-
-            for raw_line in source.splitlines():
-                line = raw_line.strip()
-                if not line or line.startswith("#"):
-                    continue
-
-                import_match = PY_IMPORT_RE.match(raw_line)
-                if import_match:
-                    modules = [
-                        token.strip().split(" as ")[0].strip()
-                        for token in import_match.group(1).split(",")
-                    ]
-                    for module in modules:
-                        target = _resolve_python_module_spec(module, current_path, module_map)
-                        if target and target != record.path:
-                            edges[record.path].add(target)
-                    continue
-
-                from_match = PY_FROM_RE.match(raw_line)
-                if not from_match:
-                    continue
-
-                module_spec = from_match.group(1).strip()
-                imported_items = [
-                    token.strip().split(" as ")[0].strip()
-                    for token in from_match.group(2).split(",")
-                ]
-                specs = [module_spec]
-                for imported in imported_items:
-                    if imported in {"", "*"}:
-                        continue
-                    if module_spec.startswith("."):
-                        specs.append(f"{module_spec}{imported}")
-                    else:
-                        specs.append(f"{module_spec}.{imported}")
-
-                for spec in specs:
-                    target = _resolve_python_module_spec(spec, current_path, module_map)
-                    if target and target != record.path:
-                        edges[record.path].add(target)
+            for spec in specs:
+                target = _resolve_python_module_spec(spec, current_path, module_map)
+                if target and target != record.path:
+                    edges[record.path].add(target)
 
     return edges
 
@@ -229,14 +306,9 @@ def _extract_js_ts_import_edges(files: list[FileRecord]) -> dict[str, set[str]]:
         for record in repo_files:
             if record.extension not in JS_TS_EXTENSIONS:
                 continue
-            try:
-                source = Path(record.absolute_path).read_text(encoding="utf-8", errors="ignore")
-            except OSError:
+            specs = _record_specs(record, _js_ts_specs)
+            if specs is None:
                 continue
-
-            specs: set[str] = set(JS_IMPORT_FROM_RE.findall(source))
-            specs.update(JS_SIDE_EFFECT_IMPORT_RE.findall(source))
-            specs.update(JS_REQUIRE_RE.findall(source))
 
             current_path = record.relative_path or record.path
             for spec in specs:
@@ -288,33 +360,12 @@ def _extract_go_import_edges(files: list[FileRecord]) -> dict[str, set[str]]:
                         suffix_to_dir[suffix] = dir_path
 
         for record in go_files:
-            try:
-                source = Path(record.absolute_path).read_text(encoding="utf-8", errors="ignore")
-            except OSError:
+            specs = _record_specs(record, _go_specs)
+            if specs is None:
                 continue
 
-            import_specs: list[str] = []
-            in_block = False
-            for raw_line in source.splitlines():
-                line = raw_line.strip()
-                if not line or line.startswith("//"):
-                    continue
-                if GO_IMPORT_SINGLE_RE.match(line):
-                    import_specs.append(GO_IMPORT_SINGLE_RE.match(line).group(1))
-                    continue
-                if GO_IMPORT_BLOCK_START_RE.match(line):
-                    in_block = True
-                    continue
-                if in_block:
-                    if line == ")":
-                        in_block = False
-                        continue
-                    block_match = GO_IMPORT_RE.match(line)
-                    if block_match:
-                        import_specs.append(block_match.group(1))
-
             current_dir = posixpath.dirname(record.relative_path or record.path)
-            for spec in import_specs:
+            for spec in specs:
                 # Try matching suffix of the import path against repo directories.
                 parts = spec.split("/")
                 matched_dir = None

--- a/tests/test_import_graph_incremental.py
+++ b/tests/test_import_graph_incremental.py
@@ -1,0 +1,115 @@
+"""The import graph reuses scan-index import specs instead of re-reading files.
+
+The scanner extracts each file's import specs once (while it already has the
+text in memory) and stores them on the FileRecord. Later import-graph builds
+resolve from those cached specs, so an unchanged repo is not re-read every
+process. Correctness is unchanged: the graph is identical whether specs come
+from the cache or from a fresh read.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from redcon.scanners.incremental import refresh_scan_index
+from redcon.scorers.import_graph import build_import_graph, extract_import_specs
+
+
+def _outgoing(graph) -> dict[str, list[str]]:
+    return {src: sorted(dst) for src, dst in graph.outgoing.items() if dst}
+
+
+def test_scan_populates_import_specs(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("import b\nfrom c import x\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text("value = 1\n", encoding="utf-8")
+    (tmp_path / "c.py").write_text("x = 2\n", encoding="utf-8")
+
+    records = {r.relative_path: r for r in refresh_scan_index(tmp_path).records}
+
+    # a.py's specs are captured; b.py has none but is still recorded as "[]"
+    # (extracted, no imports) rather than "" (not extracted).
+    assert json.loads(records["a.py"].import_specs) == ["b", "c", "c.x"]
+    assert records["b.py"].import_specs == "[]"
+
+
+def test_graph_built_from_cached_specs_reads_no_files(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("import b\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text("value = 1\n", encoding="utf-8")
+    records = refresh_scan_index(tmp_path).records
+
+    def _no_reads(*_args, **_kwargs):
+        raise AssertionError("import graph re-read a file despite cached specs")
+
+    with patch("redcon.scorers.import_graph.Path.read_text", _no_reads):
+        graph = build_import_graph(records)
+
+    by = {r.relative_path: r for r in records}
+    assert by["b.py"].path in graph.outgoing[by["a.py"].path]
+
+
+def test_cached_and_read_graphs_are_identical_python(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("import b\nfrom pkg import c\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text("import c\n", encoding="utf-8")
+    (tmp_path / "c.py").write_text("x = 1\n", encoding="utf-8")
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "__init__.py").write_text("", encoding="utf-8")
+    _assert_identical(tmp_path)
+
+
+def test_cached_and_read_graphs_are_identical_js(tmp_path: Path) -> None:
+    (tmp_path / "a.js").write_text("import {x} from './b';\nrequire('./c');\n", encoding="utf-8")
+    (tmp_path / "b.js").write_text("export const x = 1;\n", encoding="utf-8")
+    (tmp_path / "c.js").write_text("module.exports = 2;\n", encoding="utf-8")
+    _assert_identical(tmp_path)
+
+
+def test_cached_and_read_graphs_are_identical_go(tmp_path: Path) -> None:
+    (tmp_path / "svc").mkdir()
+    (tmp_path / "svc" / "main.go").write_text(
+        'package main\nimport (\n\t"app/util"\n)\n', encoding="utf-8"
+    )
+    (tmp_path / "util").mkdir()
+    (tmp_path / "util" / "u.go").write_text("package util\n", encoding="utf-8")
+    _assert_identical(tmp_path)
+
+
+def _assert_identical(repo: Path) -> None:
+    records = refresh_scan_index(repo).records
+
+    import redcon.scorers.import_graph as ig
+
+    ig._GRAPH_CACHE.clear()
+    cached = _outgoing(build_import_graph(records))
+
+    # Force the read fallback by clearing the cached specs.
+    for record in records:
+        record.import_specs = ""
+    ig._GRAPH_CACHE.clear()
+    read = _outgoing(build_import_graph(records))
+
+    assert cached == read
+
+
+def test_empty_import_specs_falls_back_to_read(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("import b\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text("value = 1\n", encoding="utf-8")
+    records = refresh_scan_index(tmp_path).records
+    for record in records:
+        record.import_specs = ""  # simulate a pre-v2 record
+
+    import redcon.scorers.import_graph as ig
+
+    ig._GRAPH_CACHE.clear()
+    graph = build_import_graph(records)
+
+    by = {r.relative_path: r for r in records}
+    assert by["b.py"].path in graph.outgoing[by["a.py"].path]
+
+
+def test_extract_import_specs_by_extension() -> None:
+    assert extract_import_specs(".py", "import os\nfrom a import b\n") == ["os", "a", "a.b"]
+    assert extract_import_specs(".ts", "import x from './m';") == ["./m"]
+    assert extract_import_specs(".go", 'import "fmt"\n') == ["fmt"]
+    assert extract_import_specs(".txt", "import nothing here") == []


### PR DESCRIPTION
## Summary

The import graph re-read every source file from disk in each process, defeating the incremental scan index. It now reuses import specs the scanner already extracted, reading a file only when its specs aren't cached.

## Problem

`build_import_graph` calls `_extract_*_import_edges`, each of which read every matching source file (`Path(record.absolute_path).read_text(...)`) to pull out import statements, every process, even when the scan index already knew a file was unchanged. On a monorepo this re-read is the dominant cost of the scoring stage, and it duplicates the read the scanner already did to hash the file. The in-process memo (PR #171) helped within one process but nothing persisted across processes.

## Approach

Split import extraction into two steps:

- **Content-only spec extraction** (`extract_import_specs(extension, text)`): the raw import specifiers, which depend solely on file content.
- **Resolution** (unchanged): specs to repo paths, which depends on the whole file set and does no I/O.

The scanner extracts specs in `_build_file_record` while it already has the file text in memory and stores them on `FileRecord.import_specs` (a JSON list), so they travel in the scan index and are reused for unchanged files. `build_import_graph` resolves from those cached specs and reads a file only when `import_specs` is empty (`""` = not extracted), so behaviour is never wrong: a fresh read yields an identical graph, just slower. `INDEX_FORMAT_VERSION` is bumped to 2 so pre-v2 indexes rebuild with specs populated; older records simply fall back to a read.

No API change, no new dependency. Scanner to scorer is a clean one-way import (no cycle).

## Test Coverage

- [x] Added `tests/test_import_graph_incremental.py`: specs are populated at scan time (`[]` for no-imports, distinct from `""`); the graph builds from cached specs with **zero file reads** (patched `read_text` raises); cached and read-fallback graphs are **identical** for Python, JS/TS, and Go; an empty `import_specs` still resolves via a read; `extract_import_specs` dispatches by extension.
- [x] All existing tests pass: full suite green (the only local flakes are the pre-existing uvicorn slow-bind timing in `test_gateway.py`, which pass in isolation and use the stdlib fast-bind path in CI).

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression