### PR TITLE
Add a shared md_table markdown helper and use it in two renderers

### DIFF
--- a/redcon/core/render.py
+++ b/redcon/core/render.py
@@ -32,6 +32,26 @@ def _guard_output_size(output: str) -> str:
     return truncated + "\n\n[WARNING] Output truncated - exceeded 10 MB render limit.\n"
 
 
+def md_table(headers: list[str], rows: list[list[str]], *, align: str = "") -> list[str]:
+    """Build a Markdown table (header, separator, rows) as a list of lines.
+
+    ``align`` is a per-column code string of ``l`` (left, the default), ``r``
+    (right), or ``c`` (centre) selecting the separator marker. Cells and headers
+    are emitted verbatim, so callers pre-format them (numbers, bold, etc.).
+    """
+
+    def _marker(index: int) -> str:
+        code = align[index] if index < len(align) else "l"
+        return {"r": "---:", "c": ":-:"}.get(code, "---")
+
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join(_marker(i) for i in range(len(headers))) + " |",
+    ]
+    lines.extend("| " + " | ".join(str(cell) for cell in row) + " |" for row in rows)
+    return lines
+
+
 def write_json(path: Path, data: dict) -> None:
     """Write JSON file with stable formatting."""
 
@@ -1169,28 +1189,35 @@ def render_benchmark_markdown(data: dict) -> str:
         _append_model_profile_lines(lines, data)
     lines.extend(["", "## Token Estimator"])
     _append_token_estimator_lines(lines, data)
+    lines.extend(["", "## Strategy Comparison", ""])
     lines.extend(
-        [
-            "",
-            "## Strategy Comparison",
-            "",
-            "| Strategy | Input Tokens | Saved Tokens | Files Included | Duplicate Reads Prevented | Quality Risk | Cache Hits | Runtime (ms) |",
-            "| --- | ---: | ---: | ---: | ---: | --- | ---: | ---: |",
-        ]
-    )
-
-    for strategy in strategies:
-        lines.append(
-            "| "
-            f"{strategy.get('strategy', '')} | "
-            f"{strategy.get('estimated_input_tokens', 0)} | "
-            f"{strategy.get('estimated_saved_tokens', 0)} | "
-            f"{len(strategy.get('files_included', []))} | "
-            f"{strategy.get('duplicate_reads_prevented', 0)} | "
-            f"{strategy.get('quality_risk_estimate', 'unknown')} | "
-            f"{strategy.get('cache_hits', 0)} | "
-            f"{strategy.get('runtime_ms', 0)} |"
+        md_table(
+            [
+                "Strategy",
+                "Input Tokens",
+                "Saved Tokens",
+                "Files Included",
+                "Duplicate Reads Prevented",
+                "Quality Risk",
+                "Cache Hits",
+                "Runtime (ms)",
+            ],
+            [
+                [
+                    strategy.get("strategy", ""),
+                    strategy.get("estimated_input_tokens", 0),
+                    strategy.get("estimated_saved_tokens", 0),
+                    len(strategy.get("files_included", [])),
+                    strategy.get("duplicate_reads_prevented", 0),
+                    strategy.get("quality_risk_estimate", "unknown"),
+                    strategy.get("cache_hits", 0),
+                    strategy.get("runtime_ms", 0),
+                ]
+                for strategy in strategies
+            ],
+            align="lrrrrlrr",
         )
+    )
 
     lines.extend(["", "## Strategy Details"])
     for strategy in strategies:
@@ -1468,27 +1495,29 @@ def render_pipeline_markdown(data: dict) -> str:
         "",
         "## Summary",
         "",
-        "| Metric | Value |",
-        "| --- | --- |",
-        f"| Scanned files | {data.get('scanned_files', 0):,} |",
-        f"| Tokens at scan (ranked pool) | {tokens_at_scan:,} |",
-        f"| Tokens after ranking | {int(data.get('tokens_after_ranking') or 0):,} |",
-        f"| Tokens before pack | {int(data.get('tokens_before_pack') or 0):,} |",
-        f"| Tokens after pack | {int(data.get('tokens_after_pack') or 0):,} |",
-        f"| **Final context tokens** | **{final_tokens:,}** |",
-        f"| Total tokens saved | {total_saved:,} |",
-        f"| **Total reduction** | **{total_pct:.1f}%** |",
-        f"| Cache active | {'yes' if data.get('has_cache') else 'no'} |",
-        f"| Delta active | {'yes' if data.get('has_delta') else 'no'} |",
+        *md_table(
+            ["Metric", "Value"],
+            [
+                ["Scanned files", f"{data.get('scanned_files', 0):,}"],
+                ["Tokens at scan (ranked pool)", f"{tokens_at_scan:,}"],
+                ["Tokens after ranking", f"{int(data.get('tokens_after_ranking') or 0):,}"],
+                ["Tokens before pack", f"{int(data.get('tokens_before_pack') or 0):,}"],
+                ["Tokens after pack", f"{int(data.get('tokens_after_pack') or 0):,}"],
+                ["**Final context tokens**", f"**{final_tokens:,}**"],
+                ["Total tokens saved", f"{total_saved:,}"],
+                ["**Total reduction**", f"**{total_pct:.1f}%**"],
+                ["Cache active", "yes" if data.get("has_cache") else "no"],
+                ["Delta active", "yes" if data.get("has_delta") else "no"],
+            ],
+        ),
         "",
         "## Stage Breakdown",
         "",
-        "| Stage | Files | Tokens In | Tokens Out | Saved | Reduction |",
-        "| --- | ---: | ---: | ---: | ---: | ---: |",
     ]
 
     OPT_INDENT = "\u00a0\u00a0\u00a0\u00bb "
 
+    stage_rows: list[list[str]] = []
     for stage in stages:
         if not isinstance(stage, dict):
             continue
@@ -1502,9 +1531,16 @@ def render_pipeline_markdown(data: dict) -> str:
         pct = float(stage.get("reduction_pct") or 0.0)
         pct_cell = f"{pct:.1f}%" if pct > 0 else "-"
         saved_cell = f"{t_saved:,}" if t_saved > 0 else "-"
-        lines.append(
-            f"| {display_label} | {files:,} | {t_in:,} | {t_out:,} | {saved_cell} | {pct_cell} |"
+        stage_rows.append(
+            [display_label, f"{files:,}", f"{t_in:,}", f"{t_out:,}", saved_cell, pct_cell]
         )
+    lines.extend(
+        md_table(
+            ["Stage", "Files", "Tokens In", "Tokens Out", "Saved", "Reduction"],
+            stage_rows,
+            align="lrrrrr",
+        )
+    )
 
     notes_rows = [s for s in stages if isinstance(s, dict) and s.get("notes")]
     if notes_rows:

--- a/tests/test_render_md_table.py
+++ b/tests/test_render_md_table.py
@@ -1,0 +1,59 @@
+"""The shared md_table helper and the render functions that now use it."""
+
+from __future__ import annotations
+
+from redcon.core.render import md_table, render_benchmark_markdown, render_pipeline_markdown
+
+
+def test_md_table_default_left_align() -> None:
+    assert md_table(["A", "B"], [["1", "2"]]) == [
+        "| A | B |",
+        "| --- | --- |",
+        "| 1 | 2 |",
+    ]
+
+
+def test_md_table_alignment_markers() -> None:
+    assert md_table(["A", "B", "C"], [], align="lrc") == [
+        "| A | B | C |",
+        "| --- | ---: | :-: |",
+    ]
+
+
+def test_md_table_align_shorter_than_headers_defaults_left() -> None:
+    assert md_table(["A", "B"], [], align="r") == ["| A | B |", "| ---: | --- |"]
+
+
+def test_md_table_stringifies_cells() -> None:
+    assert md_table(["N"], [[42], [3.5]]) == ["| N |", "| --- |", "| 42 |", "| 3.5 |"]
+
+
+def test_pipeline_summary_and_stage_tables_render() -> None:
+    out = render_pipeline_markdown({"scanned_files": 5, "stages": []})
+    assert "| Metric | Value |" in out
+    assert "| --- | --- |" in out
+    assert "| Scanned files | 5 |" in out
+    # Stage breakdown header + right-aligned separator emitted even with no stages.
+    assert "| Stage | Files | Tokens In | Tokens Out | Saved | Reduction |" in out
+    assert "| --- | ---: | ---: | ---: | ---: | ---: |" in out
+
+
+def test_benchmark_comparison_table_renders() -> None:
+    out = render_benchmark_markdown(
+        {
+            "strategies": [
+                {
+                    "strategy": "greedy",
+                    "estimated_input_tokens": 7000,
+                    "estimated_saved_tokens": 3000,
+                    "files_included": ["a.py"],
+                    "duplicate_reads_prevented": 1,
+                    "quality_risk_estimate": "low",
+                    "cache_hits": 2,
+                    "runtime_ms": 9,
+                }
+            ]
+        }
+    )
+    assert "| --- | ---: | ---: | ---: | ---: | --- | ---: | ---: |" in out
+    assert "| greedy | 7000 | 3000 | 1 | 1 | low | 2 | 9 |" in out


### PR DESCRIPTION
## Summary

`render.py` hand-built every markdown table inline (header, `| --- |` separator, and each row), repeating the pipe-formatting throughout the module. This adds a small `md_table` helper and routes two renderers through it, with no output change.

## Problem

The ~40 `render_*_markdown` functions each write their tables by hand, duplicating the `| a | b |` row formatting and the separator line. A full sweep isn't cleanly possible: many tables use bespoke column widths (`|--------|--------|`) and alignments that a generic helper can't reproduce byte-for-byte, and the render tests assert exact output. So this is a deliberately **light** first step: introduce the helper and convert the tables that already use the canonical spaced form.

## Approach

- Add `md_table(headers, rows, *, align="")` returning the table as a list of lines. `align` is a per-column code (`l`/`r`/`c`) selecting the separator marker; cells are emitted verbatim so callers keep their existing formatting.
- Convert the two tables in `render_pipeline_markdown` and the strategy-comparison table in `render_benchmark_markdown` to use it.

Byte-for-byte identical output: both renderers' full output was captured before and after and compared, with no difference. The bespoke-width tables elsewhere are intentionally untouched.

## Test Coverage

- [x] Added `tests/test_render_md_table.py`: unit tests for `md_table` (default/left, alignment markers, short-align fallback, cell stringification) plus table assertions for both converted renderers (which had no prior coverage).
- [x] All existing tests pass: full suite green (1095 passed).

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression