### PR TITLE
Persist last_run_artifact so cross-replica session resume keeps auto-delta

### DIFF
--- a/redcon/runtime/session.py
+++ b/redcon/runtime/session.py
@@ -104,6 +104,10 @@ class RuntimeSession:
             "turn_count": len(self.turns),
             "cumulative_tokens": self.cumulative_tokens,
             "turns": list(self.turns),
+            # Persisted so a cross-replica session resume keeps the delta base;
+            # without it _restore_session always sees None and auto-delta is
+            # silently disabled for exactly the multi-replica case Redis serves.
+            "last_run_artifact": self.last_run_artifact,
         }
 
     def reset(self) -> None:

--- a/tests/test_gateway_session_store.py
+++ b/tests/test_gateway_session_store.py
@@ -1,0 +1,107 @@
+"""Gateway session persistence: SessionStore and the save/restore roundtrip.
+
+Covers the Redis-backed and in-memory SessionStore, and locks in that a session
+survives a save -> load -> restore cycle field-for-field - including
+last_run_artifact, whose omission from as_dict() silently disabled auto-delta on
+cross-replica resume.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from redcon.gateway.handlers import _restore_session
+from redcon.gateway.session_store import SessionStore
+from redcon.runtime.session import RuntimeSession
+
+
+def test_as_dict_includes_last_run_artifact() -> None:
+    session = RuntimeSession()
+    session.last_run_artifact = {"files": ["a.py"]}
+    assert session.as_dict()["last_run_artifact"] == {"files": ["a.py"]}
+
+
+def test_session_survives_save_load_restore_roundtrip() -> None:
+    # The bug guard: last_run_artifact (and every other field) must round-trip.
+    session = RuntimeSession()
+    session.cumulative_tokens = 1234
+    session.turns = [{"task": "add caching"}]
+    session.last_run_artifact = {"files": ["a.py"], "estimated_input_tokens": 5000}
+
+    store = SessionStore()  # in-memory
+    store.save(session.session_id, session.as_dict())
+    loaded = store.load(session.session_id)
+    assert loaded is not None
+
+    restored = RuntimeSession()
+    _restore_session(restored, loaded)
+
+    assert restored.session_id == session.session_id
+    assert restored.cumulative_tokens == 1234
+    assert restored.turns == [{"task": "add caching"}]
+    assert restored.last_run_artifact == {"files": ["a.py"], "estimated_input_tokens": 5000}
+
+
+def test_in_memory_store_save_load_delete() -> None:
+    store = SessionStore()
+    assert store.is_distributed is False
+    assert store.load("missing") is None
+
+    store.save("s1", {"session_id": "s1", "cumulative_tokens": 7})
+    assert store.load("s1") == {"session_id": "s1", "cumulative_tokens": 7}
+
+    store.delete("s1")
+    assert store.load("s1") is None
+    store.delete("s1")  # deleting an absent key is a no-op
+
+
+def test_in_memory_store_ping_is_true() -> None:
+    assert SessionStore().ping() is True
+
+
+def test_from_env_without_redis_url_is_in_memory(monkeypatch) -> None:
+    monkeypatch.setattr("redcon.gateway.session_store._REDIS_URL", "")
+    store = SessionStore.from_env()
+    assert store.is_distributed is False
+
+
+def test_missing_redis_package_falls_back_to_memory(monkeypatch) -> None:
+    # `import redis` raising ImportError must not break the store.
+    monkeypatch.setitem(sys.modules, "redis", None)
+    store = SessionStore(redis_url="redis://localhost:6379/0")
+    assert store.is_distributed is False
+    store.save("s", {"session_id": "s"})
+    assert store.load("s") == {"session_id": "s"}
+
+
+# --- Redis-backed path via fakeredis (skipped if fakeredis absent) ---
+
+
+def _redis_store() -> SessionStore:
+    fakeredis = pytest.importorskip("fakeredis")
+    store = SessionStore()
+    store._redis = fakeredis.FakeRedis(decode_responses=True)
+    store._using_redis = True
+    return store
+
+
+def test_redis_backed_store_roundtrip() -> None:
+    store = _redis_store()
+    assert store.is_distributed is True
+
+    store.save("sid", {"session_id": "sid", "turns": [{"task": "x"}]})
+    assert store.load("sid") == {"session_id": "sid", "turns": [{"task": "x"}]}
+
+    assert store.ping() is True
+
+    store.delete("sid")
+    assert store.load("sid") is None
+
+
+def test_redis_backed_store_uses_prefixed_key() -> None:
+    store = _redis_store()
+    store.save("abc", {"session_id": "abc"})
+    # The documented key format is rc_session:<id>.
+    assert store._redis.get("rc_session:abc") is not None


### PR DESCRIPTION
## Summary

Fixes a silent correctness bug: a Redis-backed session resumed on another gateway replica lost its `last_run_artifact`, disabling the auto-delta optimization. Also adds the missing tests for the session persistence layer.

## Problem

`RuntimeSession.as_dict()` serialized `session_id`, `created_at`, `updated_at`, `turn_count`, `cumulative_tokens`, and `turns` but **not** `last_run_artifact`. `_restore_session` restores that field only when it is present in the stored dict (`if "last_run_artifact" in stored`), so it was never restored. On a cross-replica resume (`handlers.py` saves via `as_dict()`, another replica loads and restores), `last_run_artifact` always came back `None`, silently disabling the auto-delta path in `runtime.py` for exactly the multi-replica, non-sticky-routing deployment the Redis `SessionStore` exists to serve. It degrades quietly (no crash) and only bites Redis-backed multi-replica setups, which is why it shipped: the whole `SessionStore` had no tests and there was no save/restore symmetry test.

## Approach

- Add `last_run_artifact` to `RuntimeSession.as_dict()` so it round-trips through `save` / `load` / `_restore_session`.

## Test Coverage

- [x] New `tests/test_gateway_session_store.py`:
  - A `save -> load -> restore` roundtrip asserting `last_run_artifact` (and every other field) survives. Confirmed it **fails without the one-line fix and passes with it**.
  - `SessionStore` coverage that previously did not exist: in-memory save/load/delete/ping/`from_env`/`is_distributed`, the missing-`redis`-package fallback to in-memory, and the Redis-backed path via `fakeredis` (already a dev dependency) including the documented `rc_session:<id>` key format.
- [x] All existing tests pass, full suite green (1103 passed).

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression