### PR TITLE
Test the SQLite scan-index recovery paths: corruption fallback and migration

### DIFF
--- a/tests/test_scan_index_sqlite.py
+++ b/tests/test_scan_index_sqlite.py
@@ -1,0 +1,62 @@
+"""SQLite scan-index recovery paths that run by default in production.
+
+use_sqlite defaults to True, so the SQLite store is the primary read source and
+the JSON index is its fallback. These cover the two recovery paths that were
+previously untested: a corrupt SQLite database falling back to the JSON index,
+and an existing JSON index migrating into a fresh SQLite database.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from redcon.scanners.incremental import (
+    SCAN_INDEX_DB_FILE,
+    load_scan_index,
+    refresh_scan_index,
+)
+from redcon.schemas.models import SCAN_INDEX_FILE
+
+
+def _seed(repo: Path) -> None:
+    (repo / "src").mkdir(parents=True, exist_ok=True)
+    (repo / "src" / "a.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+
+
+def test_corrupt_sqlite_falls_back_to_json_index(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    first = refresh_scan_index(tmp_path)  # writes both the JSON index and SQLite
+    assert first.summary.added_count == 1
+
+    db_path = tmp_path / SCAN_INDEX_DB_FILE
+    json_path = tmp_path / SCAN_INDEX_FILE
+    assert db_path.exists()
+    assert json_path.exists()
+
+    # Corrupt the SQLite database so its load returns None.
+    db_path.write_bytes(b"this is not a valid sqlite database")
+
+    # The scan must not crash: it falls back to the JSON index and still reuses
+    # the unchanged file instead of rescanning from scratch.
+    second = refresh_scan_index(tmp_path)
+    assert second.summary.added_count == 0
+    assert second.summary.reused_count >= 1
+    # The JSON index remains readable and a fresh, valid SQLite db is rewritten.
+    assert load_scan_index(json_path)
+
+
+def test_existing_json_index_migrates_into_sqlite(tmp_path: Path) -> None:
+    _seed(tmp_path)
+
+    # Build only the JSON index, as a pre-SQLite install would have.
+    refresh_scan_index(tmp_path, use_sqlite=False)
+    db_path = tmp_path / SCAN_INDEX_DB_FILE
+    assert not db_path.exists()
+    assert (tmp_path / SCAN_INDEX_FILE).exists()
+
+    # Enabling SQLite migrates the JSON index in, then reuses the unchanged file
+    # from the migrated data (added=0, reused>=1) rather than rescanning.
+    migrated = refresh_scan_index(tmp_path)  # use_sqlite=True (default)
+    assert db_path.exists()
+    assert migrated.summary.added_count == 0
+    assert migrated.summary.reused_count >= 1


### PR DESCRIPTION
## Summary

Adds coverage for the two SQLite scan-index recovery paths that run by default (`use_sqlite=True`) but had no tests: a corrupt database falling back to the JSON index, and an existing JSON index migrating into a fresh SQLite database.

## Problem

`refresh_scan_index` defaults to SQLite as the primary store with the JSON index as its fallback, and it migrates a pre-existing JSON index into SQLite on first use. Both recovery branches (`incremental.py` load fallback and `_migrate_scan_index_json_to_sqlite`) run in production but were only exercised indirectly; the sole SQLite-specific test passed `use_sqlite=False`.

## Approach

Test-only. New `tests/test_scan_index_sqlite.py`:

- **Corruption fallback:** scan a repo (writes JSON + SQLite), overwrite the `.db` with garbage, scan again, and assert the scan does not crash, falls back to the JSON index, and still reuses the unchanged file (`added=0`, `reused>=1`).
- **Migration:** build a JSON-only index (`use_sqlite=False`), then scan with SQLite enabled and assert the `.db` is created and the unchanged file is reused from the migrated data.

## Note on the related performance item

An adversarial re-audit also suggested skipping the JSON index write when the SQLite write succeeds. On inspection that is **not safe**: `.redcon/scan-index.json` is a documented artifact (`docs/configuration.md`, `docs/cli.md`, `docs/architecture.md` all state redcon maintains it, and `test_cli_watch_once_writes_scan_index` enforces it). Skipping the write would silently break that contract, so it was intentionally not changed here.

## Test Coverage

- [x] Added `tests/test_scan_index_sqlite.py` (2 tests covering the fallback and migration paths).
- [x] All existing tests pass, full suite green (the only local flake is the pre-existing uvicorn slow-bind timing in `test_gateway.py`, which passes in isolation and uses the stdlib fast-bind path in CI).

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression