### PR TITLE
Make workspace examples runnable and refresh stale docs facts

### DIFF
--- a/.github/wiki/CLI-Reference.md
+++ b/.github/wiki/CLI-Reference.md
@@ -16,6 +16,8 @@
 | `benchmark` | Compare packing strategies |
 | `heatmap` | Aggregate historical token hotspots |
 | `watch` | Monitor incremental scan index |
+| `license` | Show or activate the Pro license (offline verification) |
+| `insights` | Prompt-optimization insights from run history (Pro) |
 
 ---
 

--- a/.github/wiki/Configuration.md
+++ b/.github/wiki/Configuration.md
@@ -222,16 +222,16 @@ top_files = 30
 
 [[repos]]
 label = "auth-service"
-path = "../auth-service"
+path = "auth-service"
 
 [[repos]]
 label = "billing-service"
-path = "../billing-service"
+path = "billing-service"
 ignore_globs = ["tests/fixtures/**"]
 
 [[repos]]
 label = "gateway"
-path = "../platform/packages/gateway"
+path = "platform/packages/gateway"
 include_globs = ["src/**/*.ts"]
 ```
 

--- a/.github/wiki/Getting-Started.md
+++ b/.github/wiki/Getting-Started.md
@@ -72,11 +72,11 @@ top_files = 24
 
 [[repos]]
 label = "auth-service"
-path = "../auth-service"
+path = "auth-service"
 
 [[repos]]
 label = "billing-service"
-path = "../billing-service"
+path = "billing-service"
 ```
 
 Then run across all repos:

--- a/.github/wiki/Workspace.md
+++ b/.github/wiki/Workspace.md
@@ -21,21 +21,21 @@ top_files = 30
 
 [[repos]]
 label = "auth-service"
-path = "../auth-service"
+path = "auth-service"
 
 [[repos]]
 label = "billing-service"
-path = "../billing-service"
+path = "billing-service"
 ignore_globs = ["tests/fixtures/**"]
 
 [[repos]]
 label = "gateway"
-path = "../platform/packages/gateway"
+path = "platform/packages/gateway"
 include_globs = ["src/**/*.ts"]
 ```
 
 **Rules:**
-- `path` is resolved relative to the workspace TOML file
+- `path` is resolved relative to the workspace TOML file and must stay inside its directory; paths reaching above it (`../...`) are rejected, so place the workspace file in a common parent folder of all repos
 - `label` must be unique; it namespaces artifact paths like `auth-service:src/auth.py`
 - Repo-specific `include_globs` replace shared `scan.include_globs` for that repo
 - Repo-specific `ignore_globs` are added on top of shared `scan.ignore_globs`

--- a/README.md
+++ b/README.md
@@ -120,16 +120,19 @@ Methodology, limitations, and how to add your own tool:
 
 ## MCP Integration (Pull Model)
 
-Instead of pushing a 30k-token blob to your agent, Redcon exposes 6 MCP tools the agent calls on demand:
+Instead of pushing a 30k-token blob to your agent, Redcon exposes 9 MCP tools the agent calls on demand:
 
 | Tool | What it does |
 |------|--------------|
 | `redcon_rank` | Top-K files with scores and reasons - call this first |
 | `redcon_overview` | Lightweight repo map grouped by directory |
+| `redcon_repo_map` | Top ranked files plus their code signatures, fitted under a token budget |
 | `redcon_compress` | Compressed single-file view for cheap inspection |
 | `redcon_search` | Regex search scoped to ranked files or full repo |
+| `redcon_structural_search` | ast-grep structural search - patterns match the AST, not text |
 | `redcon_budget` | Plan fitting files within a token budget |
 | `redcon_run` | Run a shell command, return its output compressed |
+| `redcon_quality_check` | Run a command and verify the compressed output against the quality harness |
 
 Typical agent flow uses ~5k tokens for exploration instead of 30k for a blob. The agent itself decides what to read in full.
 
@@ -165,7 +168,7 @@ redcon cmd-bench     # markdown table; --json for CI baselines
 redcon run "git diff" --quality-floor compact --max-output-tokens 4000
 ```
 
-**Sixteen compressors** ship today: `git_diff`, `git_status`, `git_log`, `pytest`, `cargo_test`, `npm_test` (vitest+jest), `go_test`, `grep`, `ls`, `tree`, `find`, `lint` (ruff+mypy), `docker`, `pkg_install` (pip+npm+yarn), `kubectl_get`/`kubectl_events`, `profiler` (py-spy+perf), `json_log`, `coverage`, `sql_explain` (Postgres+MySQL TREE), `bundle_stats` (webpack + esbuild metafiles). Full per-schema benchmarks: [`docs/benchmarks/cmd/`](docs/benchmarks/cmd/).
+**Twenty compressors** ship today: `git_diff`, `git_status`, `git_log`, `pytest`, `cargo_test`, `npm_test` (vitest+jest), `go_test`, `grep`, `ls`, `tree`, `find`, `lint` (ruff+mypy), `docker`, `pkg_install` (pip+npm+yarn), `kubectl_get`/`kubectl_events`, `profiler` (py-spy+perf), `json_log`, `coverage`, `sql_explain` (Postgres+MySQL TREE), `bundle_stats` (webpack + esbuild metafiles). Full per-schema benchmarks: [`docs/benchmarks/cmd/`](docs/benchmarks/cmd/).
 
 ### Cross-call dimension
 
@@ -177,7 +180,7 @@ Beyond per-call compression, four layers compose across an agent session:
 - **Snapshot delta vs prior call** (V47): when the same argv runs twice, ship only the delta. Schema-aware renderers for `pytest` (set-diff over failure names), `git_diff` (file-set with per-file +/- counts), and `coverage` (per-file pp moves) win meaningfully over generic line-diff. Always picks `min(cost_delta, cost_abs)` so non-regressive by construction.
 - **Invariant cert** (V93): every COMPACT/VERBOSE output stamps `mp_sha=<16hex>` over the sorted multiset of `(pattern, capture)` extracted from raw. Auditors recompute the cert against the compressed text to detect spurious additions or capture thinning - upgrades the existing must-preserve boolean to set-equality.
 
-Empirical measurement on 5 simulated agent sessions (`benchmarks/measure_sessions.py`): the cross-call layers add **+8.3% session-level saving** on top of the per-call compressors, with **+15% on heavy-overlap sessions** (debugging, search-and-edit) and near-zero on distinct-content sessions. V85 adversarial GA fuzzer ratchets all 16 schemas as a hard CI gate (`REDCON_V85_ENFORCE=1`).
+Empirical measurement on 5 simulated agent sessions (`benchmarks/measure_sessions.py`): the cross-call layers add **+8.3% session-level saving** on top of the per-call compressors, with **+15% on heavy-overlap sessions** (debugging, search-and-edit) and near-zero on distinct-content sessions. V85 adversarial GA fuzzer ratchets all 20 schemas as a hard CI gate (`REDCON_V85_ENFORCE=1`).
 
 ## VS Code Extension
 
@@ -194,7 +197,10 @@ Branding: red->navy gradient with triple chevron mark, glass-style UI.
 
 ## Workspaces (Multi-Repo)
 
-One task can span multiple repos:
+One task can span multiple repos. Place the workspace TOML in a folder that
+contains all the repos (a monorepo root or a common parent directory) - repo
+paths must resolve inside that folder, so a workspace file cannot reach above
+itself:
 
 ```toml
 name = "backend-services"
@@ -208,11 +214,11 @@ top_files = 24
 
 [[repos]]
 label = "auth-service"
-path = "../auth-service"
+path = "auth-service"
 
 [[repos]]
 label = "billing-service"
-path = "../billing-service"
+path = "billing-service"
 ignore_globs = ["tests/fixtures/**"]
 ```
 
@@ -250,7 +256,7 @@ Full reference: [docs/python-api.md](docs/python-api.md).
 
 - **Deterministic scoring**: keyword match, import graph, file role (test/docs/prod), git history
 - **Language-aware compression**: Python, TypeScript, JavaScript, Go, Rust, Java, and more
-- **Command output compression**: 16 compressors covering git, test runners, grep/rg, listings, lint, docker, pkg-install, kubectl, profilers, JSON logs, coverage, SQL EXPLAIN, and bundle stats - 70-99% reduction at compact level
+- **Command output compression**: 20 compressors covering git, test runners, grep/rg, listings, lint, docker, pkg-install, kubectl, profilers, JSON logs, coverage, SQL EXPLAIN, and bundle stats - 70-99% reduction at compact level
 - **Incremental scanning**: cached file metadata with git-aware change detection
 - **Multi-repo workspaces**: single task, multiple repos, shared config
 - **Budget policies**: enforce max tokens, quality risk levels, file counts in CI

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,6 +24,21 @@ Manage the Claude Code `UserPromptSubmit` hook that injects a compact
 `<redcon-context>` block into every qualifying prompt. `run` is the hook
 entry point Claude Code executes. See [MCP and hooks](mcp-and-hooks.md).
 
+### `redcon license [--activate KEY] [--deactivate] [--json]`
+
+Show, activate, or remove your redcon Pro license. `--activate` saves the key to
+`~/.redcon/license`; `--deactivate` removes it. Verification is fully offline
+(Ed25519 signature check), so no network call is made and air-gapped machines work.
+Without a license redcon runs the free tier. `--repo` resolves a repo-local license
+file if one exists; `--json` prints the resolved entitlement.
+
+### `redcon insights [--repo <path>] [--json]`
+
+Analyze the recorded run history for prompt-optimization opportunities: recurring
+prompts that keep pulling large contexts, and single runs that packed far more than
+your typical one. Fully local and deterministic - no LLM call, no network. Requires
+at least 5 recorded runs. Pro feature; the free tier prints a summary teaser.
+
 ### `redcon completion <shell>`
 Print shell completion for bash, zsh or fish.
 
@@ -654,7 +669,9 @@ Each command supports `--config <path>` to load a custom `redcon.toml`.
 
 ## Workspace Config
 
-`--workspace` points to a TOML file with shared config plus one or more `[[repos]]` entries:
+`--workspace` points to a TOML file with shared config plus one or more `[[repos]]` entries.
+Place the file in a folder containing all the repos; repo paths must resolve inside that
+folder (paths reaching above it are rejected):
 
 ```toml
 [scan]
@@ -662,11 +679,11 @@ include_globs = ["**/*.py", "**/*.ts"]
 
 [[repos]]
 label = "auth-service"
-path = "../auth-service"
+path = "auth-service"
 
 [[repos]]
 label = "billing-service"
-path = "../billing-service"
+path = "billing-service"
 ignore_globs = ["**/generated/**"]
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,16 +158,16 @@ top_files = 30
 
 [[repos]]
 label = "auth-service"
-path = "../auth-service"
+path = "auth-service"
 
 [[repos]]
 label = "billing-service"
-path = "../billing-service"
+path = "billing-service"
 ignore_globs = ["tests/fixtures/**"]
 
 [[repos]]
 label = "gateway"
-path = "../platform/packages/gateway"
+path = "platform/packages/gateway"
 include_globs = ["src/**/*.ts"]
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ Redcon is local-first infrastructure for deterministic context selection, compre
 - [Policy and CI](policy-and-ci.md)
 - [Benchmark and Diff](benchmark-and-diff.md)
 - [Telemetry](telemetry.md)
-- [Analytics Events](analytics-events.md)
+- [Analytics Events](events.md)
 - [Migration Notes](migration.md)
 - [GitHub Action Integration](github-action.md)
 

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -20,6 +20,20 @@ Use a workspace when a change crosses repository or package boundaries, for exam
 
 Workspace configuration is TOML. It combines shared config with one or more `[[repos]]` entries.
 
+Place the workspace file in a folder that contains all the repos it names - a
+monorepo root or a common parent directory. Repo paths are resolved relative to
+the workspace file and must stay inside its directory; paths that reach above
+it (`../...`) are rejected. This is deliberate containment: a workspace file
+checked into an untrusted repository must not be able to pull files from
+elsewhere on your machine into LLM-bound context.
+
+```
+~/code/
+  workspace.toml        <- the file below
+  auth-service/
+  billing-service/
+```
+
 ```toml
 name = "backend-services"
 
@@ -36,11 +50,11 @@ critical_path_keywords = ["auth", "session", "permissions"]
 
 [[repos]]
 label = "auth-service"
-path = "../auth-service"
+path = "auth-service"
 
 [[repos]]
 label = "billing-service"
-path = "../billing-service"
+path = "billing-service"
 ignore_globs = ["tests/fixtures/**"]
 ```
 

--- a/examples/workspaces/app-shared-library.toml
+++ b/examples/workspaces/app-shared-library.toml
@@ -1,3 +1,6 @@
+# Copy this file to the root of the folder that contains the repos below
+# (e.g. your monorepo root). Repo paths are resolved relative to this file
+# and must stay inside its directory.
 name = "app-shared-library"
 
 [scan]
@@ -13,9 +16,9 @@ critical_path_keywords = ["auth", "client", "types"]
 
 [[repos]]
 label = "web-app"
-path = "../../apps/web"
+path = "apps/web"
 
 [[repos]]
 label = "shared-ui"
-path = "../../packages/shared-ui"
+path = "packages/shared-ui"
 include_globs = ["src/**/*.ts", "src/**/*.tsx"]

--- a/examples/workspaces/two-service-backend.toml
+++ b/examples/workspaces/two-service-backend.toml
@@ -1,3 +1,6 @@
+# Copy this file to the root of the folder that contains the repos below
+# (e.g. ~/code with services/ inside). Repo paths are resolved relative to
+# this file and must stay inside its directory.
 name = "two-service-backend"
 
 [scan]
@@ -13,9 +16,9 @@ critical_path_keywords = ["auth", "session", "permissions"]
 
 [[repos]]
 label = "auth-service"
-path = "../../services/auth-service"
+path = "services/auth-service"
 
 [[repos]]
 label = "billing-service"
-path = "../../services/billing-service"
+path = "services/billing-service"
 ignore_globs = ["tests/fixtures/**"]


### PR DESCRIPTION
## Summary

Fixes the onboarding breakage flagged by the re-audit: every shipped workspace example used a path pattern the loader rejects, so the first thing a workspace user tried failed. Also refreshes docs facts that had drifted from the code.

## Problem

`load_workspace` deliberately rejects repo paths that reach above the workspace file's directory (containment: a workspace TOML checked into an untrusted repo must not be able to pull host files like `~/.ssh` into LLM-bound context; same threat class as the scanner symlink escape fixed in #182). But every example in README, `docs/`, the wiki, and `examples/workspaces/` used `../sibling` paths, which that rule rejects. 21 example paths across 9 files were unrunnable as written.

Separately: README claimed 16 compressors (20 are registered) and listed 6 MCP tools (9 are served), `docs/index.md` linked a nonexistent `analytics-events.md`, and `docs/cli.md` plus the wiki CLI reference were missing the `license` and `insights` commands, both monetized surfaces.

## Approach

Docs and examples only; the loader is intentionally unchanged (the containment rule is correct security posture).

- Rewrote all 21 workspace example paths to the supported layout: the workspace TOML lives in a common parent folder (monorepo root) and uses child-relative paths. Added a directory sketch and an explicit statement of the containment rule to `docs/workspace.md`, `docs/cli.md`, the wiki, and README. The bundled `examples/workspaces/*.toml` gained a placement comment.
- README: 16 -> 20 compressors (3 spots), 6 -> 9 MCP tools with the missing `redcon_repo_map`, `redcon_structural_search`, and `redcon_quality_check` rows (descriptions taken from the tools' docstrings).
- `docs/index.md`: Analytics Events link now points to the real `events.md`.
- `docs/cli.md` and wiki `CLI-Reference.md`: added `license` (offline Ed25519 activation) and `insights` (local, deterministic, Pro) sections.

## Test Coverage

- [x] Verified the documented example loads: reproduced the docs layout in a temp dir and called `load_workspace` (loads both repos); confirmed the old `../` pattern is rejected with the documented error.
- [x] All existing tests pass: full suite green (1105 passed, 12 skipped).

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression