### PR TITLE
Add the Pro max-compression profile

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -60,6 +60,13 @@ Plan the same lifecycle-aware workflow across multiple local repositories or mon
 ### `redcon pack <task> --repo <path> [--max-tokens N] [--top-files N]`
 Build compressed context package and write `run.json` + `run.md` by default.
 
+`--compression-profile max` switches to the Pro max-compression profile: tighter
+tier thresholds that pack roughly 20% fewer input tokens at the same budget and
+reported quality risk (measured on this repository). It can also be set
+persistently with `[compression] profile = "max"` in `redcon.toml`. Without a
+Pro license the run warns once and falls back to the default profile; `run.json`
+always records which profile actually ran (`compression_profile`).
+
 ### `redcon pack <task> --repo <path> --delta <previous-run.json>`
 Build the normal current pack artifact plus a `delta` block that contains only the
 changes relative to the previous run. The delta package records:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,8 @@ critical_path_keywords = ["auth", "permissions", "billing"]
 
 [compression]
 summary_preview_lines = 10
+# profile = "max"  # Pro: tighter tier thresholds, ~20% fewer input tokens;
+#                    falls back to the default profile without a license
 
 [summarization]
 backend = "deterministic"

--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -708,6 +708,7 @@ def cmd_pack(args: argparse.Namespace) -> int:
         max_tokens=args.max_tokens,
         top_files=args.top_files,
         delta_from=args.delta,
+        compression_profile=getattr(args, "compression_profile", None),
     )
 
     files_included = len(data.get("files_included") or [])
@@ -825,6 +826,8 @@ def cmd_pack(args: argparse.Namespace) -> int:
             f"Cost: ~${float(pack_cost['savings_usd']):.4f} saved this task if you pay "
             f"per token ({pack_cost.get('display_name', 'default')} input rates)",
         )
+    if str(data.get("compression_profile", "")) == "max":
+        _qprint(args, "Profile: max compression (Pro)")
     _qprint(
         args,
         f"Files: {files_included} included, {files_skipped} skipped"
@@ -2963,6 +2966,15 @@ def _register_packing_commands(sub: argparse._SubParsersAction) -> None:
         action="store_true",
         default=False,
         help="Show what would be packed without writing any output files.",
+    )
+    pack.add_argument(
+        "--compression-profile",
+        choices=["default", "max"],
+        default=None,
+        help=(
+            "Compression profile: 'max' packs tighter representations (Pro; "
+            "falls back to default without a license). Overrides [compression] profile."
+        ),
     )
     pack.set_defaults(func=cmd_pack)
 

--- a/redcon/compressors/profiles.py
+++ b/redcon/compressors/profiles.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 Natalia Szczepanik. Licensed under FSL-1.1-MIT (see LICENSE).
+
+"""Named compression profiles.
+
+A profile is a preset of tier-threshold overrides applied on top of the
+``[compression]`` settings. The ``max`` profile tightens every threshold so
+more files land in cheaper representations; measured on this repository it
+packed ~21% fewer input tokens than the default profile at the same budget,
+top-files count, and reported quality risk.
+
+``max`` is a Pro feature (``compression.max``). When it is requested without
+an active license the run falls back to the default profile with a one-line
+warning - free behaviour never changes and nothing errors.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from redcon.config import CompressionSettings
+from redcon.entitlements import Entitlement
+
+PROFILE_DEFAULT = "default"
+PROFILE_MAX = "max"
+
+FEATURE_MAX_COMPRESSION = "compression.max"
+
+# The max preset. Applying the profile overrides exactly these keys; users who
+# want to keep hand-tuned values for them should stay on the default profile.
+MAX_PROFILE_OVERRIDES: dict[str, int | float] = {
+    "full_file_threshold_tokens": 100,
+    "snippet_hit_limit": 4,
+    "snippet_total_line_limit": 80,
+    "snippet_fallback_lines": 40,
+    "summary_preview_lines": 4,
+    "adaptive_line_budget_max_factor": 2.0,
+    "max_degradation_rounds": 2,
+}
+
+
+def resolve_compression_profile(
+    settings: CompressionSettings, entitlement: Entitlement
+) -> tuple[CompressionSettings, str, str]:
+    """Resolve the requested profile into effective settings.
+
+    Returns ``(effective_settings, applied_profile, note)``. ``note`` is
+    non-empty only when the request could not be honored (unknown profile
+    name, or ``max`` without a Pro license) and is meant to be surfaced as a
+    single warning line. The input ``settings`` object is never mutated.
+    """
+    requested = (settings.profile or "").strip().lower()
+    if requested in ("", PROFILE_DEFAULT):
+        return settings, PROFILE_DEFAULT, ""
+    if requested != PROFILE_MAX:
+        return (
+            replace(settings, profile=PROFILE_DEFAULT),
+            PROFILE_DEFAULT,
+            f"unknown compression profile {requested!r} - using the default profile",
+        )
+    if not entitlement.has(FEATURE_MAX_COMPRESSION):
+        return (
+            replace(settings, profile=PROFILE_DEFAULT),
+            PROFILE_DEFAULT,
+            "compression profile 'max' is a Pro feature - using the default profile "
+            "(activate with: redcon license --activate KEY)",
+        )
+    return replace(settings, **MAX_PROFILE_OVERRIDES), PROFILE_MAX, ""

--- a/redcon/config.py
+++ b/redcon/config.py
@@ -141,6 +141,10 @@ class ScoreSettings:
 class CompressionSettings:
     """Settings for context compression behavior."""
 
+    # Named profile applied on top of these settings ("" or "default" = none;
+    # "max" = the Pro max-compression preset, resolved against the entitlement
+    # at run time - see redcon/compressors/profiles.py).
+    profile: str = ""
     full_file_threshold_tokens: int = 300
     snippet_score_threshold: float = 2.5
     symbol_extraction_enabled: bool = True
@@ -558,6 +562,8 @@ def _apply_score_overrides(settings: ScoreSettings, data: Mapping[str, Any]) -> 
 
 
 def _apply_compression_overrides(settings: CompressionSettings, data: Mapping[str, Any]) -> None:
+    if "profile" in data:
+        settings.profile = str(data["profile"]).strip().lower()
     if "full_file_threshold_tokens" in data:
         settings.full_file_threshold_tokens = int(data["full_file_threshold_tokens"])
     if "snippet_score_threshold" in data:
@@ -880,6 +886,7 @@ def _apply_overrides(config: RedconConfig, data: Mapping[str, Any]) -> RedconCon
             config.explicit.compression,
             compression_data,
             {
+                "profile": "profile",
                 "full_file_threshold_tokens": "full_file_threshold_tokens",
                 "snippet_score_threshold": "snippet_score_threshold",
                 "symbol_extraction_enabled": "symbol_extraction_enabled",

--- a/redcon/core/pipeline.py
+++ b/redcon/core/pipeline.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
 from redcon.cache import RunHistoryEntry, append_run_history_entry, normalize_cache_report
+from redcon.compressors.profiles import PROFILE_DEFAULT, resolve_compression_profile
 from redcon.compressors.summarizers import normalize_summarizer_report
 from redcon.config import RedconConfig, WorkspaceDefinition, load_config
 from redcon.core.agent_planning import build_agent_workflow_plan
@@ -22,6 +24,7 @@ from redcon.core.pr_audit import analyze_pull_request, pr_audit_as_dict
 from redcon.core.render import read_json, render_pr_comment_markdown
 from redcon.core.run_feed import write_run_feed_artifact
 from redcon.core.tokens import normalize_token_estimator_report
+from redcon.entitlements import load_entitlement
 from redcon.plugins import ResolvedPlugins, resolve_plugins
 from redcon.schemas.models import DEFAULT_TOP_FILES, RunReport
 from redcon.scorers.import_graph import build_import_graph
@@ -38,6 +41,8 @@ from redcon.stages.workflow import (
     run_score_stage,
 )
 from redcon.telemetry import TelemetrySession, TelemetrySink, build_telemetry_sink
+
+logger = logging.getLogger(__name__)
 
 
 def _resolve_config(
@@ -373,6 +378,7 @@ def run_pack(
     workspace: WorkspaceDefinition | None = None,
     plugins: ResolvedPlugins | None = None,
     record_history: bool = True,
+    compression_profile: str | None = None,
 ) -> RunReport:
     """Run pack command pipeline and return typed run report."""
 
@@ -384,6 +390,18 @@ def run_pack(
     effective_max_tokens = prepared_cfg.budget.max_tokens
     effective_top_files = top_files if top_files is not None else prepared_cfg.budget.top_files
     target_repo = workspace.root if workspace is not None else repo
+    # Resolve the compression profile (CLI/SDK override wins over config).
+    # Entitlement is only consulted when a profile was actually requested, and
+    # prepared_cfg is a deep copy, so reassigning its compression is safe.
+    if compression_profile is not None:
+        prepared_cfg.compression.profile = compression_profile
+    applied_compression_profile = PROFILE_DEFAULT
+    if (prepared_cfg.compression.profile or "").strip():
+        prepared_cfg.compression, applied_compression_profile, profile_note = (
+            resolve_compression_profile(prepared_cfg.compression, load_entitlement(target_repo))
+        )
+        if profile_note:
+            logger.warning(profile_note)
     telemetry = _build_telemetry_session(
         repo=target_repo,
         config=prepared_cfg,
@@ -487,6 +505,7 @@ def run_pack(
         baseline_tokens=baseline_tokens,
         files_scanned=len(files),
     )
+    report.compression_profile = applied_compression_profile
     if record_history:
         # Mirror the full report into .redcon/runs/ so editor
         # integrations see this run no matter which entry point made it
@@ -521,6 +540,7 @@ def run_pack(
                     # reason about how broadly each prompt pulled files.
                     "context_baseline_tokens": int(report.context_baseline_tokens or 0),
                     "files_scanned": int(report.files_scanned or 0),
+                    "compression_profile": applied_compression_profile,
                 },
                 result_artifacts={
                     "run_json": str(feed_path) if feed_path else "",

--- a/redcon/engine.py
+++ b/redcon/engine.py
@@ -318,6 +318,7 @@ class RedconEngine:
         delta_from: RunArtifactInput | None = None,
         config_path: str | Path | None = None,
         timeout: int = 120,
+        compression_profile: str | None = None,
     ) -> dict[str, Any]:
         """Build compressed context under token and file budgets.
 
@@ -327,6 +328,10 @@ class RedconEngine:
             Maximum wall-clock seconds for the pack pipeline (default: 120).
             The value is stored in result metadata; actual enforcement depends
             on the underlying pipeline implementation.
+        compression_profile:
+            Optional named compression profile ("default" or "max"); overrides
+            the ``[compression] profile`` config key. "max" requires a Pro
+            license and otherwise falls back to the default profile.
         """
 
         logger.info("pack: start - task=%r repo=%r timeout=%d", task, repo, timeout)
@@ -353,6 +358,7 @@ class RedconEngine:
                     config=workspace_definition.config,
                     telemetry_sink=self._telemetry_sink,
                     workspace=workspace_definition,
+                    compression_profile=compression_profile,
                 )
                 result = as_json_dict(report)
             else:
@@ -365,6 +371,7 @@ class RedconEngine:
                     delta_from=delta_from,
                     config=cfg,
                     telemetry_sink=self._telemetry_sink,
+                    compression_profile=compression_profile,
                 )
                 result = as_json_dict(report)
 

--- a/redcon/entitlements.py
+++ b/redcon/entitlements.py
@@ -43,6 +43,7 @@ PRO_FEATURES: frozenset[str] = frozenset(
         "dashboard.savings",  # the savings / cross-agent history dashboard
         "history.unlimited",  # run history beyond the free retention window
         "insights.prompt",  # prompt-optimization suggestions
+        "compression.max",  # the max-compression profile (tighter tier thresholds)
     }
 )
 

--- a/redcon/schemas/models.py
+++ b/redcon/schemas/models.py
@@ -322,6 +322,10 @@ class RunReport:
     # picking the right files.
     context_baseline_tokens: int = 0
     files_scanned: int = 0
+    # Which compression profile shaped this run's tier thresholds: "default",
+    # or "max" when the Pro max-compression preset was active. A run that
+    # requested "max" without a license reports "default" - what actually ran.
+    compression_profile: str = "default"
     # Dollar translation of the selection saving, for the "if you pay per token"
     # framing (redcon.telemetry.pricing.compute_run_costs). Empty when there is
     # no baseline to compare against. On a flat plan the value delivered is

--- a/tests/test_compression_profiles.py
+++ b/tests/test_compression_profiles.py
@@ -1,0 +1,149 @@
+"""The max compression profile: preset overrides, Pro gating, pipeline wiring.
+
+The 'max' profile must tighten the tier thresholds only for an entitled (Pro)
+run, fall back to the default profile with a warning otherwise, and always
+report which profile actually ran. Free behaviour never changes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from redcon.compressors.profiles import (
+    FEATURE_MAX_COMPRESSION,
+    MAX_PROFILE_OVERRIDES,
+    PROFILE_DEFAULT,
+    PROFILE_MAX,
+    resolve_compression_profile,
+)
+from redcon.config import CompressionSettings, load_config_from_mapping
+from redcon.core import pipeline
+from redcon.entitlements import PRO_FEATURES, TIER_PRO, Entitlement
+
+
+def _pro() -> Entitlement:
+    return Entitlement(tier=TIER_PRO, status="active", features=PRO_FEATURES)
+
+
+def _free() -> Entitlement:
+    return Entitlement()
+
+
+# ---------------------------------------------------------------------------
+# Resolver
+# ---------------------------------------------------------------------------
+
+
+def test_max_compression_is_pro_gated() -> None:
+    assert FEATURE_MAX_COMPRESSION in PRO_FEATURES
+    assert _free().has(FEATURE_MAX_COMPRESSION) is False
+    assert _pro().has(FEATURE_MAX_COMPRESSION) is True
+
+
+def test_default_profile_passes_settings_through() -> None:
+    settings = CompressionSettings()
+    out, applied, note = resolve_compression_profile(settings, _free())
+    assert out is settings
+    assert applied == PROFILE_DEFAULT
+    assert note == ""
+
+
+def test_max_with_pro_applies_every_override() -> None:
+    out, applied, note = resolve_compression_profile(CompressionSettings(profile="max"), _pro())
+    assert applied == PROFILE_MAX
+    assert note == ""
+    for key, value in MAX_PROFILE_OVERRIDES.items():
+        assert getattr(out, key) == value
+    # The preset is strictly tighter than the defaults it replaces.
+    defaults = CompressionSettings()
+    assert out.full_file_threshold_tokens < defaults.full_file_threshold_tokens
+    assert out.snippet_total_line_limit < defaults.snippet_total_line_limit
+    assert out.summary_preview_lines < defaults.summary_preview_lines
+
+
+def test_max_without_pro_falls_back_and_warns() -> None:
+    requested = CompressionSettings(profile="max")
+    out, applied, note = resolve_compression_profile(requested, _free())
+    assert applied == PROFILE_DEFAULT
+    assert "Pro" in note
+    # Settings are the untightened defaults, and the input was not mutated.
+    defaults = CompressionSettings()
+    assert out.full_file_threshold_tokens == defaults.full_file_threshold_tokens
+    assert requested.profile == "max"
+
+
+def test_unknown_profile_falls_back_and_warns() -> None:
+    out, applied, note = resolve_compression_profile(CompressionSettings(profile="turbo"), _pro())
+    assert applied == PROFILE_DEFAULT
+    assert "unknown" in note
+    assert out.full_file_threshold_tokens == CompressionSettings().full_file_threshold_tokens
+
+
+def test_config_parses_profile_key() -> None:
+    cfg = load_config_from_mapping({"compression": {"profile": "MAX"}})
+    assert cfg.compression.profile == "max"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline wiring
+# ---------------------------------------------------------------------------
+
+
+def _seed_repo(repo: Path) -> None:
+    for i in range(6):
+        body = "\n".join(
+            f'def handler_{i}_{j}(request):\n    """Handle case {j}."""\n    return request + {j}\n'
+            for j in range(30)
+        )
+        (repo / f"service_{i}.py").write_text(
+            f'"""Service module {i}."""\n\n{body}', encoding="utf-8"
+        )
+
+
+def test_run_pack_max_profile_packs_tighter_and_reports_it(tmp_path: Path, monkeypatch) -> None:
+    _seed_repo(tmp_path)
+    monkeypatch.setattr(pipeline, "load_entitlement", lambda repo=None: _pro())
+
+    default_report = pipeline.run_pack(
+        "adjust the request handlers", tmp_path, max_tokens=8000, record_history=False
+    )
+    max_report = pipeline.run_pack(
+        "adjust the request handlers",
+        tmp_path,
+        max_tokens=8000,
+        record_history=False,
+        compression_profile="max",
+    )
+
+    assert default_report.compression_profile == "default"
+    assert max_report.compression_profile == "max"
+    default_tokens = int(default_report.budget.get("estimated_input_tokens", 0) or 0)
+    max_tokens_used = int(max_report.budget.get("estimated_input_tokens", 0) or 0)
+    assert 0 < max_tokens_used <= default_tokens
+
+
+def test_run_pack_max_without_license_runs_default(tmp_path: Path, monkeypatch) -> None:
+    _seed_repo(tmp_path)
+    monkeypatch.setattr(pipeline, "load_entitlement", lambda repo=None: _free())
+
+    report = pipeline.run_pack(
+        "adjust the request handlers",
+        tmp_path,
+        max_tokens=8000,
+        record_history=False,
+        compression_profile="max",
+    )
+
+    assert report.compression_profile == "default"
+
+
+def test_run_pack_profile_from_config_toml(tmp_path: Path, monkeypatch) -> None:
+    _seed_repo(tmp_path)
+    (tmp_path / "redcon.toml").write_text('[compression]\nprofile = "max"\n', encoding="utf-8")
+    monkeypatch.setattr(pipeline, "load_entitlement", lambda repo=None: _pro())
+
+    report = pipeline.run_pack(
+        "adjust the request handlers", tmp_path, max_tokens=8000, record_history=False
+    )
+
+    assert report.compression_profile == "max"


### PR DESCRIPTION
## Summary

First Pro feature that directly buys more runway: a `max` compression profile that packs measurably tighter than the default. Measured on this repository: **22% fewer input tokens** at the same budget, top-files count, and reported quality risk.

## Problem

The engine's tier thresholds are tuned for a safe default, and everything the engine does is free. Heavy agent users who keep hitting plan limits want the opposite trade: pack as tight as possible. There was no way to opt into that, and no Pro feature that increases savings rather than reporting them.

## Approach

- **New preset, no new machinery:** `redcon/compressors/profiles.py` defines the `max` preset as overrides of seven existing tier thresholds (full-file cutoff 300 to 100, snippet limits 6/120/60 to 4/80/40, summary preview 8 to 4, adaptive factor 3.0 to 2.0, degradation rounds 1 to 2). The pipeline already knows how to honor every one of these; the profile just tightens them.
- **Requesting it:** `[compression] profile = "max"` in `redcon.toml` (works for every entry point: CLI, SDK, MCP, gateway) or `--compression-profile max` on `redcon pack` (threads through `RedconEngine.pack` to `run_pack`).
- **Pro gating that never hurts free:** `compression.max` joins `PRO_FEATURES`, so any valid Pro license grants it automatically. Without a license the run logs one warning ("max is a Pro feature - using the default profile") and proceeds with the default; nothing errors, and free behaviour is unchanged (the entitlement is only consulted when a profile is actually requested).
- **Honest reporting:** `run.json` gains `compression_profile` recording what actually ran ("default" or "max"), it is mirrored into run history for the dashboard/insights, and the pack summary prints `Profile: max compression (Pro)` when active.

Measured through the real mechanism on this repo (same task, budget 64k, top-files 40): default 18,467 tokens vs max 14,323 tokens, quality risk `medium` in both.

## Test Coverage

- [x] New `tests/test_compression_profiles.py` (9 tests): the preset applies every override and is strictly tighter; gating (free entitlement falls back with a Pro note, unknown profile falls back, input settings never mutated); config parsing; pipeline wiring (max packs tighter and reports `"max"`, unlicensed max reports `"default"`, config-file profile honored).
- [x] Verified the CLI end to end: `--compression-profile max` without a license prints the warning, completes normally, and `run.json` records `compression_profile: "default"`.
- [x] All existing tests pass: full suite green (1114 passed, 12 skipped).

## Checklist

- [x] Code follows the project guidelines in CONTRIBUTING.md
- [x] No new runtime dependencies added
- [x] Deterministic behavior preserved in core scoring/compression