### PR TITLE
Release 1.11.0: measurement methodology, PyPI keywords, changelog cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-07-23
+
 ### Added
+
+- Compression profiles: `redcon pack --compression-profile max` (Pro) applies
+  tighter tier thresholds end to end and reports `Profile: max compression
+  (Pro)` in the output; without a license the run falls back to the default
+  profile with a warning. Configurable via `profile` in `redcon.toml`.
+- `redcon license` command: `--activate KEY` stores the license, plain
+  invocation shows plan, status and expiry, `--deactivate` removes it.
+- `docs/methodology.md`: reproducible measurement procedure behind the
+  published savings numbers.
 
 - Five new cmd-side compressors: `kubectl_events` (specialised inside
   KubectlGetCompressor for event-shape headers, 91.5% reduction),
@@ -59,6 +70,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- FastAPI gateway resolves the Authorization header reliably under
+  `from __future__ import annotations` and returns a consistent JSON error
+  contract (400 with `{"error": ...}` for malformed bodies).
+- Concurrent summary-cache writers merge per key under a file lock instead of
+  last-writer-wins.
+- `last_run_artifact` survives session serialization in the gateway store.
 - ANSI sequences and CR-overwrite progress bars no longer bleed into
   compressed output (V38).
 - `git_status`, `json_log`, `bundle_stats` fall through to raw

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ AI coding agents burn tokens on irrelevant context. You either:
 - Dump the whole repo and pay for 200k input tokens per request, or
 - Let the agent grep blindly and waste tool calls figuring out where to look
 
-Redcon solves both. It ranks files by task relevance, compresses them with language-aware strategies (full, snippet, symbol extraction, summary), and packs the result under your token budget. Deterministic, local-first, no embeddings.
+Redcon solves both. It ranks files by task relevance, compresses them with language-aware strategies (full, snippet, symbol extraction, summary), and packs the result under your token budget. Deterministic, local-first, no embeddings. One MCP server covers Claude Code, Cursor, Windsurf, Cline and Zed; a plain CLI covers CI. Measured on this repository it cuts input tokens by more than 83% at the same task coverage ([methodology](docs/methodology.md)).
 
 ## Punch above your plan
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ Redcon is local-first infrastructure for deterministic context selection, compre
 
 - [Policy and CI](policy-and-ci.md)
 - [Benchmark and Diff](benchmark-and-diff.md)
+- [Measurement Methodology](methodology.md)
 - [Telemetry](telemetry.md)
 - [Analytics Events](events.md)
 - [Migration Notes](migration.md)

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -1,0 +1,78 @@
+# How the Numbers Are Measured
+
+Every savings number redcon publishes is reproducible on this repository with
+the open source CLI. This page shows the exact procedure, the latest measured
+run, and what the numbers do and do not claim.
+
+## Reproduce it in 60 seconds
+
+```bash
+pip install redcon
+git clone https://github.com/natiixnt/redcon && cd redcon
+redcon pack "add rate limiting to the gateway auth endpoints"
+```
+
+Every pack prints its own receipt, no telemetry involved:
+
+```
+Budget: input=56117 tokens, saved=963944 tokens, risk=high
+Packed 395 files (129 skipped) in 2.1s
+```
+
+`run.json` next to it lists every included file with its compression tier, so
+the pack is fully auditable: you can diff exactly what the model would see.
+
+## Latest measured run
+
+Default profile, zero configuration, fresh clone of this repository,
+five representative development tasks:
+
+| Task | Packed input | Saved | Scanned | Reduction |
+| --- | ---: | ---: | ---: | ---: |
+| add rate limiting to the gateway auth endpoints | 56,117 | 963,944 | 1,020,061 | 94.5% |
+| fix the flaky uvicorn startup in the gateway tests | 51,936 | 763,607 | 815,543 | 93.6% |
+| add a new compressor for yaml kubernetes manifests | 59,156 | 973,084 | 1,032,240 | 94.3% |
+| speed up the incremental scanner on large monorepos | 46,188 | 752,378 | 798,566 | 94.2% |
+| document the license activation flow for pro users | 59,430 | 1,107,719 | 1,167,149 | 94.9% |
+
+The website and README quote **83%**: the pack rate from an earlier, smaller
+state of this repository (512k tokens scanned, 88k packed). Repositories
+differ, so we keep quoting the lower number and let you measure your own.
+
+## What the terms mean
+
+- **Scanned**: tokens across all files redcon considered for the task
+  (packed input plus saved).
+- **Packed input**: tokens actually shipped to the model after selection and
+  compression.
+- **Saved**: scanned minus packed input.
+- **Task coverage**: selection ranks every file against the task and includes
+  the ones the change touches. Nothing is deleted: the repository stays on
+  disk, the agent keeps full tool access, and anything the pack skipped can be
+  read on demand. redcon changes what is sent per request, not what exists.
+- **Determinism**: no LLM in the loop. The same tree and task produce the
+  same pack, which is why the numbers are reproducible at all.
+- Token counts use the built-in heuristic estimator by default (the output
+  labels it); install `redcon[tokenizers]` for tiktoken-exact counts.
+
+## The max profile (Pro)
+
+The Pro `--compression-profile max` tightens tier thresholds on top of the
+default pipeline. Same task, same tree, same day as the table above:
+
+| Profile | Packed input |
+| --- | ---: |
+| default | 54,145 |
+| max | 29,744 |
+
+## Honest limitations
+
+- Numbers above are from redcon's own repository (Python, ~1.2k files,
+  including deliberately compressible benchmark fixtures). Typical real
+  repositories measure lower; small repositories (under ~50k tokens) have
+  little waste to cut.
+- redcon optimizes repository context. Tokens spent on conversation history
+  and tool output are not touched.
+- Reduction percentages depend on repository shape more than on anything
+  else. Run one pack on your own repository; that number is the only one
+  that matters for you.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,20 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redcon"
-version = "1.10.0"
+version = "1.11.0"
 description = "Deterministic context budgeting for coding-agent workflows"
 readme = "README.md"
+keywords = [
+    "ai-agents",
+    "claude-code",
+    "context-compression",
+    "context-engineering",
+    "cursor",
+    "developer-tools",
+    "llm",
+    "mcp",
+    "token-optimization",
+]
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 authors = [{ name = "Natalia Szczepanik" }]


### PR DESCRIPTION
## What

Prepares the 1.11.0 release and the public measurement story:

- `docs/methodology.md`: the reproducible procedure behind the published savings numbers, with a fresh five-task measurement table (93.6% to 94.9% reduction on this repository, default profile, zero config), definitions of scanned/packed/saved and task coverage, the max profile comparison, and honest limitations. Linked from the README and the docs index.
- README: the solution paragraph now names the supported agents and links the methodology page.
- `pyproject.toml`: version bump to 1.11.0 plus PyPI keywords so the package surfaces for the searches people actually run (mcp, claude-code, context-compression, token-optimization).
- CHANGELOG: cut the [1.11.0] - 2026-07-23 section; adds entries for the compression profiles, the `redcon license` command and the gateway/cache/session fixes that were merged without changelog coverage.

## Why

1.11.0 is the first version where the Pro max-compression profile and the license activation command ship to PyPI, so it has to go out before any license is sold. The methodology page is the receipts behind the launch claim.

## Verification

- Full license flow tested end to end on a fresh venv: signed test key activates (`redcon license --activate`), Pro profile reports `Profile: max compression (Pro)`, tampered signature rejected, no license falls back to default with a warning.
- Measurement table produced by running the documented commands on a fresh clone.
- `tomllib` parses the updated pyproject; docs-only changes otherwise.

## Release checklist (after merge)

- Embed the production license public key (currently empty, blocks Pro sales).
- Tag `v1.11.0` to trigger the release workflow.