### PR TITLE
1.11.1: version from package metadata, license public key slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.1] - 2026-07-23
+
+### Fixed
+
+- `redcon --version` (and `redcon.__version__`) now reads the installed
+  package metadata instead of a hardcoded string, which had lagged behind
+  the released version.
+
 ## [1.11.0] - 2026-07-23
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redcon"
-version = "1.11.0"
+version = "1.11.1"
 description = "Deterministic context budgeting for coding-agent workflows"
 readme = "README.md"
 keywords = [

--- a/redcon/__init__.py
+++ b/redcon/__init__.py
@@ -15,7 +15,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-__version__ = "1.10.0"
+# Single-sourced from package metadata so the CLI can never lag behind the
+# released version again (1.11.0 shipped reporting 1.10.0).
+try:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _pkg_version
+
+    __version__ = _pkg_version("redcon")
+except PackageNotFoundError:  # source tree without an installed distribution
+    __version__ = "0.0.0+source"
 
 # Mapping from public symbol name to the submodule it lives in. The first
 # attribute access triggers an import of that module and caches the symbol


### PR DESCRIPTION
## What

- `redcon --version` and `redcon.__version__` now read the installed package metadata via `importlib.metadata` instead of a hardcoded string. The 1.11.0 wheel shipped reporting 1.10.0 because the two version locations drifted; single-sourcing makes that impossible.
- Version bump to 1.11.1 and the matching changelog section.
- Pending on this branch before merge: embedding the production license public key in `redcon/entitlements.py` (one line, waiting for the key). 1.11.1 is the release that makes Pro licenses activatable, so it must not ship without it.

## Verification

- Fresh editable install: `redcon --version` prints 1.11.1, `redcon.__version__` matches.
- Source tree without installed distribution falls back to `0.0.0+source` instead of raising.
- `ruff check` and `ruff format --check` clean on the touched file.

## Release checklist (after merge)

- Tag `v1.11.1` to trigger the release workflow.
- Verify the published wheel: `redcon --version`, `redcon license --activate` with a real key.