### PR TITLE
Fingerprint packs with prompt_cache_key for prompt-cache keying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `prompt_cache_key` in run reports and pack output: a stable 16-hex
+  fingerprint of the packed (path, text) sequence. An unchanged tree and task
+  reproduce the same key and edits outside the pack keep it warm, so callers
+  can key provider prompt caches on it and detect real prefix changes.
+
 ## [1.11.0] - 2026-07-23
 
 ### Added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -67,6 +67,12 @@ persistently with `[compression] profile = "max"` in `redcon.toml`. Without a
 Pro license the run warns once and falls back to the default profile; `run.json`
 always records which profile actually ran (`compression_profile`).
 
+Every pack prints a `Cache key`: a stable 16-hex fingerprint of the packed
+content, reproduced exactly when the tree and task are unchanged. Edits that
+do not alter what gets packed keep the key (and any provider prompt cache
+keyed on it) warm; any real change to the packed content rotates it. The same
+value lands in `run.json` as `prompt_cache_key`.
+
 ### `redcon pack <task> --repo <path> --delta <previous-run.json>`
 Build the normal current pack artifact plus a `delta` block that contains only the
 changes relative to the previous run. The delta package records:

--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -803,6 +803,8 @@ def cmd_pack(args: argparse.Namespace) -> int:
         f"saved={budget['estimated_saved_tokens']} tokens, "
         f"risk={budget['quality_risk_estimate']}",
     )
+    if data.get("prompt_cache_key"):
+        _qprint(args, f"Cache key: {data['prompt_cache_key']}")
     # Selection savings: the honest "value delivered" line. saved= above only
     # counts in-file compression, which is often 0. Redcon's real win is picking
     # a subset of files, so show what was sent vs dumping the whole scanned repo.

--- a/redcon/schemas/models.py
+++ b/redcon/schemas/models.py
@@ -326,6 +326,12 @@ class RunReport:
     # or "max" when the Pro max-compression preset was active. A run that
     # requested "max" without a license reports "default" - what actually ran.
     compression_profile: str = "default"
+    # Stable fingerprint of the packed content: sha256 over the ordered
+    # (path, text) pairs of compressed_context, first 16 hex chars. Because
+    # packing is deterministic, an unchanged tree and task reproduce the same
+    # key, so callers can use it to key provider prompt caches and to detect
+    # when the pack prefix actually changed between runs.
+    prompt_cache_key: str = ""
     # Dollar translation of the selection saving, for the "if you pay per token"
     # framing (redcon.telemetry.pricing.compute_run_costs). Empty when there is
     # no baseline to compare against. On a flat plan the value delivered is

--- a/redcon/stages/workflow.py
+++ b/redcon/stages/workflow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import subprocess
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -66,6 +67,22 @@ def _serialize_ranked_file(item: RankedFile) -> dict:
         data["repo"] = item.file.repo_label
         data["relative_path"] = item.file.relative_path
     return data
+
+
+def _prompt_cache_key(entries: list[dict]) -> str:
+    """Fingerprint the ordered pack content for prompt-cache keying.
+
+    Hashes the (path, text) sequence exactly as it lands in
+    ``compressed_context``, so byte-identical packs share a key and any
+    content or ordering change produces a new one.
+    """
+    digest = hashlib.sha256()
+    for entry in entries:
+        digest.update(str(entry.get("path", "")).encode("utf-8"))
+        digest.update(b"\x00")
+        digest.update(str(entry.get("text", "")).encode("utf-8"))
+        digest.update(b"\x01")
+    return digest.hexdigest()[:16]
 
 
 def _serialize_compressed_file(item: CompressedFile) -> dict:
@@ -324,15 +341,15 @@ def run_render_stage(
             "file_count_limit": scan_summary.file_count_limit,
             "files_seen": scan_summary.files_seen,
         }
+    serialized_context = [_serialize_compressed_file(item) for item in compressed.compressed_files]
     return RunReport(
         command="pack",
         task=task,
         repo=str(repo),
         max_tokens=max_tokens,
         ranked_files=[_serialize_ranked_file(item) for item in ranked[:effective_top_files]],
-        compressed_context=[
-            _serialize_compressed_file(item) for item in compressed.compressed_files
-        ],
+        compressed_context=serialized_context,
+        prompt_cache_key=_prompt_cache_key(serialized_context),
         files_included=compressed.files_included,
         files_skipped=compressed.files_skipped,
         budget={

--- a/tests/test_prompt_cache_key.py
+++ b/tests/test_prompt_cache_key.py
@@ -1,0 +1,85 @@
+"""prompt_cache_key: stable fingerprint of the packed content.
+
+Deterministic packing means an unchanged tree and task must reproduce the
+same key, and any content change must produce a new one - that is what lets
+callers key provider prompt caches on it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from redcon.core import pipeline
+from redcon.stages.workflow import as_json_dict
+
+
+def _seed_repo(repo: Path) -> None:
+    for i in range(4):
+        body = "\n".join(
+            f'def handler_{i}_{j}(request):\n    """Handle case {j}."""\n    return request + {j}\n'
+            for j in range(20)
+        )
+        (repo / f"service_{i}.py").write_text(
+            f'"""Service module {i}."""\n\n{body}', encoding="utf-8"
+        )
+
+
+def _pack(repo: Path):
+    return pipeline.run_pack(
+        "adjust the request handlers", repo, max_tokens=8000, record_history=False
+    )
+
+
+def test_same_tree_and_task_reproduce_the_key(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    first = _pack(tmp_path)
+    second = _pack(tmp_path)
+    assert first.prompt_cache_key
+    assert first.prompt_cache_key == second.prompt_cache_key
+
+
+def test_key_is_short_hex(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    report = _pack(tmp_path)
+    assert re.fullmatch(r"[0-9a-f]{16}", report.prompt_cache_key)
+
+
+def test_packed_content_change_rotates_the_key(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    before = _pack(tmp_path)
+    target = tmp_path / "service_0.py"
+    target.write_text(
+        target.read_text(encoding="utf-8").replace("def handler_0_0(", "def handler_0_0_renamed("),
+        encoding="utf-8",
+    )
+    after = _pack(tmp_path)
+    assert before.prompt_cache_key != after.prompt_cache_key
+
+
+def test_change_outside_the_pack_keeps_the_key_warm(tmp_path: Path) -> None:
+    """The key fingerprints the pack, not the tree.
+
+    An edit that does not alter what gets packed must not rotate the key,
+    because that is exactly what keeps provider prompt caches hot across
+    irrelevant edits.
+    """
+    _seed_repo(tmp_path)
+    before = _pack(tmp_path)
+    (tmp_path / "NOTES.txt").write_text("scratchpad note\n", encoding="utf-8")
+    after = _pack(tmp_path)
+
+    def pairs(report):
+        return [(e.get("path"), e.get("text")) for e in report.compressed_context]
+
+    if pairs(after) == pairs(before):
+        assert after.prompt_cache_key == before.prompt_cache_key
+    else:
+        assert after.prompt_cache_key != before.prompt_cache_key
+
+
+def test_key_lands_in_run_json_payload(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    report = _pack(tmp_path)
+    payload = as_json_dict(report)
+    assert payload["prompt_cache_key"] == report.prompt_cache_key


### PR DESCRIPTION
## What

Every pack run now computes a stable 16-hex sha256 fingerprint over the ordered (path, text) pairs of `compressed_context`:

- `prompt_cache_key` field on `RunReport`, lands in `run.json` automatically.
- `redcon pack` prints a `Cache key:` line after the budget line.
- Documented in `docs/cli.md` and the changelog.

## Why

Provider prompt caches bill cached input at roughly a tenth of the regular price, and byte-stable prefixes are what earns those hits. Deterministic packing already guarantees that an unchanged tree and task reproduce a byte-identical pack; this makes that guarantee visible and usable: callers can key provider caches on it and detect when the pack prefix actually changed.

The nicest property fell out of the design and is now covered by a test: the key fingerprints the pack, not the tree. Edits that do not change what gets packed (a stray note file, a function that does not enter the pack) keep the key warm, so caches survive irrelevant edits.

## Verification

- New `tests/test_prompt_cache_key.py`: same tree and task reproduce the key; renaming a packed symbol rotates it; a change outside the pack keeps it warm (asserted on the (path, text) contract); the field lands in the `run.json` payload; format is 16 hex chars.
- Full adjacent suites green locally: 14 passed (`test_prompt_cache_key`, `test_compression_profiles`).
- `ruff check` and `ruff format --check` clean on all touched files.
