### PR TITLE
1.11.1: version from package metadata, license key embedded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fingerprint of the packed (path, text) sequence. An unchanged tree and task
   reproduce the same key and edits outside the pack keep it warm, so callers
   can key provider prompt caches on it and detect real prefix changes.
+- Production license verification key embedded; Pro licenses purchased
+  for 1.11.1 and later activate offline with `redcon license --activate`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.1] - 2026-07-27
+
 ### Added
 
 - `prompt_cache_key` in run reports and pack output: a stable 16-hex
   fingerprint of the packed (path, text) sequence. An unchanged tree and task
   reproduce the same key and edits outside the pack keep it warm, so callers
   can key provider prompt caches on it and detect real prefix changes.
+
+### Fixed
+
+- `redcon --version` (and `redcon.__version__`) now reads the installed
+  package metadata instead of a hardcoded string, which had lagged behind
+  the released version.
 
 ## [1.11.0] - 2026-07-23
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redcon"
-version = "1.11.0"
+version = "1.11.1"
 description = "Deterministic context budgeting for coding-agent workflows"
 readme = "README.md"
 keywords = [

--- a/redcon/__init__.py
+++ b/redcon/__init__.py
@@ -15,7 +15,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-__version__ = "1.10.0"
+# Single-sourced from package metadata so the CLI can never lag behind the
+# released version again (1.11.0 shipped reporting 1.10.0).
+try:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _pkg_version
+
+    __version__ = _pkg_version("redcon")
+except PackageNotFoundError:  # source tree without an installed distribution
+    __version__ = "0.0.0+source"
 
 # Mapping from public symbol name to the submodule it lives in. The first
 # attribute access triggers an import of that module and caches the symbol

--- a/redcon/entitlements.py
+++ b/redcon/entitlements.py
@@ -52,7 +52,7 @@ PRO_FEATURES: frozenset[str] = frozenset(
 # licenses on purchase. Empty means "no key configured yet": every license is
 # treated as unverified and the user stays free. Override for tests or a
 # self-hosted signer via REDCON_LICENSE_PUBKEY.
-_EMBEDDED_PUBLIC_KEY_B64 = ""
+_EMBEDDED_PUBLIC_KEY_B64 = "0FbwyahBFjKLGCktY3KK60sVOiaEWBZPDYpW4O1F4B0"
 
 _ENV_LICENSE = "REDCON_LICENSE_KEY"
 _ENV_PUBKEY = "REDCON_LICENSE_PUBKEY"


### PR DESCRIPTION
## What

- `redcon --version` and `redcon.__version__` now read the installed package metadata via `importlib.metadata` instead of a hardcoded string. The 1.11.0 wheel shipped reporting 1.10.0 because the two version locations drifted; single-sourcing makes that impossible.
- Production Ed25519 license verification key embedded in `redcon/entitlements.py`; Pro licenses purchased for 1.11.1 and later activate offline with `redcon license --activate`.
- Version bump to 1.11.1; the changelog section also folds in the `prompt_cache_key` entry already on main.

## Verification

- Fresh editable install: `redcon --version` prints 1.11.1, `redcon.__version__` matches.
- Source tree without installed distribution falls back to `0.0.0+source` instead of raising.
- `tests/test_entitlements.py` and `tests/test_prompt_cache_key.py`: 22 passed on the rebuilt branch.
- `ruff check` and `ruff format --check` clean on the touched files.

## Release checklist (after merge)

- Tag `v1.11.1` to trigger the release workflow.
- Verify the published wheel: `redcon --version`, then `redcon license --activate` with a freshly signed key.
