### PR TITLE
Add cursor, mcp, claude-code, token-saver to VS Code extension keywords

### DIFF
--- a/vscode-redcon/package.json
+++ b/vscode-redcon/package.json
@@ -34,7 +34,11 @@
     "agent",
     "compression",
     "context-window",
-    "token-budget"
+    "token-budget",
+    "cursor",
+    "mcp",
+    "claude-code",
+    "token-saver"
   ],
   "activationEvents": [
     "workspaceContains:redcon.toml"


### PR DESCRIPTION
## What

Add `cursor`, `mcp`, `claude-code`, and `token-saver` to the VS Code extension `keywords` so the Marketplace listing surfaces for the agents and protocol redcon actually supports.

## Notes

- Marketplace metadata only; no code change. The publish happens with the next `vsce publish` of the extension.
- `keywords` array stays valid JSON (13 entries).
