### PR TITLE
Rotate the embedded license verification key (1.11.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.2] - 2026-07-28
+
+### Changed
+
+- Rotated the embedded Ed25519 license verification key. Pro licenses are
+  issued under the new key; licenses signed against the previous key no longer
+  verify and must be re-issued.
+
 ## [1.11.1] - 2026-07-27
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redcon"
-version = "1.11.1"
+version = "1.11.2"
 description = "Deterministic context budgeting for coding-agent workflows"
 readme = "README.md"
 keywords = [

--- a/redcon/entitlements.py
+++ b/redcon/entitlements.py
@@ -52,7 +52,7 @@ PRO_FEATURES: frozenset[str] = frozenset(
 # licenses on purchase. Empty means "no key configured yet": every license is
 # treated as unverified and the user stays free. Override for tests or a
 # self-hosted signer via REDCON_LICENSE_PUBKEY.
-_EMBEDDED_PUBLIC_KEY_B64 = "0FbwyahBFjKLGCktY3KK60sVOiaEWBZPDYpW4O1F4B0"
+_EMBEDDED_PUBLIC_KEY_B64 = "NlLwPkG5vVnUEkGRzbMAPyCn7kI4WTVuhi6Mz51EctA"
 
 _ENV_LICENSE = "REDCON_LICENSE_KEY"
 _ENV_PUBKEY = "REDCON_LICENSE_PUBKEY"


### PR DESCRIPTION
## What

Rotate the embedded Ed25519 license verification key and bump to 1.11.2.

- `_EMBEDDED_PUBLIC_KEY_B64` replaced with the new production public key.
- The previous key is retired; Pro licenses are re-issued under the new key, and licenses signed against the old key no longer verify.
- Verification stays fully offline; the private signer key lives only in redcon-cloud.

## Why

The prior signer private key was exposed and is treated as compromised. Rotating the embedded public key ensures licenses are validated against a key whose private half is uncompromised. No user data involved; this is a signing-key rotation.

## Verification

- `tests/test_entitlements.py` overrides the embedded key via monkeypatch, so it is agnostic to the value - suite stays green.
- After release, activation smoke test to be re-run against the 1.11.2 wheel with a license signed by the new key.
