### PR TITLE
Add Dockerfile.mcp for the MCP server; fix stale repo label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM python:3.12-slim
 
 LABEL org.opencontainers.image.title="Redcon CLI"
 LABEL org.opencontainers.image.description="Deterministic context budgeting for coding-agent workflows"
-LABEL org.opencontainers.image.source="https://github.com/natiixnt/ContextBudget"
+LABEL org.opencontainers.image.source="https://github.com/natiixnt/redcon"
 
 # Install git for drift/pr-audit commands
 RUN apt-get update \

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -1,0 +1,33 @@
+# Redcon MCP server - Docker image
+# Runs `redcon mcp serve` over stdio for MCP clients and directory
+# introspection checks. Built from source, so the image always matches this
+# checkout (no version pin to bump on release).
+#
+# Build:   docker build -f Dockerfile.mcp -t redcon-mcp .
+# Run:     docker run --rm -i redcon-mcp
+FROM python:3.12-slim AS builder
+
+WORKDIR /app
+COPY pyproject.toml ./
+COPY redcon/ redcon/
+RUN pip install --no-cache-dir ".[mcp]"
+
+FROM python:3.12-slim
+
+LABEL org.opencontainers.image.title="Redcon MCP Server"
+LABEL org.opencontainers.image.description="Deterministic context budgeting for coding-agent workflows (MCP server)"
+LABEL org.opencontainers.image.source="https://github.com/natiixnt/redcon"
+
+# git for the scan/drift/pr-audit paths some tools exercise
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=builder /usr/local/bin/redcon* /usr/local/bin/
+
+RUN useradd --create-home --shell /bin/bash redcon
+USER redcon
+WORKDIR /repo
+
+ENTRYPOINT ["redcon", "mcp", "serve"]

--- a/examples/sdk/typescript/anthropic_agent.ts
+++ b/examples/sdk/typescript/anthropic_agent.ts
@@ -14,7 +14,7 @@
  * subsequent turns only resend files that changed.
  *
  * Prerequisites:
- *   pip install git+https://github.com/natiixnt/ContextBudget     (Python side)
+ *   pip install redcon     (Python side)
  *   npm install                   (from this directory)
  *   export ANTHROPIC_API_KEY=sk-ant-...
  *

--- a/examples/sdk/typescript/basic.ts
+++ b/examples/sdk/typescript/basic.ts
@@ -8,7 +8,7 @@
  *   profileRun      - pack and return compression profiling metrics
  *
  * Prerequisites:
- *   pip install git+https://github.com/natiixnt/ContextBudget   (or: pip install -e . from repo root)
+ *   pip install redcon   (or: pip install -e . from repo root)
  *   npm install                 (from this directory)
  *
  * Run:

--- a/examples/sdk/typescript/middleware_pattern.ts
+++ b/examples/sdk/typescript/middleware_pattern.ts
@@ -12,7 +12,7 @@
  * system or to Redcon internals.
  *
  * Prerequisites:
- *   pip install git+https://github.com/natiixnt/ContextBudget     (Python side)
+ *   pip install redcon     (Python side)
  *   npm install                   (from this directory)
  *
  * Run:

--- a/examples/sdk/typescript/redcon-sdk.ts
+++ b/examples/sdk/typescript/redcon-sdk.ts
@@ -25,7 +25,7 @@
  *
  * Prerequisites
  * ─────────────
- *   pip install git+https://github.com/natiixnt/ContextBudget   (or `pip install -e .` from repo root)
+ *   pip install redcon   (or `pip install -e .` from repo root)
  */
 
 import { spawnSync } from "child_process";


### PR DESCRIPTION
## What

- Add `Dockerfile.mcp`: builds `redcon[mcp]` from source (same multi-stage builder as the CLI `Dockerfile`) and runs `redcon mcp serve` over stdio, for MCP clients and directory introspection (e.g. Glama). No version pin, so it always matches the checkout - nothing to bump per release.
- Fix the CLI `Dockerfile` image-source label: `natiixnt/ContextBudget` -> `natiixnt/redcon` (stale from the repo rename).

## Notes

- Source-built on purpose (not a pinned wheel) so it can't drift and adds no step to the Releasing checklist.
- Verified locally that the `pyproject.toml` + `redcon/` build context installs cleanly.
