### PR TITLE
Release 1.11.3: MCP Registry marker + server.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.3] - 2026-07-30
+
+### Added
+
+- MCP Registry ownership marker (`mcp-name`) in the README, and a root
+  `server.json`, so redcon can be published to the official MCP Registry.
+
+
 ## [1.11.2] - 2026-07-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Methodology, limitations, and how to add your own tool:
 
 ## MCP Integration (Pull Model)
 
+mcp-name: io.github.natiixnt/redcon
+
 Instead of pushing a 30k-token blob to your agent, Redcon exposes 9 MCP tools the agent calls on demand:
 
 | Tool | What it does |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redcon"
-version = "1.11.2"
+version = "1.11.3"
 description = "Deterministic context budgeting for coding-agent workflows"
 readme = "README.md"
 keywords = [

--- a/server.json
+++ b/server.json
@@ -1,18 +1,26 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.natiixnt/redcon",
-  "description": "Deterministic repository context packing for AI coding agents. Measured 83% fewer input tokens at the same task coverage. Local, no LLM in the loop.",
+  "title": "redcon",
+  "description": "Deterministic context packing for AI coding agents; measured 83% fewer input tokens, local.",
   "repository": { "url": "https://github.com/natiixnt/redcon", "source": "github" },
-  "version": "1.11.2",
+  "version": "1.11.3",
   "packages": [
-    { "registry_type": "pypi", "identifier": "redcon", "version": "1.11.2",
-      "transport": { "type": "stdio" }, "runtime_hint": "uvx",
-      "runtime_arguments": [
-        { "type": "named", "name": "--from", "value": "redcon[mcp]==1.11.2" }
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "redcon",
+      "version": "1.11.3",
+      "runtimeHint": "uvx",
+      "transport": { "type": "stdio" },
+      "runtimeArguments": [
+        { "type": "named", "name": "--from", "value": "redcon[mcp]" },
+        { "type": "positional", "value": "redcon" }
       ],
-      "package_arguments": [
+      "packageArguments": [
         { "type": "positional", "value": "mcp" },
         { "type": "positional", "value": "serve" }
-      ] }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Adds the `mcp-name: io.github.natiixnt/redcon` marker to the README (frozen into the PyPI wheel so the MCP Registry can verify PyPI package ownership) and corrects `server.json` to the live camelCase schema (2025-12-11), modeled on passing registry entries. Bumps to 1.11.3. After the wheel publishes, `mcp-publisher publish` will pass ownership validation.