### PR TITLE
Release 1.11.4: pin mcp<2.0 (fix MCP server startup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.4] - 2026-07-30
+
+### Fixed
+
+- Pin the `mcp` extra to `mcp>=1.0,<2.0`. The MCP server uses the mcp 1.x
+  `Server` API (`@server.list_tools()`), which mcp 2.0.0 removed, so
+  `redcon[mcp]` crashed on start with fresh installs. Pinned to 1.x.
+
+
 ## [1.11.3] - 2026-07-30
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redcon"
-version = "1.11.3"
+version = "1.11.4"
 description = "Deterministic context budgeting for coding-agent workflows"
 readme = "README.md"
 keywords = [
@@ -37,7 +37,7 @@ pro = ["cryptography>=42"]
 tokenizers = ["tiktoken>=0.7"]
 redis = ["redis>=5.0"]
 gateway = ["fastapi>=0.110", "uvicorn[standard]>=0.29"]
-mcp = ["mcp>=1.0"]
+mcp = ["mcp>=1.0,<2.0"]
 # Tree-sitter symbol extraction for redcon repo-map / improved file context.
 # We list per-language wheels because tree-sitter-language-pack still ships
 # broken wheels on Python 3.14 ARM (RECORD-only, no package payload).

--- a/server.json
+++ b/server.json
@@ -3,23 +3,41 @@
   "name": "io.github.natiixnt/redcon",
   "title": "redcon",
   "description": "Deterministic context packing for AI coding agents; measured 83% fewer input tokens, local.",
-  "repository": { "url": "https://github.com/natiixnt/redcon", "source": "github" },
-  "version": "1.11.3",
+  "repository": {
+    "url": "https://github.com/natiixnt/redcon",
+    "source": "github"
+  },
+  "version": "1.11.4",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "redcon",
-      "version": "1.11.3",
+      "version": "1.11.4",
       "runtimeHint": "uvx",
-      "transport": { "type": "stdio" },
+      "transport": {
+        "type": "stdio"
+      },
       "runtimeArguments": [
-        { "type": "named", "name": "--from", "value": "redcon[mcp]" },
-        { "type": "positional", "value": "redcon" }
+        {
+          "type": "named",
+          "name": "--from",
+          "value": "redcon[mcp]"
+        },
+        {
+          "type": "positional",
+          "value": "redcon"
+        }
       ],
       "packageArguments": [
-        { "type": "positional", "value": "mcp" },
-        { "type": "positional", "value": "serve" }
+        {
+          "type": "positional",
+          "value": "mcp"
+        },
+        {
+          "type": "positional",
+          "value": "serve"
+        }
       ]
     }
   ]


### PR DESCRIPTION
Fresh installs of `redcon[mcp]` pulled mcp 2.0.0 (extra was unpinned `mcp>=1.0`), which removed the `Server.list_tools` API the server uses, so `redcon mcp serve` crashed with `'Server' object has no attribute 'list_tools'`. Pin `mcp>=1.0,<2.0`. Bumps to 1.11.4 and updates server.json.