### PR TITLE
vscode-redcon 0.9.4: keyword metadata refresh

### DIFF
--- a/vscode-redcon/CHANGELOG.md
+++ b/vscode-redcon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.4
+
+- Marketplace metadata refresh: added `cursor`, `mcp`, `claude-code`, `token-saver` keywords for discoverability. No functional changes.
+
 # Changelog
 
 ## 0.9.3 - 2026-07-14

--- a/vscode-redcon/package.json
+++ b/vscode-redcon/package.json
@@ -2,7 +2,7 @@
   "name": "redcon",
   "displayName": "Redcon - Token Savings for AI Coding Agents",
   "description": "Save tokens and money on Claude Code, Cursor, Windsurf and other AI coding agents: redcon deterministically ranks, compresses and packs repository context under token limits, and shows you the savings.",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "publisher": "redcon",
   "license": "FSL-1.1-MIT",
   "icon": "resources/icon.png",


### PR DESCRIPTION
0.9.3 is already on the Marketplace, so bump the extension to 0.9.4 to publish the keyword additions from #201 (cursor, mcp, claude-code, token-saver). Metadata only, no functional change. The 0.9.4 vsix is being uploaded to the Marketplace via the web UI.