### PR TITLE
Rewrite ROADMAP to the delivered state of the packer phases

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,195 +1,84 @@
 # Roadmap: Self-contained progressive packer
 
-Goal: every prompt Redcon produces must be complete and useful on its own,
-and the packer must maximize information density under any budget by degrading
+Goal: every prompt Redcon produces is complete and useful on its own, and the
+packer maximizes information density under any budget by degrading
 representations before dropping files entirely.
 
-Three phases, each shippable independently, each with its own GitHub issues.
+Status: the three phases below shipped in March 2026. This document records
+what was delivered, with commit and test references, plus the small follow-ups
+that remain open. It is not a list of pending work.
 
 ---
 
-## Phase 1 - Self-contained cache (P0)
+## Phase 1 - Self-contained cache (P0) - Done
 
-**Problem:** `@cached-summary:{ref_id}` markers leak into the LLM prompt via
-`_build_prompt_text()`. The model sees useless placeholder strings instead of
-code. Benchmarks look great because token counts drop, but the prompt is
-broken.
+Delivered in `3ad9611` (self-contained cache) and `3b92412` (removed the dead
+code path that emitted `@cached-summary:` markers).
 
-**Root cause:** `context_compressor.py:594-598` replaces `candidate_text` with
-the marker when a cache hit occurs, and `runtime.py:71-88` passes it through
-verbatim.
-
-**Fix:** The cache must never replace real content with an opaque marker in
-`CompressedFile.text`. On a cache hit we skip recompression (performance win)
-but always store the actual compressed text in the output. The cache reference
-ID stays in `cache_reference` for accounting/delta, it just never touches
-`text`.
-
-### Subtasks
-
-1. **context_compressor.py** - on cache hit, keep `candidate_text = compressed`
-   (the real text). Use the cache hit only to skip redundant `put_fragment`.
-   Token accounting stays the same (count real text tokens).
-2. **runtime.py** - add a defensive guard: if any `text` field starts with
-   `@cached-summary:`, log a warning and skip that entry. This is a safety net,
-   not the primary fix.
-3. **Tests** - add a test that packs twice with a warm cache and asserts no
-   `@cached-summary` markers appear in `CompressedFile.text` or in the
-   assembled prompt text.
-4. **Benchmark validation** - run the 4 benchmark tasks before/after and
-   document token count changes. Cache-assisted strategy will report fewer
-   "saved" tokens because we no longer fake savings via markers.
-
-**Estimated scope:** 4 files touched, ~80 lines changed, ~40 lines of new
-tests.
+- On a cache hit the compressor keeps the real compressed text in
+  `CompressedFile.text`; the hit only skips a redundant `put_fragment`. The
+  reference id lives in `cache_reference` for accounting and never touches
+  `text` (`redcon/compressors/context_compressor.py`, `_finalize_entry`).
+- `redcon/runtime/runtime.py` guards `_build_prompt_text`: any entry whose text
+  starts with `@cached-summary:` is logged and skipped. `redcon/cli.py` carries
+  the same guard on its render paths. The marker is never constructed anywhere
+  in `redcon/`; it exists only as guarded input and one deliberately broken
+  test fixture.
+- Tests: `test_warm_cache_produces_self_contained_prompt` and
+  `test_runtime_build_prompt_skips_cache_markers` in
+  `tests/test_pack_pipeline.py`.
 
 ---
 
-## Phase 2 - Progressive budget packer
+## Phase 2 - Progressive budget packer - Done
 
-**Problem:** The compressor picks one representation per file. When the budget
-fills up, remaining files are silently skipped. A 50-line utility that scores
-well gets the same "full file" treatment as a 2000-line module, wasting budget.
-If budget runs tight, high-scoring files can get dropped entirely because
-earlier files consumed too much space.
+Delivered in `3ad9611`.
 
-**Fix:** For each file, pre-generate a tier list of representations with
-decreasing token cost:
-
-```
-full  ->  symbol  ->  slice  ->  summary (1-line)
-```
-
-Then run a two-pass selection:
-
-1. **Tentative pass** - assign each file its best affordable representation
-   (highest tier that fits remaining budget), processing files in score order.
-2. **Degradation pass** - if files were skipped, try to reclaim budget by
-   downgrading the lowest-scoring *included* files one tier, then retry skipped
-   files.
-
-This is a bounded greedy with one degradation round - not a full knapsack
-solver - so it stays deterministic and fast.
-
-### Subtasks
-
-1. **New: `redcon/compressors/representations.py`** - `FileRepresentations`
-   dataclass holding `tiers: list[Tier]` where each `Tier` has `(strategy,
-   text, tokens, selected_ranges, symbols)`. One function
-   `build_representations(file_record, keywords, ...)` that produces the tier
-   list by running existing extraction functions.
-2. **Refactor `compress_ranked_files()`** - split the current monolithic loop:
-   - First: build representations for all files (reuses existing symbol/slice/
-     snippet/summary logic, just stores all variants).
-   - Second: run tentative + degradation selection.
-   - Third: post-process (cleanup, dedup imports, cache storage).
-3. **New metrics** - add `degraded_files: list[str]` and
-   `degradation_savings: int` to `CompressionResult`. Track how many files were
-   downgraded and how many tokens that freed.
-4. **Config** - add `progressive_packer_enabled: bool = True` and
-   `max_degradation_rounds: int = 1` to `CompressionSettings`. The flag lets
-   users fall back to the old greedy behavior if needed.
-5. **Tests** - test that under a tight budget, a file that would have been
-   skipped now appears with a degraded representation. Test that degradation
-   metrics are populated.
-6. **Benchmark validation** - compare old vs new packer on the 4 benchmark
-   tasks. Expect 10-25% better file coverage at the same budget, or equivalent
-   coverage at a lower budget.
-
-**Estimated scope:** 1 new file (~200 lines), 1 major refactor (~250 lines
-changed in context_compressor.py), config/schema updates, ~100 lines of new
-tests.
+- `redcon/compressors/representations.py` builds a per-file tier list
+  (`full`, `symbol`, `slice`, `summary`) of decreasing token cost.
+- `compress_ranked_files()` runs a tentative pass (best affordable
+  representation per file, in score order) followed by a bounded degradation
+  pass that downgrades the lowest-scoring included files to reclaim budget for
+  otherwise-skipped files. Controlled by `progressive_packer_enabled` and
+  `max_degradation_rounds` in `[compression]` (`redcon/config.py`).
+- `CompressionResult` carries `degraded_files` and `degradation_savings`, and
+  the quality-risk estimate accounts for the degraded ratio.
+- Tests: `test_progressive_packer_degrades_before_dropping`,
+  `test_progressive_packer_triggers_degradation_with_metrics`,
+  `test_progressive_packer_no_degradation_with_large_budget`,
+  `test_greedy_fallback_when_progressive_disabled`,
+  `test_pack_never_exceeds_budget_under_degradation`.
 
 ---
 
-## Phase 3 - File-role priors
+## Phase 3 - File-role priors - Done (two minor follow-ups open)
 
-**Problem:** Scoring treats all files equally. A `README.md`, an
-`examples/demo.py`, and the actual `auth/service.py` all compete on keyword
-overlap alone. Paraphrased tasks (e.g. "reduce prompt bloat" instead of "delta
-compression") miss relevant files because there is no semantic bridge.
+Delivered in `04571b4`, `02d31bd`, and `840574e`.
 
-**Fix:** Two changes:
+- `redcon/scorers/file_roles.py` classifies each scanned file into `prod`,
+  `test`, `docs`, `example`, `config`, or `generated` via path heuristics.
+- `redcon/scorers/relevance.py` applies `role_multipliers` after heuristic
+  scoring, with `role_keyword_overrides` for the test/docs/example special
+  cases. Both live in `[score]` (`redcon/config.py`) and are config-validated.
+- Tests: `test_file_role_classification_basic`,
+  `test_file_role_does_not_match_substrings`,
+  `test_role_multipliers_lower_docs_and_examples`,
+  `test_role_keyword_override_boosts_test_files`.
 
-### A. File role classification
+Open follow-ups (minor, not blocking):
 
-Classify every scanned file into one of: `prod`, `test`, `docs`, `example`,
-`config`, `generated`. Use path heuristics:
-
-| Role       | Heuristic                                                |
-|------------|----------------------------------------------------------|
-| test       | path contains `test`, `tests`, `spec`, `__tests__`      |
-| docs       | path contains `docs`, `doc`, extension `.md`, `.rst`     |
-| example    | path contains `example`, `examples`, `demo`, `sample`    |
-| config     | extension `.toml`, `.yaml`, `.yml`, `.json`, `.cfg`, `.ini` and in root or config dir |
-| generated  | path contains `generated`, `__pycache__`, `.g.`, `_pb2`  |
-| prod       | everything else                                          |
-
-### B. Role-based scoring adjustments
-
-In `relevance.py`, after keyword scoring, apply multipliers:
-
-| Role      | Multiplier | Rationale                                   |
-|-----------|------------|---------------------------------------------|
-| prod      | 1.0        | Baseline                                    |
-| test      | 0.6        | Tests are relevant only when task mentions testing |
-| docs      | 0.4        | Rarely needed unless task is about docs     |
-| example   | 0.3        | Almost never the right context              |
-| config    | 0.7        | Often useful but not primary                |
-| generated | 0.1        | Almost never useful                         |
-
-When task keywords contain "test", "spec", or "fixture", the test multiplier
-becomes 1.2 instead. Same pattern for docs/example roles.
-
-### Subtasks
-
-1. **New: `redcon/scorers/file_roles.py`** - `classify_file_role(path) -> str`
-   using path heuristics.
-2. **Update `relevance.py`** - apply role multipliers after heuristic scoring.
-   Add role to `RankedFile` for downstream visibility.
-3. **Config** - add `role_multipliers: dict[str, float]` to `ScoreSettings`
-   with the defaults above. Add `role_keyword_overrides` for the test/docs
-   special cases.
-4. **Update scanner** - include `role` in scan index entries so it does not need
-   to be recomputed on every score run.
-5. **Tests** - test that docs/examples score lower than equivalent prod files.
-   Test keyword override (test task boosts test files).
-6. **Benchmark validation** - verify that the "add rate limiting" task no longer
-   pulls in docs/examples above prod code.
-
-**Estimated scope:** 1 new file (~60 lines), updates to relevance.py (~40
-lines), scanner/config updates (~30 lines), ~80 lines of new tests.
+1. The computed role is not stored on `RankedFile`, so it is not visible to
+   downstream consumers or `run.json`.
+2. The role is recomputed on every score run rather than cached in the scan
+   index. `840574e` added an `lru_cache` to `classify_file_role`, which removes
+   most of the repeated cost, so this is an optimization rather than a
+   correctness gap.
 
 ---
 
-## Execution order
+## What is next
 
-```
-Phase 1 (P0)  -->  Phase 2  -->  Phase 3
-   ~2d              ~5-6d          ~3-4d
-```
-
-Phase 1 first because it is a correctness bug - every prompt must be
-self-contained before we optimize packing.
-
-Phase 2 next because it has the highest impact on token efficiency and file
-coverage, which is the core value proposition.
-
-Phase 3 last because it improves recall quality but the system is already
-functional without it.
-
-Each phase gets its own GitHub issues (one per subtask), tests must pass before
-merging, and benchmarks are run after each phase to measure impact.
-
----
-
-## Out of scope (for now)
-
-- **Language parity** (Rust/Java import graph, symbol extraction) - real need
-  but lower priority than the packer/cache fixes. Revisit after Phase 3.
-- **External summarization** - adds LLM dependency and latency. Not needed
-  until deterministic summaries prove insufficient.
-- **Semantic/embedding-based recall** - high cost, unclear marginal gain over
-  file-role priors. Revisit after measuring Phase 3 impact.
-- **Exact tokenizer** - heuristic estimator is within 5% for budget decisions.
-  Not worth the tiktoken dependency or latency.
+The progressive-packer arc above is complete. Current direction is tracked in
+the launch backlog and issues, not in this document. The near-term 1.12.0 work
+is the free max-compression profile, changed-file targeting for `plan` and
+`pack`, and a per-file scoring breakdown in `plan` output and `run.json`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -78,7 +78,7 @@ Open follow-ups (minor, not blocking):
 
 ## What is next
 
-The progressive-packer arc above is complete. Current direction is tracked in
-the launch backlog and issues, not in this document. The near-term 1.12.0 work
-is the free max-compression profile, changed-file targeting for `plan` and
-`pack`, and a per-file scoring breakdown in `plan` output and `run.json`.
+The progressive-packer arc above is complete; this document is no longer the
+source of truth for future work. Near-term work (tracked in the launch
+backlog): the free max-compression profile, changed-file targeting for `plan`
+and `pack`, and a per-file scoring breakdown in `plan` output and `run.json`.


### PR DESCRIPTION
## What

Rewrite `ROADMAP.md` to reflect the code as it actually is. All three phases of the "self-contained progressive packer" roadmap shipped in March 2026, but the document still presented them as open future work (P0/P1) with line numbers that no longer exist. Ahead of directory and press traffic, a root-level doc accusing the product of a "broken prompt" bug that was fixed five months ago is a liability.

Audited every subtask against the code:

- **Phase 1 (self-contained cache):** done in `3ad9611` + `3b92412`. Cache hits keep real text in `CompressedFile.text`; `runtime._build_prompt_text` guards `@cached-summary:`; the marker is never constructed in `redcon/`. Tests: `test_warm_cache_produces_self_contained_prompt`, `test_runtime_build_prompt_skips_cache_markers`.
- **Phase 2 (progressive budget packer):** done in `3ad9611`. `representations.py` tier lists; tentative + degradation passes; `degraded_files`/`degradation_savings`; `progressive_packer_enabled`/`max_degradation_rounds`. Five dedicated tests.
- **Phase 3 (file-role priors):** done in `04571b4`/`02d31bd`/`840574e`. `file_roles.classify_file_role`; `role_multipliers` + `role_keyword_overrides`. Four dedicated tests. **Two minor follow-ups remain open** and are recorded honestly: role is not stored on `RankedFile`, and role is recomputed per run rather than cached in the scan index (perf-mitigated by an `lru_cache`).

## Benchmark honesty check (current main)

Re-ran the benchmarks to confirm the README "more than 83%" headline still holds. It does.

**Headline metric** - the whole-repo `redcon pack` rate (`saved/scanned`), which is what `docs/methodology.md` actually defines the 83% floor from:

| Task | Packed | Scanned | Savings |
|---|---:|---:|---:|
| add rate limiting to gateway auth | 56,890 | 763,925 | 92.6% |
| fix flaky uvicorn startup | 52,588 | 821,598 | 93.6% |
| add yaml k8s compressor | 59,120 | 1,038,142 | 94.3% |
| speed up incremental scanner | 46,840 | 804,621 | 94.2% |
| document license activation flow | 59,459 | 1,172,099 | 94.9% |

Pooled aggregate: **94.0%** (heuristic estimator, default profile, 640 files). Reproduces the committed methodology table (94.2-94.9%) closely; only "add rate limiting" is lower than committed because the repo grew.

**Note for reviewers:** the four synthetic "strategy benchmark" tasks (`benchmarks/run_benchmarks.py`, baseline 12,228) average **78.9%**, below 83%. These are a separate pipeline and are *not* the basis for the headline - `methodology.md` defines the 83% from the whole-repo rate above. No headline change is made or needed.

## Not in scope

No code changes. `docs/methodology.md` figures are left as-is (they reproduce within rounding; the headline holds). No positioning or pricing edits.
