### PR TITLE
Make the max compression profile free for everyone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Max compression profile is now free for everyone.
+
 ## [1.11.4] - 2026-07-30
 
 ### Fixed

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -60,11 +60,10 @@ Plan the same lifecycle-aware workflow across multiple local repositories or mon
 ### `redcon pack <task> --repo <path> [--max-tokens N] [--top-files N]`
 Build compressed context package and write `run.json` + `run.md` by default.
 
-`--compression-profile max` switches to the Pro max-compression profile: tighter
+`--compression-profile max` switches to the max-compression profile: tighter
 tier thresholds that pack roughly 20% fewer input tokens at the same budget and
 reported quality risk (measured on this repository). It can also be set
-persistently with `[compression] profile = "max"` in `redcon.toml`. Without a
-Pro license the run warns once and falls back to the default profile; `run.json`
+persistently with `[compression] profile = "max"` in `redcon.toml`. `run.json`
 always records which profile actually ran (`compression_profile`).
 
 Every pack prints a `Cache key`: a stable 16-hex fingerprint of the packed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,8 +48,7 @@ critical_path_keywords = ["auth", "permissions", "billing"]
 
 [compression]
 summary_preview_lines = 10
-# profile = "max"  # Pro: tighter tier thresholds, ~20% fewer input tokens;
-#                    falls back to the default profile without a license
+# profile = "max"  # tighter tier thresholds, ~20% fewer input tokens
 
 [summarization]
 backend = "deterministic"

--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -829,7 +829,7 @@ def cmd_pack(args: argparse.Namespace) -> int:
             f"per token ({pack_cost.get('display_name', 'default')} input rates)",
         )
     if str(data.get("compression_profile", "")) == "max":
-        _qprint(args, "Profile: max compression (Pro)")
+        _qprint(args, "Profile: max compression")
     _qprint(
         args,
         f"Files: {files_included} included, {files_skipped} skipped"
@@ -2974,8 +2974,8 @@ def _register_packing_commands(sub: argparse._SubParsersAction) -> None:
         choices=["default", "max"],
         default=None,
         help=(
-            "Compression profile: 'max' packs tighter representations (Pro; "
-            "falls back to default without a license). Overrides [compression] profile."
+            "Compression profile: 'max' packs tighter representations. "
+            "Overrides [compression] profile."
         ),
     )
     pack.set_defaults(func=cmd_pack)

--- a/redcon/compressors/profiles.py
+++ b/redcon/compressors/profiles.py
@@ -6,11 +6,8 @@ A profile is a preset of tier-threshold overrides applied on top of the
 ``[compression]`` settings. The ``max`` profile tightens every threshold so
 more files land in cheaper representations; measured on this repository it
 packed ~21% fewer input tokens than the default profile at the same budget,
-top-files count, and reported quality risk.
-
-``max`` is a Pro feature (``compression.max``). When it is requested without
-an active license the run falls back to the default profile with a one-line
-warning - free behaviour never changes and nothing errors.
+top-files count, and reported quality risk. It works for everyone; no
+license is required.
 """
 
 from __future__ import annotations
@@ -22,8 +19,6 @@ from redcon.entitlements import Entitlement
 
 PROFILE_DEFAULT = "default"
 PROFILE_MAX = "max"
-
-FEATURE_MAX_COMPRESSION = "compression.max"
 
 # The max preset. Applying the profile overrides exactly these keys; users who
 # want to keep hand-tuned values for them should stay on the default profile.
@@ -44,9 +39,8 @@ def resolve_compression_profile(
     """Resolve the requested profile into effective settings.
 
     Returns ``(effective_settings, applied_profile, note)``. ``note`` is
-    non-empty only when the request could not be honored (unknown profile
-    name, or ``max`` without a Pro license) and is meant to be surfaced as a
-    single warning line. The input ``settings`` object is never mutated.
+    non-empty only when the request could not be honored (an unknown profile
+    name) and is meant to be surfaced as a single warning line. The input ``settings`` object is never mutated.
     """
     requested = (settings.profile or "").strip().lower()
     if requested in ("", PROFILE_DEFAULT):
@@ -56,12 +50,5 @@ def resolve_compression_profile(
             replace(settings, profile=PROFILE_DEFAULT),
             PROFILE_DEFAULT,
             f"unknown compression profile {requested!r} - using the default profile",
-        )
-    if not entitlement.has(FEATURE_MAX_COMPRESSION):
-        return (
-            replace(settings, profile=PROFILE_DEFAULT),
-            PROFILE_DEFAULT,
-            "compression profile 'max' is a Pro feature - using the default profile "
-            "(activate with: redcon license --activate KEY)",
         )
     return replace(settings, **MAX_PROFILE_OVERRIDES), PROFILE_MAX, ""

--- a/redcon/config.py
+++ b/redcon/config.py
@@ -142,8 +142,7 @@ class CompressionSettings:
     """Settings for context compression behavior."""
 
     # Named profile applied on top of these settings ("" or "default" = none;
-    # "max" = the Pro max-compression preset, resolved against the entitlement
-    # at run time - see redcon/compressors/profiles.py).
+    # "max" = the max-compression preset - see redcon/compressors/profiles.py).
     profile: str = ""
     full_file_threshold_tokens: int = 300
     snippet_score_threshold: float = 2.5

--- a/redcon/entitlements.py
+++ b/redcon/entitlements.py
@@ -43,7 +43,6 @@ PRO_FEATURES: frozenset[str] = frozenset(
         "dashboard.savings",  # the savings / cross-agent history dashboard
         "history.unlimited",  # run history beyond the free retention window
         "insights.prompt",  # prompt-optimization suggestions
-        "compression.max",  # the max-compression profile (tighter tier thresholds)
     }
 )
 

--- a/redcon/schemas/models.py
+++ b/redcon/schemas/models.py
@@ -322,9 +322,9 @@ class RunReport:
     # picking the right files.
     context_baseline_tokens: int = 0
     files_scanned: int = 0
-    # Which compression profile shaped this run's tier thresholds: "default",
-    # or "max" when the Pro max-compression preset was active. A run that
-    # requested "max" without a license reports "default" - what actually ran.
+    # Which compression profile shaped this run's tier thresholds: "default"
+    # or "max" (the max-compression preset). An unknown profile name falls
+    # back to "default" - what actually ran.
     compression_profile: str = "default"
     # Stable fingerprint of the packed content: sha256 over the ordered
     # (path, text) pairs of compressed_context, first 16 hex chars. Because

--- a/tests/test_compression_profiles.py
+++ b/tests/test_compression_profiles.py
@@ -1,8 +1,9 @@
-"""The max compression profile: preset overrides, Pro gating, pipeline wiring.
+"""The max compression profile: preset overrides and pipeline wiring.
 
-The 'max' profile must tighten the tier thresholds only for an entitled (Pro)
-run, fall back to the default profile with a warning otherwise, and always
-report which profile actually ran. Free behaviour never changes.
+The 'max' profile tightens the tier thresholds for every run. It is free for
+everyone, no license required, and the run always reports which profile
+actually ran. An unknown profile name still falls back to the default with a
+warning.
 """
 
 from __future__ import annotations
@@ -10,7 +11,6 @@ from __future__ import annotations
 from pathlib import Path
 
 from redcon.compressors.profiles import (
-    FEATURE_MAX_COMPRESSION,
     MAX_PROFILE_OVERRIDES,
     PROFILE_DEFAULT,
     PROFILE_MAX,
@@ -18,11 +18,7 @@ from redcon.compressors.profiles import (
 )
 from redcon.config import CompressionSettings, load_config_from_mapping
 from redcon.core import pipeline
-from redcon.entitlements import PRO_FEATURES, TIER_PRO, Entitlement
-
-
-def _pro() -> Entitlement:
-    return Entitlement(tier=TIER_PRO, status="active", features=PRO_FEATURES)
+from redcon.entitlements import PRO_FEATURES, Entitlement
 
 
 def _free() -> Entitlement:
@@ -34,10 +30,10 @@ def _free() -> Entitlement:
 # ---------------------------------------------------------------------------
 
 
-def test_max_compression_is_pro_gated() -> None:
-    assert FEATURE_MAX_COMPRESSION in PRO_FEATURES
-    assert _free().has(FEATURE_MAX_COMPRESSION) is False
-    assert _pro().has(FEATURE_MAX_COMPRESSION) is True
+def test_max_is_free_for_everyone() -> None:
+    assert "compression.max" not in PRO_FEATURES
+    # Ungated features are available to everyone, including a free entitlement.
+    assert _free().has("compression.max") is True
 
 
 def test_default_profile_passes_settings_through() -> None:
@@ -48,8 +44,8 @@ def test_default_profile_passes_settings_through() -> None:
     assert note == ""
 
 
-def test_max_with_pro_applies_every_override() -> None:
-    out, applied, note = resolve_compression_profile(CompressionSettings(profile="max"), _pro())
+def test_max_applies_every_override_without_a_license() -> None:
+    out, applied, note = resolve_compression_profile(CompressionSettings(profile="max"), _free())
     assert applied == PROFILE_MAX
     assert note == ""
     for key, value in MAX_PROFILE_OVERRIDES.items():
@@ -61,19 +57,8 @@ def test_max_with_pro_applies_every_override() -> None:
     assert out.summary_preview_lines < defaults.summary_preview_lines
 
 
-def test_max_without_pro_falls_back_and_warns() -> None:
-    requested = CompressionSettings(profile="max")
-    out, applied, note = resolve_compression_profile(requested, _free())
-    assert applied == PROFILE_DEFAULT
-    assert "Pro" in note
-    # Settings are the untightened defaults, and the input was not mutated.
-    defaults = CompressionSettings()
-    assert out.full_file_threshold_tokens == defaults.full_file_threshold_tokens
-    assert requested.profile == "max"
-
-
 def test_unknown_profile_falls_back_and_warns() -> None:
-    out, applied, note = resolve_compression_profile(CompressionSettings(profile="turbo"), _pro())
+    out, applied, note = resolve_compression_profile(CompressionSettings(profile="turbo"), _free())
     assert applied == PROFILE_DEFAULT
     assert "unknown" in note
     assert out.full_file_threshold_tokens == CompressionSettings().full_file_threshold_tokens
@@ -100,9 +85,8 @@ def _seed_repo(repo: Path) -> None:
         )
 
 
-def test_run_pack_max_profile_packs_tighter_and_reports_it(tmp_path: Path, monkeypatch) -> None:
+def test_run_pack_max_profile_packs_tighter_and_reports_it(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
-    monkeypatch.setattr(pipeline, "load_entitlement", lambda repo=None: _pro())
 
     default_report = pipeline.run_pack(
         "adjust the request handlers", tmp_path, max_tokens=8000, record_history=False
@@ -122,9 +106,9 @@ def test_run_pack_max_profile_packs_tighter_and_reports_it(tmp_path: Path, monke
     assert 0 < max_tokens_used <= default_tokens
 
 
-def test_run_pack_max_without_license_runs_default(tmp_path: Path, monkeypatch) -> None:
+def test_run_pack_max_runs_for_free(tmp_path: Path) -> None:
+    # No license and no monkeypatch: max must still run for everyone.
     _seed_repo(tmp_path)
-    monkeypatch.setattr(pipeline, "load_entitlement", lambda repo=None: _free())
 
     report = pipeline.run_pack(
         "adjust the request handlers",
@@ -134,13 +118,12 @@ def test_run_pack_max_without_license_runs_default(tmp_path: Path, monkeypatch) 
         compression_profile="max",
     )
 
-    assert report.compression_profile == "default"
+    assert report.compression_profile == "max"
 
 
-def test_run_pack_profile_from_config_toml(tmp_path: Path, monkeypatch) -> None:
+def test_run_pack_profile_from_config_toml(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "redcon.toml").write_text('[compression]\nprofile = "max"\n', encoding="utf-8")
-    monkeypatch.setattr(pipeline, "load_entitlement", lambda repo=None: _pro())
 
     report = pipeline.run_pack(
         "adjust the request handlers", tmp_path, max_tokens=8000, record_history=False


### PR DESCRIPTION
## What

Move the `max` compression profile from Pro to Free. It now applies for everyone; no license required.

- `redcon/entitlements.py`: remove `compression.max` from `PRO_FEATURES`. Pro keeps `dashboard.savings`, `history.unlimited`, `insights.prompt`.
- `redcon/compressors/profiles.py`: drop the license gate and the no-license fallback warning in `resolve_compression_profile` - `max` now resolves to the tighter preset unconditionally. An unknown profile name still falls back to the default with a warning. Remove the now-dead `FEATURE_MAX_COMPRESSION` constant and the Pro paragraph from the module docstring.
- `redcon/cli.py`: pack label `Profile: max compression (Pro)` becomes `Profile: max compression`; drop the "(Pro; falls back without a license)" clause from the `--compression-profile` help.
- Docs: `docs/cli.md` and `docs/configuration.md` no longer mark `max` as Pro or mention a license fallback. `redcon/schemas/models.py` comment on `compression_profile` updated.
- `tests/test_compression_profiles.py`: reworked for the ungated behaviour - `max` applies without a license, still reports the profile that ran, unknown profiles still warn.

## Scope

Minimal, as requested: only what this move requires. No pricing or positioning rewrites; other positioning decisions are still pending. README unchanged (it never marked `max` as Pro).

## Changelog

Under Unreleased: "Max compression profile is now free for everyone."

## Verification

`ruff check` + `ruff format --check` clean on all touched files. `pytest tests/test_compression_profiles.py tests/test_entitlements.py`: 25 passed.
