### PR TITLE
Add changed-file targeting to plan and pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `--changed PATH ...` on `plan` and `pack`: boost the named files and their
+  import-graph neighbours in ranking, so a task scoped to a diff surfaces the
+  files it touches. Deterministic.
+
 ### Changed
 
 - Max compression profile is now free for everyone.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,6 +47,11 @@ Print shell completion for bash, zsh or fish.
 ### `redcon plan <task> --repo <path>`
 Rank relevant files for a natural-language task.
 
+`--changed <path> ...` (on `plan` and `pack`) targets a diff: the named files
+and their one-hop import-graph neighbours get a deterministic ranking boost, so
+the files a task touches surface even when keyword overlap is weak. Tune with
+`[score] changed_file_boost` and `changed_neighbor_boost`.
+
 ### `redcon plan <task> --workspace <workspace.toml>`
 Rank relevant files across multiple local repositories or monorepo packages.
 

--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -485,6 +485,7 @@ def cmd_plan(args: argparse.Namespace) -> int:
         repo=args.repo,
         workspace=args.workspace,
         top_files=args.top_files,
+        changed_files=getattr(args, "changed", None),
     )
 
     if not data.get("ranked_files"):
@@ -709,6 +710,7 @@ def cmd_pack(args: argparse.Namespace) -> int:
         top_files=args.top_files,
         delta_from=args.delta,
         compression_profile=getattr(args, "compression_profile", None),
+        changed_files=getattr(args, "changed", None),
     )
 
     files_included = len(data.get("files_included") or [])
@@ -2765,6 +2767,12 @@ def _register_planning_commands(sub: argparse._SubParsersAction) -> None:
     plan.add_argument("task", help="Task description")
     plan.add_argument("--repo", default=".", help="Repository path")
     plan.add_argument(
+        "--changed",
+        nargs="*",
+        metavar="PATH",
+        help="Changed file paths to target; boosts them and their import-graph neighbours in ranking.",
+    )
+    plan.add_argument(
         "--workspace", help="Workspace TOML describing multiple local repositories/packages."
     )
     plan.add_argument("--out-prefix", help="Output file prefix for JSON/Markdown")
@@ -2977,6 +2985,12 @@ def _register_packing_commands(sub: argparse._SubParsersAction) -> None:
             "Compression profile: 'max' packs tighter representations. "
             "Overrides [compression] profile."
         ),
+    )
+    pack.add_argument(
+        "--changed",
+        nargs="*",
+        metavar="PATH",
+        help="Changed file paths to target; boosts them and their import-graph neighbours in ranking.",
     )
     pack.set_defaults(func=cmd_pack)
 

--- a/redcon/config.py
+++ b/redcon/config.py
@@ -83,6 +83,11 @@ class ScoreSettings:
     # (most recent commit gets the full boost, older ones decay linearly).
     git_recent_boost: float = 1.5
     git_recent_commits: int = 10
+    # Files named explicitly as changed (--changed) and their one-hop
+    # import-graph neighbours get a deterministic boost so a task scoped to a
+    # diff surfaces the files it touches. Neighbours get the smaller boost.
+    changed_file_boost: float = 3.0
+    changed_neighbor_boost: float = 1.0
     # Pull a file's test/source counterpart along when its pair scores well
     # (foo.py <-> test_foo.py, foo.ts <-> foo.test.ts, ...).
     test_pair_boost: float = 2.0
@@ -498,6 +503,10 @@ def _apply_score_overrides(settings: ScoreSettings, data: Mapping[str, Any]) -> 
         settings.git_recent_boost = float(data["git_recent_boost"])
     if "git_recent_commits" in data:
         settings.git_recent_commits = int(data["git_recent_commits"])
+    if "changed_file_boost" in data:
+        settings.changed_file_boost = float(data["changed_file_boost"])
+    if "changed_neighbor_boost" in data:
+        settings.changed_neighbor_boost = float(data["changed_neighbor_boost"])
     if "test_pair_boost" in data:
         settings.test_pair_boost = float(data["test_pair_boost"])
     if "code_extension_bonus" in data:

--- a/redcon/core/pipeline.py
+++ b/redcon/core/pipeline.py
@@ -128,7 +128,12 @@ def run_plan(
         scanned_repos = []
     telemetry.emit("scan_completed", scanned_files=len(files), scanned_repos=len(scanned_repos))
     ranked = run_score_stage(
-        task, files, prepared_cfg, repo=target_repo, plugins=resolved_plugins, changed_files=changed_files
+        task,
+        files,
+        prepared_cfg,
+        repo=target_repo,
+        plugins=resolved_plugins,
+        changed_files=changed_files,
     )
     telemetry.emit(
         "scoring_completed",
@@ -433,7 +438,12 @@ def run_pack(
         scanned_repos = []
     telemetry.emit("scan_completed", scanned_files=len(files), scanned_repos=len(scanned_repos))
     ranked = run_score_stage(
-        task, files, prepared_cfg, repo=target_repo, plugins=resolved_plugins, changed_files=changed_files
+        task,
+        files,
+        prepared_cfg,
+        repo=target_repo,
+        plugins=resolved_plugins,
+        changed_files=changed_files,
     )
     ranked_count = len(ranked)
     telemetry.emit(

--- a/redcon/core/pipeline.py
+++ b/redcon/core/pipeline.py
@@ -98,6 +98,7 @@ def run_plan(
     telemetry_sink: TelemetrySink | None = None,
     workspace: WorkspaceDefinition | None = None,
     plugins: ResolvedPlugins | None = None,
+    changed_files: list[str] | None = None,
 ) -> dict:
     """Run plan command pipeline and return serializable payload."""
 
@@ -126,7 +127,9 @@ def run_plan(
         files = run_scan_stage(repo, prepared_cfg)
         scanned_repos = []
     telemetry.emit("scan_completed", scanned_files=len(files), scanned_repos=len(scanned_repos))
-    ranked = run_score_stage(task, files, prepared_cfg, repo=target_repo, plugins=resolved_plugins)
+    ranked = run_score_stage(
+        task, files, prepared_cfg, repo=target_repo, plugins=resolved_plugins, changed_files=changed_files
+    )
     telemetry.emit(
         "scoring_completed",
         scanned_files=len(files),
@@ -379,6 +382,7 @@ def run_pack(
     plugins: ResolvedPlugins | None = None,
     record_history: bool = True,
     compression_profile: str | None = None,
+    changed_files: list[str] | None = None,
 ) -> RunReport:
     """Run pack command pipeline and return typed run report."""
 
@@ -428,7 +432,9 @@ def run_pack(
         scan_summary = scan_result.summary
         scanned_repos = []
     telemetry.emit("scan_completed", scanned_files=len(files), scanned_repos=len(scanned_repos))
-    ranked = run_score_stage(task, files, prepared_cfg, repo=target_repo, plugins=resolved_plugins)
+    ranked = run_score_stage(
+        task, files, prepared_cfg, repo=target_repo, plugins=resolved_plugins, changed_files=changed_files
+    )
     ranked_count = len(ranked)
     telemetry.emit(
         "scoring_completed",

--- a/redcon/engine.py
+++ b/redcon/engine.py
@@ -174,6 +174,7 @@ class RedconEngine:
         repo: str | Path = ".",
         workspace: str | Path | None = None,
         top_files: int | None = None,
+        changed_files: list[str] | None = None,
         config_path: str | Path | None = None,
     ) -> dict[str, Any]:
         """Rank repository or workspace files relevant to a task."""
@@ -199,6 +200,7 @@ class RedconEngine:
                 config=workspace_definition.config,
                 telemetry_sink=self._telemetry_sink,
                 workspace=workspace_definition,
+                changed_files=changed_files,
             )
             logger.info("plan: done - task=%r", task)
             return result
@@ -211,6 +213,7 @@ class RedconEngine:
             top_n=effective_top_files,
             config=cfg,
             telemetry_sink=self._telemetry_sink,
+            changed_files=changed_files,
         )
         logger.info("plan: done - task=%r", task)
         return result
@@ -319,6 +322,7 @@ class RedconEngine:
         config_path: str | Path | None = None,
         timeout: int = 120,
         compression_profile: str | None = None,
+        changed_files: list[str] | None = None,
     ) -> dict[str, Any]:
         """Build compressed context under token and file budgets.
 
@@ -359,6 +363,7 @@ class RedconEngine:
                     telemetry_sink=self._telemetry_sink,
                     workspace=workspace_definition,
                     compression_profile=compression_profile,
+                    changed_files=changed_files,
                 )
                 result = as_json_dict(report)
             else:
@@ -372,6 +377,7 @@ class RedconEngine:
                     config=cfg,
                     telemetry_sink=self._telemetry_sink,
                     compression_profile=compression_profile,
+                    changed_files=changed_files,
                 )
                 result = as_json_dict(report)
 

--- a/redcon/plugins/builtins.py
+++ b/redcon/plugins/builtins.py
@@ -36,6 +36,7 @@ def _builtin_relevance_score(
         similarity=options.get("task_similarity"),
         dirty_paths=options.get("dirty_paths"),
         recent_paths=options.get("recent_paths"),
+        changed_paths=options.get("changed_paths"),
     )
 
 

--- a/redcon/scorers/relevance.py
+++ b/redcon/scorers/relevance.py
@@ -93,6 +93,7 @@ def score_files(
     similarity: TaskSimilarityCallable | None = None,
     dirty_paths: set[str] | None = None,
     recent_paths: dict[str, float] | None = None,
+    changed_paths: set[str] | None = None,
 ) -> list[RankedFile]:
     """Score files for a task using deterministic keyword and import-graph heuristics."""
 
@@ -305,6 +306,48 @@ def score_files(
 
             heuristic_scores[path] = score
             reasons_by_path[path] = reasons
+
+    # -- Changed-file targeting --
+    # Files named as changed (and their one-hop import-graph neighbours) get a
+    # deterministic boost so a task scoped to a diff surfaces what it touches.
+    if changed_paths and (cfg.changed_file_boost > 0 or cfg.changed_neighbor_boost > 0):
+        by_rel: dict[str, str] = {}
+        by_path: dict[str, str] = {}
+        for record in files:
+            by_path[record.path] = record.path
+            if record.relative_path:
+                by_rel.setdefault(record.relative_path, record.path)
+        matched: set[str] = set()
+        for cp in changed_paths:
+            resolved = by_rel.get(cp) or by_path.get(cp)
+            if resolved is not None:
+                matched.add(resolved)
+        neighbours: set[str] = set()
+        if matched and cfg.changed_neighbor_boost > 0:
+            graph = build_import_graph(files, entrypoint_filenames=cfg.entrypoint_filenames)
+            for path in matched:
+                neighbours |= graph.incoming.get(path, set())
+                neighbours |= graph.outgoing.get(path, set())
+            neighbours -= matched
+        if cfg.changed_file_boost > 0:
+            for path in sorted(matched):
+                heuristic_scores[path] = heuristic_scores.get(path, 0.0) + cfg.changed_file_boost
+                bd = breakdowns.setdefault(path, {})
+                bd["changed_file"] = round(bd.get("changed_file", 0.0) + cfg.changed_file_boost, 3)
+                _add_reason(reasons_by_path.setdefault(path, []), "explicitly changed file")
+        if cfg.changed_neighbor_boost > 0:
+            for path in sorted(neighbours):
+                heuristic_scores[path] = (
+                    heuristic_scores.get(path, 0.0) + cfg.changed_neighbor_boost
+                )
+                bd = breakdowns.setdefault(path, {})
+                bd["changed_neighbor"] = round(
+                    bd.get("changed_neighbor", 0.0) + cfg.changed_neighbor_boost, 3
+                )
+                _add_reason(
+                    reasons_by_path.setdefault(path, []),
+                    "imports or imported by a changed file",
+                )
 
     historical_adjustments = compute_historical_adjustments(
         task,

--- a/redcon/stages/workflow.py
+++ b/redcon/stages/workflow.py
@@ -232,6 +232,7 @@ def run_score_stage(
     config: RedconConfig,
     repo: Path | None = None,
     plugins: ResolvedPlugins | None = None,
+    changed_files: list[str] | None = None,
 ) -> list[RankedFile]:
     """Rank scanned files by deterministic relevance score."""
 
@@ -252,6 +253,8 @@ def run_score_stage(
         recent = _get_git_recent_paths(repo, config.score.git_recent_commits)
         if recent:
             scorer_options["recent_paths"] = recent
+    if changed_files:
+        scorer_options["changed_paths"] = {str(p) for p in changed_files if str(p).strip()}
     return resolved.scorer.score(
         task=task,
         files=files,

--- a/tests/test_changed_files.py
+++ b/tests/test_changed_files.py
@@ -1,0 +1,87 @@
+"""Changed-file targeting.
+
+Files named as changed (via --changed) and their one-hop import-graph
+neighbours get a deterministic boost, so a task scoped to a diff surfaces the
+files it touches even when keyword overlap is weak.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from redcon.config import ScoreSettings
+from redcon.scanners.repository import scan_repository
+from redcon.scorers.relevance import score_files
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _seed(repo: Path) -> None:
+    # service_a imports service_b, so service_b is a one-hop neighbour.
+    _write(
+        repo / "pkg" / "service_a.py",
+        "from pkg.service_b import helper\n\n\ndef run():\n    return helper()\n",
+    )
+    _write(repo / "pkg" / "service_b.py", "def helper():\n    return 1\n")
+    _write(repo / "pkg" / "service_c.py", "def unrelated():\n    return 2\n")
+
+
+def test_changed_file_and_neighbour_are_boosted(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    records = scan_repository(tmp_path)
+    # A task with no keyword overlap: the changed boost is the dominant signal.
+    ranked = score_files(
+        "refactor the widget subsystem", records, changed_paths={"pkg/service_a.py"}
+    )
+    by_path = {r.file.path: r for r in ranked}
+
+    assert {"pkg/service_a.py", "pkg/service_b.py", "pkg/service_c.py"} <= set(by_path)
+    a = by_path["pkg/service_a.py"]
+    b = by_path["pkg/service_b.py"]
+    c = by_path["pkg/service_c.py"]
+
+    # The explicit file and its import neighbour both outrank the untargeted file.
+    assert a.score > b.score > c.score
+    assert a.score_breakdown.get("changed_file", 0.0) > 0
+    assert b.score_breakdown.get("changed_neighbor", 0.0) > 0
+    assert "changed_file" not in c.score_breakdown
+    assert "changed_neighbor" not in c.score_breakdown
+    assert any("explicitly changed file" in r for r in a.reasons)
+    assert any("changed file" in r for r in b.reasons)
+
+
+def test_changed_targeting_is_deterministic(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    records = scan_repository(tmp_path)
+    first = score_files("do the thing", records, changed_paths={"pkg/service_a.py"})
+    second = score_files("do the thing", records, changed_paths={"pkg/service_a.py"})
+    assert [(r.file.path, r.score) for r in first] == [(r.file.path, r.score) for r in second]
+
+
+def test_changed_paths_can_use_relative_or_none(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    records = scan_repository(tmp_path)
+    # No changed set: nothing gets a changed-file boost.
+    base = {r.file.path: r for r in score_files("refactor the widget subsystem", records)}
+    assert all(r.score_breakdown.get("changed_file", 0.0) == 0.0 for r in base.values())
+    # An unknown path is ignored rather than raising.
+    ranked = score_files(
+        "refactor the widget subsystem", records, changed_paths={"does/not/exist.py"}
+    )
+    assert all(r.score_breakdown.get("changed_file", 0.0) == 0.0 for r in ranked)
+
+
+def test_changed_boost_disabled_by_zero_config(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    records = scan_repository(tmp_path)
+    settings = ScoreSettings(changed_file_boost=0.0, changed_neighbor_boost=0.0)
+    ranked = score_files(
+        "refactor the widget subsystem",
+        records,
+        settings=settings,
+        changed_paths={"pkg/service_a.py"},
+    )
+    assert all(r.score_breakdown.get("changed_file", 0.0) == 0.0 for r in ranked)


### PR DESCRIPTION
## What

`plan` and `pack` accept an optional `--changed PATH ...` flag. The named files and their one-hop import-graph neighbours get a deterministic ranking boost, so a task scoped to a diff surfaces the files it touches even when keyword overlap is weak. Launch backlog issue 3.

- **CLI**: `--changed` (nargs `*`, metavar `PATH`) on `plan` and `pack`.
- **Scoring** (`relevance.score_files`): explicit files get `changed_file_boost`; their import-graph neighbours (via `graph.incoming` / `graph.outgoing`) get the smaller `changed_neighbor_boost`. Contributions land in `score_breakdown` as `changed_file` / `changed_neighbor` with matching reasons. Fully deterministic (sorted iteration; the import graph is deterministic and cached). Paths resolve by relative path, then repo path; unknown paths are ignored.
- **Config** (`[score]`): `changed_file_boost = 3.0`, `changed_neighbor_boost = 1.0`, both TOML-configurable. Set either to 0 to disable.
- **Threaded** through `cli` -> `engine.plan`/`engine.pack` -> `run_plan`/`run_pack` -> `run_score_stage` -> the scorer plugin, mirroring the existing `dirty_paths` path.
- **Docs**: `docs/cli.md`. **Changelog**: under Unreleased (Added).

## Verification

- New `tests/test_changed_files.py`: explicit file and neighbour boosted and outrank an untargeted file; deterministic; unknown paths ignored; zero-config disables it. 
- `ruff check` + `ruff format --check` clean. `pytest tests/test_changed_files.py tests/test_scan_and_score.py tests/test_pack_pipeline.py tests/test_compression_profiles.py`: 57 passed.
- End-to-end smoke: `redcon plan "..." --changed redcon/scorers/relevance.py` ranks that file #1; `pack --changed` runs clean.
