### PR TITLE
Expose per-file scoring breakdown in plan output and run.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--changed PATH ...` on `plan` and `pack`: boost the named files and their
   import-graph neighbours in ranking, so a task scoped to a diff surfaces the
   files it touches. Deterministic.
+- Per-file `score_breakdown` in `plan` output, `run.json`, and the human plan
+  view: the weighted contribution of each ranking signal (path/content
+  keywords, symbols, import-graph, role and changed-file boosts). Deterministic.
 
 ### Changed
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -52,6 +52,12 @@ and their one-hop import-graph neighbours get a deterministic ranking boost, so
 the files a task touches surface even when keyword overlap is weak. Tune with
 `[score] changed_file_boost` and `changed_neighbor_boost`.
 
+Every ranked file in `plan` output and `run.json` carries a `score_breakdown`:
+the weighted contribution of each ranking signal (path and content keyword
+matches, symbol matches, import-graph relationships, and file-role and
+changed-file boosts). The human `plan` view prints these as a `signals:` line
+under each file. Deterministic.
+
 ### `redcon plan <task> --workspace <workspace.toml>`
 Rank relevant files across multiple local repositories or monorepo packages.
 

--- a/redcon/core/render.py
+++ b/redcon/core/render.py
@@ -458,6 +458,10 @@ def render_plan_markdown(data: dict) -> str:
     for item in data["ranked_files"]:
         reasons = ", ".join(item["reasons"]) if item["reasons"] else "no specific reason"
         lines.append(f"- `{item['path']}` ({_format_ranked_file_scores(item)}) - {reasons}")
+        breakdown = item.get("score_breakdown") or {}
+        if breakdown:
+            parts = ", ".join(f"{k} {v}" for k, v in sorted(breakdown.items()))
+            lines.append(f"  - signals: {parts}")
     if not data["ranked_files"]:
         lines.append("- No files matched current heuristic signals.")
     lines.append("")

--- a/redcon/stages/workflow.py
+++ b/redcon/stages/workflow.py
@@ -62,6 +62,7 @@ def _serialize_ranked_file(item: RankedFile) -> dict:
         "historical_score": item.historical_score,
         "reasons": item.reasons,
         "line_count": item.file.line_count,
+        "score_breakdown": {k: item.score_breakdown[k] for k in sorted(item.score_breakdown)},
     }
     if item.file.repo_label:
         data["repo"] = item.file.repo_label
@@ -226,6 +227,14 @@ def _get_git_recent_paths(repo: Path, commits: int) -> dict[str, float]:
     return recent
 
 
+def _normalize_changed_path(path: str) -> str:
+    """Normalize a user-supplied --changed path to match scanned relative paths."""
+    normalized = str(path).strip().replace("\\", "/")
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
 def run_score_stage(
     task: str,
     files: list[FileRecord],
@@ -254,7 +263,9 @@ def run_score_stage(
         if recent:
             scorer_options["recent_paths"] = recent
     if changed_files:
-        scorer_options["changed_paths"] = {str(p) for p in changed_files if str(p).strip()}
+        scorer_options["changed_paths"] = {
+            _normalize_changed_path(p) for p in changed_files if str(p).strip()
+        }
     return resolved.scorer.score(
         task=task,
         files=files,

--- a/tests/test_scoring_breakdown.py
+++ b/tests/test_scoring_breakdown.py
@@ -1,0 +1,78 @@
+"""Scoring breakdown.
+
+Each ranked file exposes a ``score_breakdown``: the weighted contribution of
+every ranking signal (path/content keywords, symbols, import-graph, role and
+changed-file boosts), in ``plan`` output, ``run.json``, and the human plan view.
+Deterministic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from redcon.core import pipeline
+from redcon.core.render import render_plan_markdown
+from redcon.schemas.models import FileRecord, RankedFile
+from redcon.stages.workflow import _serialize_ranked_file
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_serialize_includes_sorted_score_breakdown() -> None:
+    rf = RankedFile(
+        file=FileRecord(
+            path="a.py",
+            absolute_path="/x/a.py",
+            extension=".py",
+            size_bytes=1,
+            line_count=1,
+            content_hash="h",
+            content_preview="",
+        ),
+        score=3.0,
+        heuristic_score=3.0,
+        score_breakdown={"path_keyword": 2.0, "content_keyword": 1.0, "import_graph": 0.9},
+    )
+    data = _serialize_ranked_file(rf)
+    assert "score_breakdown" in data
+    # Keys are emitted in sorted order for deterministic output.
+    assert list(data["score_breakdown"]) == sorted(data["score_breakdown"])
+    assert data["score_breakdown"]["path_keyword"] == 2.0
+
+
+def _seed(repo: Path) -> None:
+    _write(repo / "auth" / "login.py", "def login(token):\n    return validate(token)\n")
+    _write(repo / "auth" / "validate.py", "def validate(token):\n    return bool(token)\n")
+
+
+def test_plan_output_exposes_breakdown(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    data = pipeline.run_plan("fix the login auth flow", tmp_path)
+    ranked = data.get("ranked_files") or []
+    assert ranked
+    top = ranked[0]
+    assert isinstance(top.get("score_breakdown"), dict)
+    assert top["score_breakdown"]  # a keyword-matching file has at least one signal
+
+
+def test_breakdown_is_deterministic(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    a = pipeline.run_plan("fix the login auth flow", tmp_path)
+    b = pipeline.run_plan("fix the login auth flow", tmp_path)
+    assert [r["score_breakdown"] for r in a["ranked_files"]] == [
+        r["score_breakdown"] for r in b["ranked_files"]
+    ]
+
+
+def test_human_plan_shows_signals_line(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    data = pipeline.run_plan("fix the login auth flow", tmp_path)
+    md = render_plan_markdown(data)
+    assert "signals:" in md
+    # A concrete signal from the top file appears in the rendered breakdown.
+    top_signals = data["ranked_files"][0]["score_breakdown"]
+    some_key = sorted(top_signals)[0]
+    assert some_key in md


### PR DESCRIPTION
## What

Expose the per-file scoring breakdown that the scorer already computes. Launch backlog issue 6.

- `_serialize_ranked_file` (workflow.py) now includes `score_breakdown` with sorted keys, so `plan` output, `run.json`, and pack `ranked_files` carry the weighted contribution of each ranking signal (`path_keyword`, `content_keyword`, `symbol_match`, `import_graph`, `critical_path`, `code_extension`, role/changed-file boosts, `historical`, ...). Deterministic (sorted keys; scoring is deterministic).
- `render_plan_markdown` (render.py) prints them as a `signals:` line under each ranked file in the human `plan` view.
- Docs in `docs/cli.md`; changelog under Unreleased (Added).

Also folds in the review nit from #214: `run_score_stage` now normalizes `--changed` input paths (strips a leading `./`, converts backslashes to `/`) so Windows-style and `./`-prefixed paths match scanned relative paths instead of being silently ignored.

## Verification

- New `tests/test_scoring_breakdown.py`: serialization includes sorted `score_breakdown`; `plan` output exposes it; deterministic across runs; the human view shows a `signals:` line.
- `ruff check` + `ruff format --check` clean (all changed files). `pytest tests/test_scoring_breakdown.py tests/test_changed_files.py tests/test_scan_and_score.py tests/test_pack_pipeline.py`: 53 passed.
- End-to-end smoke: `redcon plan "..."` writes `score_breakdown` into `run.json` and a `signals:` line into the markdown.
