### PR TITLE
Release 1.12.0: changed-file targeting, scoring breakdown, free max profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-08-03
+
 ### Added
 
 - `--changed PATH ...` on `plan` and `pack`: boost the named files and their

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,6 +1,6 @@
 # Cache
 
-Redcon is local-first by default. The open-source build ships cache backend abstractions so the pack pipeline can stay stable as teams add stricter trust boundaries or future shared cache integrations.
+Redcon is local-first by default. The source-available build ships cache backend abstractions so the pack pipeline can stay stable as teams add stricter trust boundaries or future shared cache integrations.
 
 ## Built-in Backends
 

--- a/docs/launch-pack.md
+++ b/docs/launch-pack.md
@@ -23,7 +23,7 @@ During a broad service refactor, the team runs `benchmark` to compare naive, top
 
 ### Tweet
 
-Redcon is open-source infrastructure for token-aware coding-agent workflows: deterministic context packing, cache reuse, strict policy gates, diff + benchmark artifacts, and a reusable Python API. Stop sending your whole repo to the model.
+Redcon is source-available infrastructure for token-aware coding-agent workflows: deterministic context packing, cache reuse, strict policy gates, diff + benchmark artifacts, and a reusable Python API. Stop sending your whole repo to the model.
 
 ### Hacker News Description
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -1,7 +1,7 @@
 # How the Numbers Are Measured
 
 Every savings number redcon publishes is reproducible on this repository with
-the open source CLI. This page shows the exact procedure, the latest measured
+the source-available CLI. This page shows the exact procedure, the latest measured
 run, and what the numbers do and do not claim.
 
 ## Reproduce it in 60 seconds

--- a/docs/social-copy.md
+++ b/docs/social-copy.md
@@ -7,7 +7,7 @@ Deterministic context packing and budget enforcement for coding-agent workflows 
 Stop sending your whole repository to the model.
 
 ## Tweet
-Redcon is open-source infrastructure for token-aware coding-agent workflows: deterministic context packing, cache reuse, strict policy gates, diff + benchmark artifacts, and a reusable Python API. Stop sending your whole repo to the model.
+Redcon is source-available infrastructure for token-aware coding-agent workflows: deterministic context packing, cache reuse, strict policy gates, diff + benchmark artifacts, and a reusable Python API. Stop sending your whole repo to the model.
 
 ## Hacker News Description
 Redcon reduces context waste in coding-agent workflows. Instead of sending broad repository slices, it deterministically ranks files, compresses context, reuses cache, and enforces token/risk policies in CI. It ships as a CLI and Python API, outputs machine-readable artifacts (`run.json`, diff, benchmark), and stays local-first. Telemetry is optional, disabled by default, and includes no network sink in OSS.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=69", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "redcon"
-version = "1.11.4"
+version = "1.12.0"
 description = "Deterministic context budgeting for coding-agent workflows"
 readme = "README.md"
 keywords = [
@@ -19,7 +19,7 @@ keywords = [
     "token-optimization",
 ]
 requires-python = ">=3.10"
-license = { file = "LICENSE" }
+license = "FSL-1.1-MIT"
 authors = [{ name = "Natalia Szczepanik" }]
 dependencies = []
 

--- a/redcon/entitlements.py
+++ b/redcon/entitlements.py
@@ -10,7 +10,7 @@ Design:
   private key never leaves redcon-cloud, so Pro works on a plane and never
   phones home.
 - A license is UNFORGEABLE without the private key, so "holds a valid license"
-  is proof of purchase - even though the local gate itself, being open source,
+  is proof of purchase - even though the local gate itself, being source-available,
   can always be patched out by a determined user. The real paid value lives
   server-side in redcon-cloud; the local gate only stops casual bypass, which
   is the honest ceiling for any open-core license.

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/natiixnt/redcon",
     "source": "github"
   },
-  "version": "1.11.4",
+  "version": "1.12.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "redcon",
-      "version": "1.11.4",
+      "version": "1.12.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Release 1.12.0

Cuts the 1.12.0 release from the four merged feature PRs.

**Changelog (moved from Unreleased):**
- Added: `--changed PATH ...` on `plan`/`pack` (changed-file targeting, #214); per-file `score_breakdown` in plan output / `run.json` / human view (#215).
- Changed: max compression profile is now free for everyone (#211).

**Also in this release:**
- **License metadata**: declare `license = "FSL-1.1-MIT"` (PEP 639 SPDX expression) instead of `{ file = "LICENSE" }`, and bump the build requirement to `setuptools>=77`. Verified locally: `python -m build` succeeds, the wheel records `License-Expression: FSL-1.1-MIT`, and `twine check` passes. So PyPI shows the license by name.
- **Wording accuracy**: the project is **source-available** under FSL (converts to MIT after two years), not open source. Corrected four docs (`cache.md`, `launch-pack.md`, `methodology.md`, `social-copy.md`) and one `entitlements.py` docstring that still said "open source". README was already clean. (The `agent_cost.py` "Open Source" string is a pricing-tier label for hosted API providers, left as-is.)
- `server.json` bumped to 1.12.0 for the post-release `mcp-publisher publish`.

## After merge (per CONTRIBUTING Releasing)

Tag `v1.12.0` (triggers the release workflow to publish the wheel + GitHub Release), then clean-venv verify (`redcon --version`, `import redcon; __version__`). Natalia: `mcp-publisher publish` with the bumped `server.json`.
