### PR TITLE
Revert to file-based license declaration (unblock 1.12.0 publish)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=77", "wheel"]
+requires = ["setuptools>=69", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -19,7 +19,7 @@ keywords = [
     "token-optimization",
 ]
 requires-python = ">=3.10"
-license = "FSL-1.1-MIT"
+license = { file = "LICENSE" }
 authors = [{ name = "Natalia Szczepanik" }]
 dependencies = []
 


### PR DESCRIPTION
`twine` 7 rejects `license = "FSL-1.1-MIT"` (`InvalidDistribution: 'FSL-1.1-MIT' is invalid for 'license-expression'`) because FSL-1.1-MIT is not an SPDX-registered id, so the 1.12.0 release workflow failed at 'Publish to PyPI'. Revert to `license = { file = "LICENSE" }` (the 1.11.x form) and `setuptools>=69`; the LICENSE file is unchanged. Verified: build + `twine check` (7.0.0) pass. After merge I re-tag v1.12.0 to republish (PyPI never received 1.12.0, so no collision). Note: `LicenseRef-FSL-1.1-MIT` also passes twine 7 and would show the name - a future option.