### PR TITLE
Add glama.json server manifest

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["natiixnt"],
+  "name": "redcon",
+  "description": "Deterministic context budgeting for coding-agent workflows",
+  "repository": "https://github.com/natiixnt/redcon",
+  "license": "FSL-1.1-MIT",
+  "runtime": "python",
+  "tags": ["mcp", "context", "coding-agents", "token-budget", "deterministic"]
+}


### PR DESCRIPTION
Add a Glama MCP server manifest so redcon has a maintainer-controlled registry entry.

- `maintainers`: the only field Glama's schema requires and validates (unique GitHub usernames).
- The rest (`name`, `description`, `repository`, `license`, `runtime`, `tags`) are informational display metadata; the schema allows them via unset additionalProperties.

Description matches pyproject.toml. Note: Glama's license grade keys off GitHub's own license detection, not this file, so the FSL-1.1-MIT value here is informational only.