### PR TITLE
Add Junie CLI as an MCP install target

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pip install "redcon[mcp]"
 redcon init                      # creates redcon.toml + registers MCP
 ```
 
-The `init` command auto-configures MCP for Claude Code, Cursor and Windsurf, plus VS Code, Codex CLI and Gemini CLI when they are detected, so your AI agent can call `redcon_rank`, `redcon_search`, `redcon_compress`, and `redcon_budget` as native tools. It also writes a short `AGENTS.md` section that tells agents to prefer these tools for context selection.
+The `init` command auto-configures MCP for Claude Code, Cursor and Windsurf, plus VS Code, Codex CLI, Gemini CLI and Junie CLI when they are detected, so your AI agent can call `redcon_rank`, `redcon_search`, `redcon_compress`, and `redcon_budget` as native tools. It also writes a short `AGENTS.md` section that tells agents to prefer these tools for context selection.
 
 ### Option 3: CLI only
 

--- a/docs/mcp-and-hooks.md
+++ b/docs/mcp-and-hooks.md
@@ -28,8 +28,9 @@ redcon mcp serve        # run the stdio server (agents invoke this)
 
 `install` writes the appropriate config for each detected agent:
 Claude Code (`.mcp.json`), Cursor (`.cursor/mcp.json`), Windsurf,
-VS Code (`.vscode/mcp.json`), Codex (`~/.codex/config.toml`) and
-Gemini (`~/.gemini/settings.json`). Restart the IDE or agent session
+VS Code (`.vscode/mcp.json`), Codex (`~/.codex/config.toml`),
+Gemini (`~/.gemini/settings.json`) and Junie
+(`.junie/mcp/mcp.json`). Restart the IDE or agent session
 after installing so it picks up the new tools.
 
 ### Tools exposed

--- a/redcon/mcp/install.py
+++ b/redcon/mcp/install.py
@@ -1,8 +1,8 @@
 """
 Auto-install Redcon MCP server config into supported AI agents.
 
-Covers Claude Code, Cursor, Windsurf, VS Code, Codex CLI and Gemini CLI.
-JSON based agents get the redcon entry merged into their MCP config file
+Covers Claude Code, Cursor, Windsurf, VS Code, Codex CLI, Gemini CLI and
+Junie CLI. JSON based agents get the redcon entry merged into their MCP config file
 (VS Code uses a "servers" key and a stdio type marker instead of the
 "mcpServers" shape the others share). Codex CLI is configured through
 TOML, where the redcon section is appended or removed textually so the
@@ -34,7 +34,7 @@ DEFAULT_TARGETS = ["claude", "cursor", "windsurf"]
 # Targets registered only when their config location already exists, so
 # `redcon init` does not scatter config for agents the user never
 # installed. Explicitly naming the target still forces the install.
-DETECTED_TARGETS = ["vscode", "codex", "gemini"]
+DETECTED_TARGETS = ["vscode", "codex", "gemini", "junie"]
 
 ALL_TARGETS = DEFAULT_TARGETS + DETECTED_TARGETS
 
@@ -44,6 +44,7 @@ _SERVERS_KEY: dict[str, str] = {
     "cursor": "mcpServers",
     "windsurf": "mcpServers",
     "gemini": "mcpServers",
+    "junie": "mcpServers",
     "vscode": "servers",
 }
 
@@ -62,6 +63,7 @@ def _target_paths(project_root: Path) -> dict[str, list[Path]]:
     VS Code uses a project-scoped .vscode/mcp.json.
     Codex CLI uses ~/.codex/config.toml.
     Gemini CLI uses ~/.gemini/settings.json.
+    Junie CLI uses project .junie/mcp/mcp.json or global ~/.junie/mcp/mcp.json.
     """
     home = Path.home()
     return {
@@ -74,6 +76,10 @@ def _target_paths(project_root: Path) -> dict[str, list[Path]]:
         "vscode": [project_root / ".vscode" / "mcp.json"],
         "codex": [home / ".codex" / "config.toml"],
         "gemini": [home / ".gemini" / "settings.json"],
+        "junie": [
+            project_root / ".junie" / "mcp" / "mcp.json",
+            home / ".junie" / "mcp" / "mcp.json",
+        ],
     }
 
 
@@ -87,6 +93,8 @@ def detect_targets(project_root: Path) -> list[str]:
         targets.append("codex")
     if (home / ".gemini").is_dir():
         targets.append("gemini")
+    if (project_root / ".junie").is_dir() or (home / ".junie").is_dir():
+        targets.append("junie")
     return targets
 
 

--- a/tests/test_mcp_install.py
+++ b/tests/test_mcp_install.py
@@ -186,6 +186,60 @@ def test_install_gemini_writes_settings(tmp_path: Path, monkeypatch: pytest.Monk
     assert data["mcpServers"]["redcon"] == REDCON_ENTRY
 
 
+def test_install_junie_writes_project_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Junie CLI reads a standard mcpServers entry from .junie/mcp/mcp.json."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+    result = install_for_target("junie", tmp_path)
+    assert result["status"] == "installed"
+    data = json.loads((tmp_path / ".junie" / "mcp" / "mcp.json").read_text())
+    assert data["mcpServers"]["redcon"] == REDCON_ENTRY
+
+
+def test_install_junie_prefers_existing_global_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """An existing global ~/.junie config is merged into rather than shadowed."""
+    home = tmp_path / "home"
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    global_path = home / ".junie" / "mcp" / "mcp.json"
+    global_path.parent.mkdir(parents=True)
+    global_path.write_text(json.dumps({"mcpServers": {"other": {"command": "x", "args": []}}}))
+
+    result = install_for_target("junie", tmp_path)
+    assert result["status"] == "installed"
+    assert result["path"] == str(global_path)
+    data = json.loads(global_path.read_text())
+    assert "other" in data["mcpServers"]
+    assert data["mcpServers"]["redcon"] == REDCON_ENTRY
+    # The project path is left untouched when a global config already exists.
+    assert not (tmp_path / ".junie" / "mcp" / "mcp.json").exists()
+
+
+def test_uninstall_junie_removes_entry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Uninstall strips the redcon entry from the Junie config."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+    install_for_target("junie", tmp_path)
+    result = uninstall_for_target("junie", tmp_path)
+    assert result["status"] == "removed"
+    data = json.loads((tmp_path / ".junie" / "mcp" / "mcp.json").read_text())
+    assert "redcon" not in data.get("mcpServers", {})
+
+
+def test_detect_targets_finds_junie_by_project_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A project .junie directory adds junie to the detected targets."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+    (tmp_path / ".junie").mkdir()
+    assert "junie" in detect_targets(tmp_path)
+
+
+def test_installed_path_reports_junie(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """installed_path locates the Junie registration once written."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+    assert installed_path("junie", tmp_path) is None
+    install_for_target("junie", tmp_path)
+    assert installed_path("junie", tmp_path) == tmp_path / ".junie" / "mcp" / "mcp.json"
+
+
 def test_detect_targets_defaults_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Without detected agents only the default trio is targeted."""
     monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")


### PR DESCRIPTION
Make Junie CLI a first-class `redcon mcp install` target.

## Config format (verified against JetBrains docs)
Junie CLI consumes **stdio** MCP servers from the standard `mcpServers` map:
- Project scope: `.junie/mcp/mcp.json`
- Global scope: `~/.junie/mcp/mcp.json`
- Entry shape: `{"command": "redcon", "args": ["mcp", "serve"]}` - identical to Claude Code, Cursor, Windsurf and Gemini.

Sources: [Junie CLI MCP configuration](https://junie.jetbrains.com/docs/junie-cli-mcp-configuration.html), [Junie MCP Settings](https://junie.jetbrains.com/docs/junie-plugin-mcp-settings.html).

## Changes
- `junie` added to `DETECTED_TARGETS`, `_SERVERS_KEY`, `_target_paths` and `detect_targets` (registered only when a `.junie` directory is present, like codex and gemini).
- Install, uninstall, status and `installed_path` work through the existing generic JSON path - no new writer needed since Junie uses the same `mcpServers` shape.
- Agent instructions are already covered by the shared `AGENTS.md` block, same as the other targets.
- Docs: mcp-and-hooks.md and README detected-target lists.
- Tests: project install, existing-global merge, uninstall, detection, `installed_path`.

No change to defaults for existing targets.