### PR TITLE
Add Cline and Zed as MCP install targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pip install "redcon[mcp]"
 redcon init                      # creates redcon.toml + registers MCP
 ```
 
-The `init` command auto-configures MCP for Claude Code, Cursor and Windsurf, plus VS Code, Codex CLI, Gemini CLI and Junie CLI when they are detected, so your AI agent can call `redcon_rank`, `redcon_search`, `redcon_compress`, and `redcon_budget` as native tools. It also writes a short `AGENTS.md` section that tells agents to prefer these tools for context selection.
+The `init` command auto-configures MCP for Claude Code, Cursor and Windsurf, plus VS Code, Codex CLI, Gemini CLI, Junie CLI, Cline and Zed when they are detected, so your AI agent can call `redcon_rank`, `redcon_search`, `redcon_compress`, and `redcon_budget` as native tools. It also writes a short `AGENTS.md` section that tells agents to prefer these tools for context selection.
 
 ### Option 3: CLI only
 

--- a/docs/mcp-and-hooks.md
+++ b/docs/mcp-and-hooks.md
@@ -29,9 +29,10 @@ redcon mcp serve        # run the stdio server (agents invoke this)
 `install` writes the appropriate config for each detected agent:
 Claude Code (`.mcp.json`), Cursor (`.cursor/mcp.json`), Windsurf,
 VS Code (`.vscode/mcp.json`), Codex (`~/.codex/config.toml`),
-Gemini (`~/.gemini/settings.json`) and Junie
-(`.junie/mcp/mcp.json`). Restart the IDE or agent session
-after installing so it picks up the new tools.
+Gemini (`~/.gemini/settings.json`), Junie (`.junie/mcp/mcp.json`), Cline
+(its VS Code global-storage `cline_mcp_settings.json`) and Zed
+(`~/.config/zed/settings.json`, under the `context_servers` key). Restart
+the IDE or agent session after installing so it picks up the new tools.
 
 ### Tools exposed
 

--- a/redcon/mcp/install.py
+++ b/redcon/mcp/install.py
@@ -1,9 +1,10 @@
 """
 Auto-install Redcon MCP server config into supported AI agents.
 
-Covers Claude Code, Cursor, Windsurf, VS Code, Codex CLI, Gemini CLI and
-Junie CLI. JSON based agents get the redcon entry merged into their MCP config file
-(VS Code uses a "servers" key and a stdio type marker instead of the
+Covers Claude Code, Cursor, Windsurf, VS Code, Codex CLI, Gemini CLI,
+Junie CLI, Cline and Zed. JSON based agents get the redcon entry merged
+into their MCP config file (VS Code uses a "servers" key and a stdio type
+marker, and Zed uses a "context_servers" key with an env map, instead of the
 "mcpServers" shape the others share). Codex CLI is configured through
 TOML, where the redcon section is appended or removed textually so the
 rest of the user's config is never rewritten.
@@ -14,6 +15,8 @@ All writes are idempotent and preserve existing entries.
 from __future__ import annotations
 
 import json
+import os
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +28,10 @@ REDCON_ENTRY: dict[str, Any] = {
 # VS Code's .vscode/mcp.json schema wants an explicit transport type.
 _VSCODE_ENTRY: dict[str, Any] = {"type": "stdio", **REDCON_ENTRY}
 
+# Zed's context_servers entry follows its documented custom-server shape,
+# which carries an explicit (here empty) env map.
+_ZED_ENTRY: dict[str, Any] = {**REDCON_ENTRY, "env": {}}
+
 _CODEX_HEADER = "[mcp_servers.redcon]"
 _CODEX_SECTION = '[mcp_servers.redcon]\ncommand = "redcon"\nargs = ["mcp", "serve"]\n'
 
@@ -34,7 +41,7 @@ DEFAULT_TARGETS = ["claude", "cursor", "windsurf"]
 # Targets registered only when their config location already exists, so
 # `redcon init` does not scatter config for agents the user never
 # installed. Explicitly naming the target still forces the install.
-DETECTED_TARGETS = ["vscode", "codex", "gemini", "junie"]
+DETECTED_TARGETS = ["vscode", "codex", "gemini", "junie", "cline", "zed"]
 
 ALL_TARGETS = DEFAULT_TARGETS + DETECTED_TARGETS
 
@@ -45,12 +52,46 @@ _SERVERS_KEY: dict[str, str] = {
     "windsurf": "mcpServers",
     "gemini": "mcpServers",
     "junie": "mcpServers",
+    "cline": "mcpServers",
     "vscode": "servers",
+    "zed": "context_servers",
 }
 
 
 def _entry_for(target: str) -> dict[str, Any]:
-    return dict(_VSCODE_ENTRY) if target == "vscode" else dict(REDCON_ENTRY)
+    if target == "vscode":
+        return dict(_VSCODE_ENTRY)
+    if target == "zed":
+        return {**REDCON_ENTRY, "env": {}}
+    return dict(REDCON_ENTRY)
+
+
+def _vscode_user_dir() -> Path:
+    """Locate VS Code's per-user config directory across platforms.
+
+    Cline stores its MCP settings under VS Code global storage, so the
+    base path differs by operating system rather than living under a
+    single home-relative location like the other agents.
+    """
+    home = Path.home()
+    if sys.platform == "darwin":
+        return home / "Library" / "Application Support" / "Code" / "User"
+    if sys.platform.startswith("win"):
+        appdata = os.environ.get("APPDATA")
+        base = Path(appdata) if appdata else home / "AppData" / "Roaming"
+        return base / "Code" / "User"
+    return home / ".config" / "Code" / "User"
+
+
+def _cline_settings_path() -> Path:
+    """Cline's MCP settings file inside VS Code global storage."""
+    return (
+        _vscode_user_dir()
+        / "globalStorage"
+        / "saoudrizwan.claude-dev"
+        / "settings"
+        / "cline_mcp_settings.json"
+    )
 
 
 def _target_paths(project_root: Path) -> dict[str, list[Path]]:
@@ -64,6 +105,8 @@ def _target_paths(project_root: Path) -> dict[str, list[Path]]:
     Codex CLI uses ~/.codex/config.toml.
     Gemini CLI uses ~/.gemini/settings.json.
     Junie CLI uses project .junie/mcp/mcp.json or global ~/.junie/mcp/mcp.json.
+    Cline uses its VS Code global-storage cline_mcp_settings.json.
+    Zed uses ~/.config/zed/settings.json.
     """
     home = Path.home()
     return {
@@ -80,6 +123,8 @@ def _target_paths(project_root: Path) -> dict[str, list[Path]]:
             project_root / ".junie" / "mcp" / "mcp.json",
             home / ".junie" / "mcp" / "mcp.json",
         ],
+        "cline": [_cline_settings_path()],
+        "zed": [home / ".config" / "zed" / "settings.json"],
     }
 
 
@@ -95,6 +140,10 @@ def detect_targets(project_root: Path) -> list[str]:
         targets.append("gemini")
     if (project_root / ".junie").is_dir() or (home / ".junie").is_dir():
         targets.append("junie")
+    if _cline_settings_path().parent.parent.is_dir():
+        targets.append("cline")
+    if (home / ".config" / "zed").is_dir():
+        targets.append("zed")
     return targets
 
 

--- a/redcon/mcp/install.py
+++ b/redcon/mcp/install.py
@@ -156,6 +156,34 @@ def _load_config(path: Path) -> dict[str, Any]:
         return {}
 
 
+def _read_json_config(path: Path) -> tuple[dict[str, Any], str | None]:
+    """Load a JSON config for a write, distinguishing missing from unparseable.
+
+    Returns ``(config, error)``. A missing or empty file yields ``({}, None)``
+    so install can safely create or fill it. An existing file with content that
+    does not parse as a JSON object yields ``({}, "<reason>")`` so the caller
+    refuses to overwrite it. This matters for editors like Zed whose
+    ``settings.json`` is JSONC (comments/trailing commas): parsing fails, and
+    blindly writing ``{}`` merged with the redcon entry would wipe real user
+    configuration.
+    """
+    if not path.exists():
+        return {}, None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as e:
+        return {}, f"read failed: {e}"
+    if not text.strip():
+        return {}, None
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        return {}, f"invalid JSON: {e}"
+    if not isinstance(data, dict):
+        return {}, "top-level JSON is not an object"
+    return data, None
+
+
 def _merge_redcon_entry(
     config: dict[str, Any],
     servers_key: str = "mcpServers",
@@ -298,7 +326,19 @@ def install_for_target(target: str, project_root: Path) -> dict[str, Any]:
         chosen = paths[0]
 
     servers_key = _SERVERS_KEY.get(target, "mcpServers")
-    config = _load_config(chosen)
+    config, parse_error = _read_json_config(chosen)
+    if parse_error is not None:
+        return {
+            "target": target,
+            "status": "failed",
+            "path": str(chosen),
+            "message": (
+                f"{chosen} exists but could not be parsed ({parse_error}); "
+                "not overwriting to avoid losing your configuration. Add redcon "
+                f'manually under "{servers_key}": '
+                '{"redcon": {"command": "redcon", "args": ["mcp", "serve"]}}.'
+            ),
+        }
     new_config, changed = _merge_redcon_entry(config, servers_key, _entry_for(target))
     if not changed:
         return {

--- a/tests/test_mcp_install.py
+++ b/tests/test_mcp_install.py
@@ -48,10 +48,21 @@ def test_install_preserves_existing_servers(tmp_path: Path):
     assert "redcon" in data["mcpServers"]
 
 
-def test_install_handles_malformed_json(tmp_path: Path):
-    """Install overwrites a malformed .mcp.json without crashing."""
+def test_install_refuses_to_overwrite_malformed_json(tmp_path: Path):
+    """An existing but unparseable config is preserved, not overwritten."""
     config_path = tmp_path / ".mcp.json"
     config_path.write_text("not json at all")
+    result = install_for_target("claude", tmp_path)
+    assert result["status"] == "failed"
+    assert "not overwriting" in result["message"]
+    # The user's file is left exactly as it was.
+    assert config_path.read_text() == "not json at all"
+
+
+def test_install_fills_empty_config_file(tmp_path: Path):
+    """An empty (whitespace-only) file has no content to lose, so install fills it."""
+    config_path = tmp_path / ".mcp.json"
+    config_path.write_text("   \n")
     result = install_for_target("claude", tmp_path)
     assert result["status"] == "installed"
     data = json.loads(config_path.read_text())
@@ -296,6 +307,25 @@ def test_install_zed_uses_context_servers_key(tmp_path: Path, monkeypatch: pytes
     assert entry["command"] == "redcon"
     assert entry["args"] == ["mcp", "serve"]
     assert entry["env"] == {}
+
+
+def test_install_zed_preserves_jsonc_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A Zed settings.json with comments (JSONC) is never clobbered.
+
+    Zed's settings.json routinely contains comments, so json.loads fails. The
+    installer must refuse rather than replace the user's whole config with just
+    the redcon entry.
+    """
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+    settings = tmp_path / "home" / ".config" / "zed" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    original = '{\n  // user settings\n  "theme": "One Dark",\n  "buffer_font_size": 15\n}\n'
+    settings.write_text(original)
+
+    result = install_for_target("zed", tmp_path)
+    assert result["status"] == "failed"
+    assert "not overwriting" in result["message"]
+    assert settings.read_text() == original
 
 
 def test_install_zed_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_mcp_install.py
+++ b/tests/test_mcp_install.py
@@ -269,11 +269,19 @@ def test_cline_settings_path_is_platform_specific(monkeypatch: pytest.MonkeyPatc
     from redcon.mcp.install import _cline_settings_path
 
     monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    # Compare path components, not string suffixes, so the assertion is
+    # independent of the host separator (the runner may be Windows).
     monkeypatch.setattr("redcon.mcp.install.sys.platform", "darwin")
-    assert "Application Support" in str(_cline_settings_path())
+    assert "Application Support" in _cline_settings_path().parts
     monkeypatch.setattr("redcon.mcp.install.sys.platform", "linux")
-    assert str(_cline_settings_path()).endswith(
-        "/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json"
+    assert _cline_settings_path().parts[-7:] == (
+        ".config",
+        "Code",
+        "User",
+        "globalStorage",
+        "saoudrizwan.claude-dev",
+        "settings",
+        "cline_mcp_settings.json",
     )
 
 

--- a/tests/test_mcp_install.py
+++ b/tests/test_mcp_install.py
@@ -240,6 +240,90 @@ def test_installed_path_reports_junie(tmp_path: Path, monkeypatch: pytest.Monkey
     assert installed_path("junie", tmp_path) == tmp_path / ".junie" / "mcp" / "mcp.json"
 
 
+def test_install_cline_writes_globalstorage_settings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Cline reads a standard mcpServers entry from its VS Code global storage."""
+    home = tmp_path / "home"
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.setattr("redcon.mcp.install.sys.platform", "linux")
+
+    result = install_for_target("cline", tmp_path)
+    assert result["status"] == "installed"
+    settings = (
+        home
+        / ".config"
+        / "Code"
+        / "User"
+        / "globalStorage"
+        / "saoudrizwan.claude-dev"
+        / "settings"
+        / "cline_mcp_settings.json"
+    )
+    data = json.loads(settings.read_text())
+    assert data["mcpServers"]["redcon"] == REDCON_ENTRY
+
+
+def test_cline_settings_path_is_platform_specific(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """The Cline settings path follows the VS Code layout for each OS."""
+    from redcon.mcp.install import _cline_settings_path
+
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("redcon.mcp.install.sys.platform", "darwin")
+    assert "Application Support" in str(_cline_settings_path())
+    monkeypatch.setattr("redcon.mcp.install.sys.platform", "linux")
+    assert str(_cline_settings_path()).endswith(
+        "/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json"
+    )
+
+
+def test_install_zed_uses_context_servers_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Zed config uses a 'context_servers' key with an env map."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+    result = install_for_target("zed", tmp_path)
+    assert result["status"] == "installed"
+    data = json.loads((tmp_path / "home" / ".config" / "zed" / "settings.json").read_text())
+    assert "mcpServers" not in data
+    entry = data["context_servers"]["redcon"]
+    assert entry["command"] == "redcon"
+    assert entry["args"] == ["mcp", "serve"]
+    assert entry["env"] == {}
+
+
+def test_install_zed_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A second Zed install is a no-op."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+    install_for_target("zed", tmp_path)
+    again = install_for_target("zed", tmp_path)
+    assert again["status"] == "up_to_date"
+
+
+def test_uninstall_cline_and_zed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Uninstall strips the redcon entry from Cline and Zed configs."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+    monkeypatch.setattr("redcon.mcp.install.sys.platform", "linux")
+    for target in ("cline", "zed"):
+        install_for_target(target, tmp_path)
+        result = uninstall_for_target(target, tmp_path)
+        assert result["status"] == "removed"
+        assert installed_path(target, tmp_path) is None
+
+
+def test_detect_targets_finds_cline_and_zed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A present Cline extension dir and ~/.config/zed add both targets."""
+    home = tmp_path / "home"
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    monkeypatch.setattr("redcon.mcp.install.sys.platform", "linux")
+    (home / ".config" / "Code" / "User" / "globalStorage" / "saoudrizwan.claude-dev").mkdir(
+        parents=True
+    )
+    (home / ".config" / "zed").mkdir(parents=True)
+
+    targets = detect_targets(tmp_path)
+    assert "cline" in targets
+    assert "zed" in targets
+
+
 def test_detect_targets_defaults_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Without detected agents only the default trio is targeted."""
     monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")


### PR DESCRIPTION
Make Cline and Zed first-class `redcon mcp install` targets. README already lists both under supported agents; this backs that with an installer rather than generic MCP compatibility.

## Config formats (verified against current docs)
**Cline** - standard `mcpServers` map, stdio `{command, args}`, but the file lives in VS Code global storage under the `saoudrizwan.claude-dev` extension, so the base path is per-OS:
- macOS: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
- Linux: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
- Windows: `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\settings\cline_mcp_settings.json`

Source: [Cline MCP overview](https://docs.cline.bot/mcp/mcp-overview).

**Zed** - different top-level key `context_servers`, and its documented custom-server shape carries an explicit `env` map: `{"command": "redcon", "args": ["mcp", "serve"], "env": {}}`. Path: `~/.config/zed/settings.json`. Confirmed against Zed’s own docs (`docs/src/ai/mcp.md` on `main`), which show no `source` field for custom servers.

Source: [Zed MCP docs](https://zed.dev/docs/ai/mcp).

## Changes
- `cline` and `zed` added to `DETECTED_TARGETS`, `_SERVERS_KEY`, `_target_paths` and `detect_targets` (registered only when their config location is present).
- New `_vscode_user_dir()` / `_cline_settings_path()` helpers compute the per-OS VS Code storage path; `_entry_for` grows a Zed branch for the `env` map.
- Install, uninstall, status and `installed_path` reuse the generic JSON path via the servers-key map.
- Docs: mcp-and-hooks.md and README detected-target lists.
- Tests: Cline global-storage write, per-OS path assertion (macOS + Linux), Zed `context_servers` shape, Zed idempotency, uninstall for both, detection.

No change to defaults for existing targets.