### PR TITLE
Add JSON Schemas and a validate command for artifacts

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -211,6 +211,19 @@ Render summary report from run artifact.
 ### `redcon diff <old-run.json> <new-run.json>`
 Compare two run artifacts and emit JSON + Markdown delta outputs.
 
+### `redcon validate <artifact.json> [--type run|diff|benchmark] [--json]`
+Validate a redcon JSON artifact against its published schema. The artifact
+type is inferred from the `command` field (`pack` -> run, `diff`, `benchmark`);
+`--type` overrides that. Exit code is `0` when valid and `1` when invalid or
+unrecognized, so it drops straight into CI. `--json` emits a machine-readable
+result (`{artifact, type, valid, errors:[{path, message}]}`).
+
+The versioned draft 2020-12 schemas ship in the package under
+`redcon/schemas/json/v1/` and cover, among other fields, each ranked file's
+`score_breakdown` and the run's `prompt_cache_key`. Validation uses a built-in
+zero-dependency checker; installing `redcon[validate]` swaps in `jsonschema`
+for full-spec coverage.
+
 ### `redcon pr-audit --repo <path> [--base <ref>] [--head <ref>]`
 Analyze a pull request diff directly from git and emit:
 - `<prefix>.json`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ tokenizers = ["tiktoken>=0.7"]
 redis = ["redis>=5.0"]
 gateway = ["fastapi>=0.110", "uvicorn[standard]>=0.29"]
 mcp = ["mcp>=1.0,<2.0"]
+# Optional full-spec JSON Schema validation for `redcon validate`. The core
+# ships a built-in checker covering the keywords the packaged schemas use, so
+# this extra is only needed for exhaustive draft 2020-12 coverage.
+validate = ["jsonschema>=4"]
 # Tree-sitter symbol extraction for redcon repo-map / improved file context.
 # We list per-language wheels because tree-sitter-language-pack still ships
 # broken wheels on Python 3.14 ARM (RECORD-only, no package payload).
@@ -66,6 +70,9 @@ redcon-gateway = "redcon.gateway.server:run_gateway"
 
 [tool.setuptools]
 include-package-data = true
+
+[tool.setuptools.package-data]
+"redcon.schemas" = ["json/v1/*.json"]
 
 [tool.setuptools.packages.find]
 # "redcon*" alone would also match hyphenated sibling directories

--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -1191,6 +1191,47 @@ def cmd_diff(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_validate(args: argparse.Namespace) -> int:
+    from redcon.validation import detect_artifact_type, validate_artifact
+
+    path = Path(args.artifact_json)
+    errors: list[dict[str, str]] = []
+    data = None
+    resolved_type = args.type
+
+    try:
+        data = _json_mod.loads(path.read_text(encoding="utf-8"))
+    except OSError as e:
+        errors = [{"path": "$", "message": f"cannot read file: {e}"}]
+    except _json_mod.JSONDecodeError as e:
+        errors = [{"path": "$", "message": f"invalid JSON: {e}"}]
+
+    if data is not None:
+        resolved_type = args.type or detect_artifact_type(data)
+        errors = [err.as_dict() for err in validate_artifact(data, args.type)]
+
+    valid = not errors
+    if args.json:
+        print(
+            _json_mod.dumps(
+                {
+                    "artifact": str(path),
+                    "type": resolved_type,
+                    "valid": valid,
+                    "errors": errors,
+                },
+                indent=2,
+            )
+        )
+    elif valid:
+        print(f"[OK] {path}: valid {resolved_type} artifact")
+    else:
+        print(f"[X] {path}: {len(errors)} error(s):")
+        for err in errors:
+            print(f"  {err['path']}: {err['message']}")
+    return 0 if valid else 1
+
+
 def cmd_pr_audit(args: argparse.Namespace) -> int:
     engine = RedconEngine(config_path=args.config)
     audit_data = engine.pr_audit(
@@ -3054,6 +3095,20 @@ def _register_reporting_commands(sub: argparse._SubParsersAction) -> None:
     diff.add_argument("new_run_json", help="Path to newer run JSON")
     diff.add_argument("--out-prefix", help="Output prefix for diff JSON/Markdown")
     diff.set_defaults(func=cmd_diff)
+
+    validate = sub.add_parser(
+        "validate", help="Validate a run, diff or benchmark JSON artifact against its schema"
+    )
+    validate.add_argument("artifact_json", help="Path to a redcon JSON artifact")
+    validate.add_argument(
+        "--type",
+        choices=["run", "diff", "benchmark"],
+        help="Override artifact-type detection (default: infer from the 'command' field).",
+    )
+    validate.add_argument(
+        "--json", action="store_true", help="Emit a machine-readable JSON result."
+    )
+    validate.set_defaults(func=cmd_validate)
 
     pr_audit = sub.add_parser("pr-audit", help="Analyze pull-request diffs for context growth")
     pr_audit.add_argument("--repo", default=".", help="Repository path")

--- a/redcon/schemas/json/v1/benchmark.schema.json
+++ b/redcon/schemas/json/v1/benchmark.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://redcon.dev/schemas/v1/benchmark.schema.json",
+  "title": "redcon benchmark artifact",
+  "description": "Artifact written by `redcon benchmark`. Identified by command == \"benchmark\".",
+  "type": "object",
+  "required": ["command", "task", "repo", "max_tokens", "strategies"],
+  "properties": {
+    "command": { "const": "benchmark" },
+    "task": { "type": "string" },
+    "repo": { "type": "string" },
+    "max_tokens": { "type": "integer", "minimum": 1 },
+    "top_files": { "type": "integer" },
+    "baseline_full_context_tokens": { "type": "integer" },
+    "scan_runtime_ms": { "type": "integer" },
+    "generated_at": { "type": "string" },
+    "failed_strategies": { "type": "array", "items": { "type": "string" } },
+    "strategies": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["strategy", "estimated_input_tokens"],
+        "properties": {
+          "strategy": { "type": "string" },
+          "description": { "type": "string" },
+          "estimated_input_tokens": { "type": "integer" },
+          "estimated_saved_tokens": { "type": "integer" },
+          "files_included": { "type": "array", "items": { "type": "string" } },
+          "files_skipped": { "type": "array", "items": { "type": "string" } },
+          "duplicate_reads_prevented": { "type": "integer" },
+          "quality_risk_estimate": { "type": "string" },
+          "cache_hits": { "type": "integer" },
+          "runtime_ms": { "type": "integer" }
+        }
+      }
+    }
+  }
+}

--- a/redcon/schemas/json/v1/diff.schema.json
+++ b/redcon/schemas/json/v1/diff.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://redcon.dev/schemas/v1/diff.schema.json",
+  "title": "redcon diff artifact",
+  "description": "Artifact written by `redcon diff old.json new.json`. Identified by command == \"diff\".",
+  "type": "object",
+  "required": [
+    "command",
+    "old_run",
+    "new_run",
+    "task_diff",
+    "context_diff",
+    "ranked_score_changes",
+    "budget_delta"
+  ],
+  "properties": {
+    "command": { "const": "diff" },
+    "old_run": { "type": "string" },
+    "new_run": { "type": "string" },
+    "task_diff": {
+      "type": "object",
+      "required": ["old_task", "new_task", "changed"],
+      "properties": {
+        "old_task": { "type": "string" },
+        "new_task": { "type": "string" },
+        "changed": { "type": "boolean" }
+      }
+    },
+    "context_diff": {
+      "type": "object",
+      "required": ["files_added", "files_removed", "added_count", "removed_count"],
+      "properties": {
+        "files_added": { "type": "array", "items": { "type": "string" } },
+        "files_removed": { "type": "array", "items": { "type": "string" } },
+        "added_count": { "type": "integer" },
+        "removed_count": { "type": "integer" }
+      }
+    },
+    "ranked_score_changes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "delta", "change_type"],
+        "properties": {
+          "path": { "type": "string" },
+          "old_score": { "type": ["number", "null"] },
+          "new_score": { "type": ["number", "null"] },
+          "delta": { "type": "number" },
+          "change_type": {
+            "type": "string",
+            "enum": ["added", "removed", "changed"]
+          }
+        }
+      }
+    },
+    "budget_delta": { "type": "object" }
+  }
+}

--- a/redcon/schemas/json/v1/run.schema.json
+++ b/redcon/schemas/json/v1/run.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://redcon.dev/schemas/v1/run.schema.json",
+  "title": "redcon run artifact",
+  "description": "Artifact written by `redcon pack` and mirrored to .redcon/runs/. Identified by command == \"pack\".",
+  "type": "object",
+  "required": [
+    "command",
+    "task",
+    "repo",
+    "max_tokens",
+    "ranked_files",
+    "compressed_context",
+    "files_included",
+    "files_skipped",
+    "budget",
+    "generated_at"
+  ],
+  "properties": {
+    "command": { "const": "pack" },
+    "task": { "type": "string" },
+    "repo": { "type": "string" },
+    "max_tokens": { "type": "integer", "minimum": 1 },
+    "generated_at": { "type": "string" },
+    "cache_hits": { "type": "integer" },
+    "context_baseline_tokens": { "type": "integer" },
+    "files_scanned": { "type": "integer" },
+    "compression_profile": { "type": "string" },
+    "prompt_cache_key": {
+      "type": "string",
+      "description": "Deterministic sha256 hex digest (16 chars) over the packed context."
+    },
+    "files_included": { "type": "array", "items": { "type": "string" } },
+    "files_skipped": { "type": "array", "items": { "type": "string" } },
+    "budget": {
+      "type": "object",
+      "required": ["max_tokens", "estimated_input_tokens"],
+      "properties": {
+        "max_tokens": { "type": "integer" },
+        "estimated_input_tokens": { "type": "integer" },
+        "estimated_saved_tokens": { "type": "integer" },
+        "utilization_pct": { "type": "number" },
+        "duplicate_reads_prevented": { "type": "integer" },
+        "quality_risk_estimate": { "type": "string" }
+      }
+    },
+    "ranked_files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "score"],
+        "properties": {
+          "path": { "type": "string" },
+          "score": { "type": "number" },
+          "heuristic_score": { "type": "number" },
+          "historical_score": { "type": "number" },
+          "line_count": { "type": "integer" },
+          "reasons": { "type": "array", "items": { "type": "string" } },
+          "score_breakdown": {
+            "type": "object",
+            "description": "Per-signal weighted contribution to the file score.",
+            "additionalProperties": { "type": "number" }
+          }
+        }
+      }
+    },
+    "compressed_context": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "text"],
+        "properties": {
+          "path": { "type": "string" },
+          "text": { "type": "string" },
+          "strategy": { "type": "string" },
+          "original_tokens": { "type": "integer" },
+          "compressed_tokens": { "type": "integer" }
+        }
+      }
+    }
+  }
+}

--- a/redcon/validation.py
+++ b/redcon/validation.py
@@ -1,0 +1,184 @@
+"""
+Validate redcon output artifacts against versioned JSON Schemas.
+
+redcon ships draft 2020-12 schemas for its three JSON artifacts - the
+``pack`` run report, the ``diff`` report and the ``benchmark`` report -
+under ``redcon/schemas/json/v1``. The artifact type is read from the
+``command`` field, the only discriminator the artifacts carry.
+
+The core stays dependency-free, so validation runs on a small built-in
+checker that covers exactly the JSON Schema keywords these schemas use.
+When ``jsonschema`` is installed it is used instead, for full-spec
+coverage. Either way the schemas are plain standard files that any
+external validator can consume.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from functools import cache
+from importlib import resources
+from typing import Any
+
+SCHEMA_VERSION = "v1"
+
+# Maps the artifact's ``command`` field to a schema name (and file stem).
+_COMMAND_TO_TYPE: dict[str, str] = {
+    "pack": "run",
+    "diff": "diff",
+    "benchmark": "benchmark",
+}
+
+ARTIFACT_TYPES = tuple(sorted(set(_COMMAND_TO_TYPE.values())))
+
+
+@dataclass(frozen=True)
+class ValidationError:
+    """A single schema violation, addressed by a JSON path like ``$.budget``."""
+
+    path: str
+    message: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {"path": self.path, "message": self.message}
+
+    def __str__(self) -> str:
+        return f"{self.path}: {self.message}"
+
+
+@cache
+def _load_schema(artifact_type: str) -> dict[str, Any]:
+    """Load a packaged schema by type, cached for the process lifetime."""
+    filename = f"{artifact_type}.schema.json"
+    resource = resources.files("redcon.schemas").joinpath("json", SCHEMA_VERSION, filename)
+    return json.loads(resource.read_text(encoding="utf-8"))
+
+
+def schema_for(artifact_type: str) -> dict[str, Any]:
+    """Return the JSON Schema dict for a known artifact type."""
+    if artifact_type not in ARTIFACT_TYPES:
+        raise ValueError(f"unknown artifact type: {artifact_type!r}")
+    return _load_schema(artifact_type)
+
+
+def detect_artifact_type(data: Any) -> str | None:
+    """Infer the artifact type from the ``command`` field, or None."""
+    if not isinstance(data, dict):
+        return None
+    return _COMMAND_TO_TYPE.get(data.get("command"))
+
+
+def validate_artifact(data: Any, artifact_type: str | None = None) -> list[ValidationError]:
+    """Validate a parsed artifact against its schema.
+
+    ``artifact_type`` overrides discriminator-based detection. Returns the
+    list of violations; an empty list means the artifact is valid.
+    """
+    if artifact_type is None:
+        artifact_type = detect_artifact_type(data)
+        if artifact_type is None:
+            return [
+                ValidationError(
+                    "$",
+                    "cannot determine artifact type: expected a 'command' field of "
+                    + ", ".join(repr(c) for c in sorted(_COMMAND_TO_TYPE)),
+                )
+            ]
+    schema = schema_for(artifact_type)
+    return _validate(data, schema)
+
+
+def _validate(data: Any, schema: dict[str, Any]) -> list[ValidationError]:
+    """Dispatch to jsonschema when available, else the built-in checker."""
+    try:
+        import jsonschema  # noqa: PLC0415
+    except ImportError:
+        errors: list[ValidationError] = []
+        _check(data, schema, "$", errors)
+        return errors
+    validator = jsonschema.Draft202012Validator(schema)
+    return [
+        ValidationError(_jsonschema_path(err), err.message)
+        for err in sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path))
+    ]
+
+
+def _jsonschema_path(err: Any) -> str:
+    parts = ["$"]
+    for token in err.absolute_path:
+        if isinstance(token, int):
+            parts.append(f"[{token}]")
+        else:
+            parts.append(f".{token}")
+    return "".join(parts)
+
+
+# --- Built-in checker (zero-dependency subset of draft 2020-12) -----------
+#
+# Supports only the keywords the packaged schemas use: type, const, enum,
+# required, properties, additionalProperties, items, minimum, maximum.
+
+_TYPE_CHECKS = {
+    "object": lambda v: isinstance(v, dict),
+    "array": lambda v: isinstance(v, list),
+    "string": lambda v: isinstance(v, str),
+    "boolean": lambda v: isinstance(v, bool),
+    "null": lambda v: v is None,
+    "number": lambda v: isinstance(v, (int, float)) and not isinstance(v, bool),
+    "integer": lambda v: isinstance(v, int) and not isinstance(v, bool),
+}
+
+
+def _matches_type(value: Any, type_spec: Any) -> bool:
+    types = type_spec if isinstance(type_spec, list) else [type_spec]
+    return any(_TYPE_CHECKS.get(t, lambda _v: True)(value) for t in types)
+
+
+def _child_path(path: str, key: Any) -> str:
+    return f"{path}[{key}]" if isinstance(key, int) else f"{path}.{key}"
+
+
+def _check(value: Any, schema: dict[str, Any], path: str, errors: list[ValidationError]) -> None:
+    if "const" in schema and value != schema["const"]:
+        errors.append(ValidationError(path, f"expected constant {schema['const']!r}"))
+    if "enum" in schema and value not in schema["enum"]:
+        errors.append(ValidationError(path, f"value not in {schema['enum']!r}"))
+
+    if "type" in schema and not _matches_type(value, schema["type"]):
+        errors.append(ValidationError(path, f"expected type {schema['type']!r}"))
+        # A type mismatch makes nested object/array checks meaningless.
+        return
+
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if "minimum" in schema and value < schema["minimum"]:
+            errors.append(ValidationError(path, f"must be >= {schema['minimum']}"))
+        if "maximum" in schema and value > schema["maximum"]:
+            errors.append(ValidationError(path, f"must be <= {schema['maximum']}"))
+
+    if isinstance(value, dict):
+        _check_object(value, schema, path, errors)
+    elif isinstance(value, list) and "items" in schema:
+        for i, item in enumerate(value):
+            _check(item, schema["items"], _child_path(path, i), errors)
+
+
+def _check_object(
+    value: dict[str, Any], schema: dict[str, Any], path: str, errors: list[ValidationError]
+) -> None:
+    for key in schema.get("required", []):
+        if key not in value:
+            errors.append(ValidationError(path, f"missing required property {key!r}"))
+
+    properties = schema.get("properties", {})
+    for key, sub_value in value.items():
+        if key in properties:
+            _check(sub_value, properties[key], _child_path(path, key), errors)
+            continue
+        additional = schema.get("additionalProperties", True)
+        if additional is False:
+            errors.append(
+                ValidationError(_child_path(path, key), "additional property not allowed")
+            )
+        elif isinstance(additional, dict):
+            _check(sub_value, additional, _child_path(path, key), errors)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,118 @@
+"""Artifact schema validation.
+
+redcon ships versioned draft 2020-12 schemas for its pack (run), diff and
+benchmark JSON artifacts, and `redcon validate` checks an artifact against
+the schema chosen by its `command` field. Validation runs on a built-in
+zero-dependency checker (jsonschema is used instead when installed).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from redcon.core import pipeline
+from redcon.stages.workflow import as_json_dict
+from redcon.validation import (
+    ARTIFACT_TYPES,
+    detect_artifact_type,
+    schema_for,
+    validate_artifact,
+)
+
+_SAMPLES = Path(__file__).resolve().parent.parent / "examples" / "sample-outputs"
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_all_schemas_load_and_are_objects() -> None:
+    for artifact_type in ARTIFACT_TYPES:
+        schema = schema_for(artifact_type)
+        assert schema["type"] == "object"
+        assert schema["$schema"].endswith("2020-12/schema")
+
+
+def test_detect_artifact_type() -> None:
+    assert detect_artifact_type({"command": "pack"}) == "run"
+    assert detect_artifact_type({"command": "diff"}) == "diff"
+    assert detect_artifact_type({"command": "benchmark"}) == "benchmark"
+    assert detect_artifact_type({"command": "plan"}) is None
+    assert detect_artifact_type(["not", "a", "dict"]) is None
+
+
+def test_real_run_pack_artifact_validates(tmp_path: Path) -> None:
+    """A run.json produced by run_pack passes its own schema."""
+    _write(tmp_path / "auth" / "login.py", "def login(token):\n    return validate(token)\n")
+    _write(tmp_path / "auth" / "validate.py", "def validate(token):\n    return bool(token)\n")
+    report = pipeline.run_pack("fix the login auth flow", tmp_path, max_tokens=5000)
+    data = as_json_dict(report)
+
+    assert detect_artifact_type(data) == "run"
+    assert data["ranked_files"][0]["score_breakdown"]  # the feature under contract
+    assert validate_artifact(data) == []
+
+
+def test_committed_benchmark_and_diff_samples_validate() -> None:
+    """The repo's own sample artifacts satisfy the schemas."""
+    benchmark = json.loads((_SAMPLES / "risky-auth-benchmark.json").read_text())
+    assert validate_artifact(benchmark) == []
+
+    diff = json.loads((_SAMPLES / "risky-auth-vs-language-aware.diff.json").read_text())
+    assert validate_artifact(diff) == []
+
+
+def test_missing_required_field_is_reported() -> None:
+    data = {"command": "pack", "task": "t", "repo": "."}  # missing most required keys
+    errors = validate_artifact(data)
+    messages = [e.message for e in errors]
+    assert all(e.path == "$" for e in errors)
+    assert any("ranked_files" in m for m in messages)
+    assert any("budget" in m for m in messages)
+
+
+def test_wrong_type_is_reported() -> None:
+    benchmark = json.loads((_SAMPLES / "risky-auth-benchmark.json").read_text())
+    benchmark["strategies"] = "not-a-list"
+    errors = validate_artifact(benchmark)
+    assert any(e.path == "$.strategies" for e in errors)
+
+
+def test_score_breakdown_values_must_be_numbers(tmp_path: Path) -> None:
+    _write(tmp_path / "a.py", "def a():\n    return 1\n")
+    data = as_json_dict(pipeline.run_pack("do a thing", tmp_path, max_tokens=2000))
+    data["ranked_files"][0]["score_breakdown"]["path_keyword"] = "high"
+    errors = validate_artifact(data)
+    assert any("score_breakdown" in e.path for e in errors)
+
+
+def test_enum_violation_is_reported() -> None:
+    diff = json.loads((_SAMPLES / "risky-auth-vs-language-aware.diff.json").read_text())
+    diff["ranked_score_changes"][0]["change_type"] = "mutated"
+    errors = validate_artifact(diff)
+    assert any("ranked_score_changes[0].change_type" in e.path for e in errors)
+
+
+def test_undetectable_type_is_a_single_error() -> None:
+    errors = validate_artifact({"not": "an artifact"})
+    assert len(errors) == 1
+    assert errors[0].path == "$"
+    assert "artifact type" in errors[0].message
+
+
+def test_type_override_bypasses_detection() -> None:
+    benchmark = json.loads((_SAMPLES / "risky-auth-benchmark.json").read_text())
+    # Force the wrong schema: a benchmark artifact is not a valid run artifact.
+    errors = validate_artifact(benchmark, artifact_type="run")
+    assert errors  # command const "benchmark" != "pack", plus missing run keys
+
+
+def test_jsonschema_backend_parity_when_available(tmp_path: Path) -> None:
+    """If jsonschema is installed, it agrees the sample artifacts are valid."""
+    pytest.importorskip("jsonschema")
+    benchmark = json.loads((_SAMPLES / "risky-auth-benchmark.json").read_text())
+    assert validate_artifact(benchmark) == []


### PR DESCRIPTION
Add versioned JSON Schemas for redcon output artifacts and a `redcon validate` command (launch backlog issues 1 and 2).

## Schemas
Draft 2020-12 schemas under `redcon/schemas/json/v1/`, one per artifact type:
- `run.schema.json` (`command == "pack"`) - covers `ranked_files[].score_breakdown` (object of numbers) and `prompt_cache_key` (string), plus the `budget` block.
- `diff.schema.json` (`command == "diff"`).
- `benchmark.schema.json` (`command == "benchmark"`).

They require each artifact’s stable identity core and type-check the rest, so both freshly generated artifacts and the repo’s committed sample-outputs validate. Packaged into the wheel via `[tool.setuptools.package-data]` (verified: the three files appear in the built wheel).

## `redcon validate <artifact.json> [--type ...] [--json]`
Picks the schema from the `command` discriminator (overridable with `--type`), exit `0` valid / `1` invalid or unrecognized, and `--json` emits `{artifact, type, valid, errors:[{path, message}]}` for CI.

## Dependency decision (as requested)
The core has **zero runtime dependencies**, and a contract-checker that can’t run without an extra would undercut that. So validation runs on a **small built-in checker** vendored in `redcon/validation.py`, covering exactly the keywords these schemas use (type, const, enum, required, properties, additionalProperties, items, minimum/maximum). When `jsonschema` is installed (new optional `redcon[validate]` extra) it is used instead for full-spec coverage. Both paths are exercised in tests. I recommend keeping the vendored default; the extra is a pure enhancement, no new hard dependency.

## Tests
`tests/test_validation.py`: schemas load, a **real `run_pack` run.json validates**, committed benchmark and diff samples validate, missing-required / wrong-type / enum / non-numeric-`score_breakdown` failures are reported with JSON paths, type detection and `--type` override, and a jsonschema-backend parity test (skipped when not installed).

## Docs
`docs/cli.md` gains a `redcon validate` entry.

Independent of #219/#220 - touches no installer code.