### PR TITLE
Add benchmark baseline comparison and CSV export

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -272,6 +272,18 @@ Compare deterministic strategies:
 Benchmark artifacts also record the active token-estimator backend and a small estimator comparison
 on local sample text from the run.
 
+`--baseline <earlier-benchmark.json>` compares the run against a previous benchmark
+artifact. It matches strategies by name and reports the per-strategy delta (input
+tokens, saved tokens, runtime) plus added/removed strategies, using the same metric
+definitions the benchmark already records. The delta lands in the JSON under
+`baseline_comparison`, in the Markdown as a `Baseline Comparison` table, and in the
+run summary. Strategy order in the comparison is sorted, so output is deterministic.
+
+`--csv` additionally writes `<prefix>.csv` with one row per strategy (input/saved
+tokens, file counts, cache hits, quality risk, runtime). With `--baseline`, the CSV
+gains baseline and delta columns. Without the flag no CSV is written; defaults are
+unchanged.
+
 `benchmark` also accepts `--workspace <workspace.toml>` for multi-repo/local-package runs.
 
 ### `redcon heatmap [<history> ...] [--limit N] [--out-prefix <path>]`

--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import csv as _csv_mod
 import json as _json_mod
 import logging
 import sys
@@ -21,6 +22,7 @@ from redcon.core.render import (
     render_advise_markdown,
     render_agent_plan_markdown,
     render_agent_simulation_markdown,
+    render_benchmark_comparison_markdown,
     render_benchmark_markdown,
     render_context_dataset_markdown,
     render_dataset_markdown,
@@ -1253,13 +1255,42 @@ def cmd_benchmark(args: argparse.Namespace) -> int:
         max_tokens=args.max_tokens,
         top_files=args.top_files,
     )
+    comparison = None
+    if args.baseline:
+        baseline_path = Path(args.baseline)
+        try:
+            baseline_data = _json_mod.loads(baseline_path.read_text(encoding="utf-8"))
+        except (OSError, _json_mod.JSONDecodeError) as e:
+            print(f"Error: cannot read baseline {baseline_path}: {e}")
+            return 1
+        if not (isinstance(baseline_data, dict) and baseline_data.get("command") == "benchmark"):
+            print(f"Error: baseline {baseline_path} is not a benchmark artifact")
+            return 1
+        from redcon.core.benchmark import compare_benchmarks
+
+        comparison = compare_benchmarks(baseline_data, benchmark_data)
+        benchmark_data["baseline_comparison"] = comparison
+
     markdown = render_benchmark_markdown(benchmark_data)
+    if comparison is not None:
+        markdown = markdown.rstrip("\n") + "\n\n" + render_benchmark_comparison_markdown(comparison)
 
     base = args.out_prefix or f"redcon-benchmark-{_base_name(args.task)}"
     json_path = Path(f"{base}.json")
     md_path = Path(f"{base}.md")
     write_json(json_path, benchmark_data)
     md_path.write_text(markdown, encoding="utf-8")
+
+    csv_path = None
+    if args.csv:
+        from redcon.core.benchmark import benchmark_csv_rows
+
+        header, rows = benchmark_csv_rows(benchmark_data, comparison)
+        csv_path = Path(f"{base}.csv")
+        with csv_path.open("w", encoding="utf-8", newline="") as fh:
+            writer = _csv_mod.writer(fh)
+            writer.writerow(header)
+            writer.writerows(rows)
 
     print("Benchmark summary:")
     model_profile = benchmark_data.get("model_profile", {})
@@ -1292,8 +1323,19 @@ def cmd_benchmark(args: argparse.Namespace) -> int:
             f"risk={strategy.get('quality_risk_estimate')} "
             f"runtime_ms={strategy.get('runtime_ms')}"
         )
+    if comparison is not None:
+        print(f"Baseline comparison (vs {args.baseline}):")
+        for row in comparison.get("strategies", []):
+            input_delta = row.get("estimated_input_tokens", {}).get("delta")
+            saved_delta = row.get("estimated_saved_tokens", {}).get("delta")
+            print(
+                f"- {row.get('strategy')} [{row.get('status')}]: "
+                f"input_delta={input_delta} saved_delta={saved_delta}"
+            )
     print(f"Wrote benchmark JSON: {json_path}")
     print(f"Wrote benchmark Markdown: {md_path}")
+    if csv_path is not None:
+        print(f"Wrote benchmark CSV: {csv_path}")
     return 0
 
 
@@ -3100,6 +3142,15 @@ def _register_reporting_commands(sub: argparse._SubParsersAction) -> None:
         "--config", help="Optional path to config TOML (default: <repo>/redcon.toml)."
     )
     benchmark.add_argument("--out-prefix", help="Output file prefix for benchmark JSON/Markdown")
+    benchmark.add_argument(
+        "--baseline",
+        help="Path to an earlier benchmark JSON to compare against; adds a delta summary.",
+    )
+    benchmark.add_argument(
+        "--csv",
+        action="store_true",
+        help="Also write a per-strategy CSV artifact alongside the JSON/Markdown.",
+    )
     benchmark.set_defaults(func=cmd_benchmark)
 
 

--- a/redcon/core/benchmark.py
+++ b/redcon/core/benchmark.py
@@ -1,13 +1,13 @@
-from __future__ import annotations
-
 """Benchmark mode for comparing deterministic context packing strategies."""
 
+from __future__ import annotations
+
 import logging
+import time
+import traceback
 from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
-import time
-import traceback
 from typing import Any
 
 from redcon.config import RedconConfig, WorkspaceDefinition, load_config
@@ -17,9 +17,146 @@ from redcon.core.tokens import compare_builtin_token_estimators
 from redcon.plugins import ResolvedPlugins, resolve_plugins
 from redcon.schemas.models import DEFAULT_TOP_FILES
 from redcon.stages.workflow import run_scan_stage, run_scan_workspace_stage, run_score_stage
-from redcon.telemetry import NoOpTelemetrySink, TelemetrySession, TelemetrySink, build_telemetry_sink
+from redcon.telemetry import (
+    NoOpTelemetrySink,
+    TelemetrySession,
+    TelemetrySink,
+    build_telemetry_sink,
+)
 
 logger = logging.getLogger(__name__)
+
+# Per-strategy numeric metrics compared against a baseline benchmark and
+# emitted as CSV columns. Order is fixed for deterministic output.
+_COMPARED_METRICS = ("estimated_input_tokens", "estimated_saved_tokens", "runtime_ms")
+
+_CSV_BASE_COLUMNS = (
+    "strategy",
+    "estimated_input_tokens",
+    "estimated_saved_tokens",
+    "files_included",
+    "files_skipped",
+    "duplicate_reads_prevented",
+    "cache_hits",
+    "quality_risk_estimate",
+    "runtime_ms",
+)
+
+
+def _strategies_by_name(data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {s.get("strategy", ""): s for s in data.get("strategies", []) if isinstance(s, dict)}
+
+
+def compare_benchmarks(baseline: dict[str, Any], current: dict[str, Any]) -> dict[str, Any]:
+    """Compute a deterministic delta of a current benchmark against a baseline.
+
+    Both arguments are benchmark artifacts (``command == "benchmark"``).
+    Strategies are matched by name; each shared strategy reports the numeric
+    delta (current minus baseline) for the standard metrics, plus the
+    file-count and quality-risk change. Strategies present in only one run are
+    flagged ``added`` or ``removed``. The metric definitions are exactly those
+    the benchmark already records, so this adds no new measurement.
+    """
+    base_by_name = _strategies_by_name(baseline)
+    cur_by_name = _strategies_by_name(current)
+
+    strategy_rows: list[dict[str, Any]] = []
+    for name in sorted(set(base_by_name) | set(cur_by_name)):
+        base = base_by_name.get(name)
+        cur = cur_by_name.get(name)
+        if base is None:
+            status = "added"
+        elif cur is None:
+            status = "removed"
+        else:
+            status = "compared"
+
+        row: dict[str, Any] = {"strategy": name, "status": status}
+        for metric in _COMPARED_METRICS:
+            b = base.get(metric) if base else None
+            c = cur.get(metric) if cur else None
+            row[metric] = {
+                "baseline": b,
+                "current": c,
+                "delta": (c - b)
+                if isinstance(b, (int, float)) and isinstance(c, (int, float))
+                else None,
+            }
+        b_files = len(base.get("files_included", [])) if base else None
+        c_files = len(cur.get("files_included", [])) if cur else None
+        row["files_included"] = {
+            "baseline": b_files,
+            "current": c_files,
+            "delta": (c_files - b_files) if b_files is not None and c_files is not None else None,
+        }
+        row["quality_risk_estimate"] = {
+            "baseline": base.get("quality_risk_estimate") if base else None,
+            "current": cur.get("quality_risk_estimate") if cur else None,
+        }
+        strategy_rows.append(row)
+
+    base_full = baseline.get("baseline_full_context_tokens")
+    cur_full = current.get("baseline_full_context_tokens")
+    return {
+        "baseline_task": baseline.get("task"),
+        "baseline_generated_at": baseline.get("generated_at"),
+        "baseline_full_context_tokens": {
+            "baseline": base_full,
+            "current": cur_full,
+            "delta": (cur_full - base_full)
+            if isinstance(base_full, (int, float)) and isinstance(cur_full, (int, float))
+            else None,
+        },
+        "strategies": strategy_rows,
+    }
+
+
+def benchmark_csv_rows(
+    data: dict[str, Any], comparison: dict[str, Any] | None = None
+) -> tuple[list[str], list[list[Any]]]:
+    """Build (header, rows) for a benchmark CSV, one row per strategy.
+
+    When ``comparison`` is provided, baseline and delta columns for the
+    standard metrics are appended. Pure and deterministic.
+    """
+    header = list(_CSV_BASE_COLUMNS)
+    delta_by_name: dict[str, dict[str, Any]] = {}
+    if comparison is not None:
+        header += [
+            "baseline_estimated_input_tokens",
+            "estimated_input_tokens_delta",
+            "estimated_saved_tokens_delta",
+            "runtime_ms_delta",
+        ]
+        delta_by_name = {r["strategy"]: r for r in comparison.get("strategies", [])}
+
+    rows: list[list[Any]] = []
+    for strategy in data.get("strategies", []):
+        name = strategy.get("strategy", "")
+        row: list[Any] = [
+            name,
+            strategy.get("estimated_input_tokens"),
+            strategy.get("estimated_saved_tokens"),
+            len(strategy.get("files_included", [])),
+            len(strategy.get("files_skipped", [])),
+            strategy.get("duplicate_reads_prevented"),
+            strategy.get("cache_hits"),
+            strategy.get("quality_risk_estimate"),
+            strategy.get("runtime_ms"),
+        ]
+        if comparison is not None:
+            delta = delta_by_name.get(name, {})
+            input_metric = delta.get("estimated_input_tokens", {})
+            saved_metric = delta.get("estimated_saved_tokens", {})
+            runtime_metric = delta.get("runtime_ms", {})
+            row += [
+                input_metric.get("baseline"),
+                input_metric.get("delta"),
+                saved_metric.get("delta"),
+                runtime_metric.get("delta"),
+            ]
+        rows.append(row)
+    return header, rows
 
 
 def _risk_from_coverage(input_tokens: int, baseline_tokens: int) -> str:
@@ -64,8 +201,18 @@ def run_benchmark(
 ) -> dict[str, Any]:
     """Run benchmark strategies and return JSON-serializable report."""
 
-    cfg = config if config is not None else (workspace.config if workspace is not None else load_config(repo, config_path=config_path))
-    prepared_cfg, model_profile = prepare_config_for_model_profile(cfg, requested_max_tokens=max_tokens)
+    cfg = (
+        config
+        if config is not None
+        else (
+            workspace.config
+            if workspace is not None
+            else load_config(repo, config_path=config_path)
+        )
+    )
+    prepared_cfg, model_profile = prepare_config_for_model_profile(
+        cfg, requested_max_tokens=max_tokens
+    )
     resolved_plugins = resolve_plugins(prepared_cfg)
     effective_max_tokens = prepared_cfg.budget.max_tokens
     effective_top_files = top_files if top_files is not None else prepared_cfg.budget.top_files
@@ -83,7 +230,9 @@ def run_benchmark(
             "repo": target_repo,
         },
     )
-    telemetry_top_files = effective_top_files if effective_top_files is not None else DEFAULT_TOP_FILES
+    telemetry_top_files = (
+        effective_top_files if effective_top_files is not None else DEFAULT_TOP_FILES
+    )
     telemetry.emit(
         "run_started",
         max_tokens=effective_max_tokens,
@@ -149,7 +298,9 @@ def run_benchmark(
             }
         )
     except Exception:
-        logger.warning("benchmark: strategy naive_full_context failed, skipping:\n%s", traceback.format_exc())
+        logger.warning(
+            "benchmark: strategy naive_full_context failed, skipping:\n%s", traceback.format_exc()
+        )
         failed_strategies.append("naive_full_context")
 
     # -- Strategy 2/4: top_k_selection --
@@ -169,14 +320,18 @@ def run_benchmark(
                 "files_included": topk_included,
                 "files_skipped": topk_skipped,
                 "duplicate_reads_prevented": 0,
-                "quality_risk_estimate": _risk_from_coverage(topk_input_tokens, baseline_total_tokens),
+                "quality_risk_estimate": _risk_from_coverage(
+                    topk_input_tokens, baseline_total_tokens
+                ),
                 "cache_hits": 0,
                 "runtime_ms": _round_runtime_ms(topk_start, topk_end),
                 "notes": f"top_files={effective_top_files}",
             }
         )
     except Exception:
-        logger.warning("benchmark: strategy top_k_selection failed, skipping:\n%s", traceback.format_exc())
+        logger.warning(
+            "benchmark: strategy top_k_selection failed, skipping:\n%s", traceback.format_exc()
+        )
         failed_strategies.append("top_k_selection")
 
     # -- Strategy 3/4: compressed_pack --
@@ -209,14 +364,18 @@ def run_benchmark(
                 "estimated_saved_tokens": compressed_saved_tokens,
                 "files_included": list(packed_run.get("files_included", [])),
                 "files_skipped": list(packed_run.get("files_skipped", [])),
-                "duplicate_reads_prevented": int(pack_budget.get("duplicate_reads_prevented", 0) or 0),
+                "duplicate_reads_prevented": int(
+                    pack_budget.get("duplicate_reads_prevented", 0) or 0
+                ),
                 "quality_risk_estimate": str(pack_budget.get("quality_risk_estimate", "unknown")),
                 "cache_hits": int(packed_run.get("cache_hits", 0) or 0),
                 "runtime_ms": _round_runtime_ms(pack_start, pack_end),
             }
         )
     except Exception:
-        logger.warning("benchmark: strategy compressed_pack failed, skipping:\n%s", traceback.format_exc())
+        logger.warning(
+            "benchmark: strategy compressed_pack failed, skipping:\n%s", traceback.format_exc()
+        )
         failed_strategies.append("compressed_pack")
 
     # -- Strategy 4/4: cache_assisted_pack --
@@ -248,7 +407,9 @@ def run_benchmark(
                 "estimated_saved_tokens": cache_saved_tokens,
                 "files_included": list(cache_run.get("files_included", [])),
                 "files_skipped": list(cache_run.get("files_skipped", [])),
-                "duplicate_reads_prevented": int(cache_budget.get("duplicate_reads_prevented", 0) or 0),
+                "duplicate_reads_prevented": int(
+                    cache_budget.get("duplicate_reads_prevented", 0) or 0
+                ),
                 "quality_risk_estimate": str(cache_budget.get("quality_risk_estimate", "unknown")),
                 "cache_hits": int(cache_run.get("cache_hits", 0) or 0),
                 "runtime_ms": _round_runtime_ms(cache_start, cache_end),
@@ -256,7 +417,9 @@ def run_benchmark(
             }
         )
     except Exception:
-        logger.warning("benchmark: strategy cache_assisted_pack failed, skipping:\n%s", traceback.format_exc())
+        logger.warning(
+            "benchmark: strategy cache_assisted_pack failed, skipping:\n%s", traceback.format_exc()
+        )
         failed_strategies.append("cache_assisted_pack")
 
     estimator_samples: list[dict[str, Any]] = compare_builtin_token_estimators(

--- a/redcon/core/render.py
+++ b/redcon/core/render.py
@@ -1270,6 +1270,56 @@ def render_benchmark_markdown(data: dict) -> str:
     return "\n".join(lines)
 
 
+def _fmt_signed(value: object) -> str:
+    """Format a numeric delta with an explicit sign, or '-' when unknown."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return "-"
+    return f"+{value}" if value > 0 else str(value)
+
+
+def render_benchmark_comparison_markdown(comparison: dict) -> str:
+    """Render a benchmark-vs-baseline delta to Markdown."""
+    full = comparison.get("baseline_full_context_tokens", {})
+    lines = [
+        "## Baseline Comparison",
+        "",
+        f"Baseline task: {comparison.get('baseline_task', '')}",
+        f"Baseline generated at: {comparison.get('baseline_generated_at', '')}",
+        f"Baseline full-context tokens: {full.get('baseline')} "
+        f"-> {full.get('current')} ({_fmt_signed(full.get('delta'))})",
+        "",
+    ]
+    rows = []
+    for row in comparison.get("strategies", []):
+        input_metric = row.get("estimated_input_tokens", {})
+        saved_metric = row.get("estimated_saved_tokens", {})
+        runtime_metric = row.get("runtime_ms", {})
+        rows.append(
+            [
+                row.get("strategy", ""),
+                row.get("status", ""),
+                _fmt_signed(input_metric.get("delta")),
+                _fmt_signed(saved_metric.get("delta")),
+                _fmt_signed(runtime_metric.get("delta")),
+            ]
+        )
+    lines.extend(
+        md_table(
+            [
+                "Strategy",
+                "Status",
+                "Input Tokens Delta",
+                "Saved Tokens Delta",
+                "Runtime (ms) Delta",
+            ],
+            rows,
+            align="llrrr",
+        )
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
 def render_profile_markdown(data: dict) -> str:
     """Render a token savings profile artifact to Markdown."""
 

--- a/tests/test_benchmark_compare.py
+++ b/tests/test_benchmark_compare.py
@@ -1,0 +1,142 @@
+"""Benchmark baseline comparison and CSV export.
+
+`redcon benchmark --baseline prior.json` adds a deterministic per-strategy
+delta against an earlier benchmark, and `--csv` writes a per-strategy CSV
+alongside the JSON/Markdown. Defaults (no flags) are unchanged.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+from redcon.cli import build_parser
+from redcon.core.benchmark import benchmark_csv_rows, compare_benchmarks
+from redcon.core.render import render_benchmark_comparison_markdown
+
+
+def _bench(strategies: list[dict], full_tokens: int = 1000) -> dict:
+    return {
+        "command": "benchmark",
+        "task": "demo",
+        "repo": ".",
+        "max_tokens": 5000,
+        "baseline_full_context_tokens": full_tokens,
+        "generated_at": "2026-01-01T00:00:00+00:00",
+        "strategies": strategies,
+    }
+
+
+def _strategy(name: str, inp: int, saved: int, runtime: int, files: int = 2) -> dict:
+    return {
+        "strategy": name,
+        "estimated_input_tokens": inp,
+        "estimated_saved_tokens": saved,
+        "runtime_ms": runtime,
+        "files_included": [f"f{i}.py" for i in range(files)],
+        "files_skipped": [],
+        "duplicate_reads_prevented": 0,
+        "cache_hits": 0,
+        "quality_risk_estimate": "low",
+    }
+
+
+def test_compare_benchmarks_computes_deltas() -> None:
+    baseline = _bench([_strategy("compressed_pack", 400, 600, 30)], full_tokens=1000)
+    current = _bench([_strategy("compressed_pack", 300, 700, 25)], full_tokens=900)
+    comp = compare_benchmarks(baseline, current)
+
+    assert comp["baseline_full_context_tokens"]["delta"] == -100
+    row = comp["strategies"][0]
+    assert row["status"] == "compared"
+    assert row["estimated_input_tokens"] == {"baseline": 400, "current": 300, "delta": -100}
+    assert row["estimated_saved_tokens"]["delta"] == 100
+    assert row["runtime_ms"]["delta"] == -5
+
+
+def test_compare_flags_added_and_removed_strategies() -> None:
+    baseline = _bench([_strategy("only_old", 100, 0, 10)])
+    current = _bench([_strategy("only_new", 200, 0, 20)])
+    comp = compare_benchmarks(baseline, current)
+    by_name = {r["strategy"]: r for r in comp["strategies"]}
+    assert by_name["only_old"]["status"] == "removed"
+    assert by_name["only_new"]["status"] == "added"
+    # A strategy in only one run has no numeric delta.
+    assert by_name["only_new"]["estimated_input_tokens"]["delta"] is None
+
+
+def test_compare_is_deterministic() -> None:
+    baseline = _bench([_strategy("b", 400, 600, 30), _strategy("a", 100, 200, 10)])
+    current = _bench([_strategy("a", 90, 210, 9), _strategy("b", 380, 620, 28)])
+    first = compare_benchmarks(baseline, current)
+    second = compare_benchmarks(baseline, current)
+    assert first == second
+    # Strategies are emitted in a stable sorted order regardless of input order.
+    assert [r["strategy"] for r in first["strategies"]] == ["a", "b"]
+
+
+def test_csv_rows_without_comparison() -> None:
+    data = _bench([_strategy("compressed_pack", 300, 700, 25, files=3)])
+    header, rows = benchmark_csv_rows(data)
+    assert header[0] == "strategy"
+    assert "baseline_estimated_input_tokens" not in header
+    assert rows[0][0] == "compressed_pack"
+    assert rows[0][header.index("estimated_input_tokens")] == 300
+    assert rows[0][header.index("files_included")] == 3
+
+
+def test_csv_rows_with_comparison_add_delta_columns() -> None:
+    baseline = _bench([_strategy("compressed_pack", 400, 600, 30)])
+    current = _bench([_strategy("compressed_pack", 300, 700, 25)])
+    comp = compare_benchmarks(baseline, current)
+    header, rows = benchmark_csv_rows(current, comp)
+    assert "estimated_input_tokens_delta" in header
+    assert rows[0][header.index("baseline_estimated_input_tokens")] == 400
+    assert rows[0][header.index("estimated_input_tokens_delta")] == -100
+    assert rows[0][header.index("estimated_saved_tokens_delta")] == 100
+
+
+def test_comparison_markdown_has_section_and_signed_deltas() -> None:
+    baseline = _bench([_strategy("compressed_pack", 400, 600, 30)])
+    current = _bench([_strategy("compressed_pack", 300, 700, 25)])
+    md = render_benchmark_comparison_markdown(compare_benchmarks(baseline, current))
+    assert "## Baseline Comparison" in md
+    assert "+100" in md  # saved-tokens delta rendered with sign
+    assert "-100" in md  # input-tokens delta
+
+
+def _run_benchmark(tmp_path: Path, out_prefix: Path, extra: list[str]) -> int:
+    (tmp_path / "auth.py").write_text("def login(token):\n    return bool(token)\n")
+    parser = build_parser()
+    args = parser.parse_args(
+        ["benchmark", "make auth safer", "--repo", str(tmp_path), "--out-prefix", str(out_prefix)]
+        + extra
+    )
+    return int(args.func(args))
+
+
+def test_cli_benchmark_baseline_and_csv_end_to_end(tmp_path: Path) -> None:
+    first = tmp_path / "first"
+    assert _run_benchmark(tmp_path, first, []) == 0
+    assert not first.with_suffix(".csv").exists()  # csv is opt-in
+
+    second = tmp_path / "second"
+    rc = _run_benchmark(tmp_path, second, ["--baseline", str(first) + ".json", "--csv"])
+    assert rc == 0
+
+    result = json.loads((second.with_suffix(".json")).read_text())
+    assert "baseline_comparison" in result
+
+    with (second.with_suffix(".csv")).open() as fh:
+        table = list(csv.reader(fh))
+    assert table[0][0] == "strategy"
+    assert "estimated_input_tokens_delta" in table[0]
+    assert len(table) > 1
+
+
+def test_cli_benchmark_rejects_non_benchmark_baseline(tmp_path: Path) -> None:
+    bogus = tmp_path / "bogus.json"
+    bogus.write_text(json.dumps({"command": "pack"}))
+    rc = _run_benchmark(tmp_path, tmp_path / "out", ["--baseline", str(bogus)])
+    assert rc == 1


### PR DESCRIPTION
Add benchmark-vs-baseline comparison and an optional CSV artifact (launch backlog issues 12 and 11).

## `--baseline <earlier-benchmark.json>`
Compares the run against a previous benchmark artifact. Strategies are matched by name; each shared strategy reports the delta (current minus baseline) for input tokens, saved tokens and runtime, plus file-count and quality-risk change, and strategies present in only one run are flagged `added`/`removed`. **No new measurement** - it reuses the metric definitions the benchmark already records. Strategy order in the comparison is sorted, so output is deterministic.

The delta lands in the JSON under `baseline_comparison` (an additive key), in the Markdown as a `Baseline Comparison` table, and in the run summary. A non-benchmark baseline file is rejected with exit 1.

## `--csv`
Also writes `<prefix>.csv`, one row per strategy (input/saved tokens, file counts, duplicate reads prevented, cache hits, quality risk, runtime). With `--baseline`, baseline and delta columns are appended. Opt-in: without the flag no CSV is written.

**Defaults unchanged** - a plain `redcon benchmark` produces exactly the same JSON/Markdown as before.

## Implementation
- Pure, testable helpers in `core/benchmark.py`: `compare_benchmarks()` and `benchmark_csv_rows()`.
- `render_benchmark_comparison_markdown()` in `core/render.py`.
- CLI wires `--baseline`/`--csv` into `cmd_benchmark`; CSV via stdlib `csv`.

## Tests
`tests/test_benchmark_compare.py`: delta computation, added/removed handling, determinism, CSV rows with and without a baseline, comparison markdown, plus an end-to-end CLI run (baseline + csv) and rejection of a non-benchmark baseline.

## Note
The benchmark module header was reordered (module docstring before `from __future__ import annotations`) to fix 16 pre-existing ruff E402/I001 errors that CI only enforces once the file is edited. Header-only change, no behavior impact.

Independent of #219/#220/#221.