### PR TITLE
Store file role on ranked files and cache it in the scan index

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,7 +51,7 @@ Delivered in `3ad9611`.
 
 ---
 
-## Phase 3 - File-role priors - Done (two minor follow-ups open)
+## Phase 3 - File-role priors - Done
 
 Delivered in `04571b4`, `02d31bd`, and `840574e`.
 
@@ -65,14 +65,16 @@ Delivered in `04571b4`, `02d31bd`, and `840574e`.
   `test_role_multipliers_lower_docs_and_examples`,
   `test_role_keyword_override_boosts_test_files`.
 
-Open follow-ups (minor, not blocking):
+Follow-ups (both now done):
 
-1. The computed role is not stored on `RankedFile`, so it is not visible to
-   downstream consumers or `run.json`.
-2. The role is recomputed on every score run rather than cached in the scan
-   index. `840574e` added an `lru_cache` to `classify_file_role`, which removes
-   most of the repeated cost, so this is an optimization rather than a
-   correctness gap.
+1. The computed role is stored on `RankedFile` and serialized into `run.json`,
+   plan `run.json` and the human plan view (as a `[role]` tag). `FileRecord`
+   carries a `role` field; `_serialize_ranked_file` emits it.
+2. The role is cached in the scan index rather than recomputed per run.
+   `FileRecord.role` is classified once at scan time and persisted, so reloaded
+   records reuse it (`classify_file_role` still backstops empty roles).
+   `INDEX_FORMAT_VERSION` was bumped to 3 so older indexes rebuild with the role
+   populated.
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -58,6 +58,10 @@ matches, symbol matches, import-graph relationships, and file-role and
 changed-file boosts). The human `plan` view prints these as a `signals:` line
 under each file. Deterministic.
 
+Each ranked file also carries its `role` (`prod`, `test`, `docs`, `example`,
+`config` or `generated`), classified once at scan time and cached in the scan
+index. It appears in `run.json` and as a `[role]` tag in the human `plan` view.
+
 ### `redcon plan <task> --workspace <workspace.toml>`
 Rank relevant files across multiple local repositories or monorepo packages.
 

--- a/redcon/core/render.py
+++ b/redcon/core/render.py
@@ -457,7 +457,11 @@ def render_plan_markdown(data: dict) -> str:
     lines.extend(["", "## Ranked Relevant Files"])
     for item in data["ranked_files"]:
         reasons = ", ".join(item["reasons"]) if item["reasons"] else "no specific reason"
-        lines.append(f"- `{item['path']}` ({_format_ranked_file_scores(item)}) - {reasons}")
+        role = item.get("role")
+        role_tag = f" [{role}]" if role else ""
+        lines.append(
+            f"- `{item['path']}`{role_tag} ({_format_ranked_file_scores(item)}) - {reasons}"
+        )
         breakdown = item.get("score_breakdown") or {}
         if breakdown:
             parts = ", ".join(f"{k} {v}" for k, v in sorted(breakdown.items()))

--- a/redcon/scanners/incremental.py
+++ b/redcon/scanners/incremental.py
@@ -35,7 +35,9 @@ SCAN_INDEX_DB_FILE = ".redcon/scan-index.db"
 
 # v2 added FileRecord.import_specs; bumping discards v1 indexes so they rebuild
 # with import specs populated instead of serving records that lack them.
-INDEX_FORMAT_VERSION = 2
+# v3 added FileRecord.role, cached so file-role classification is not recomputed
+# per run; bumping discards v2 indexes so they rebuild with role populated.
+INDEX_FORMAT_VERSION = 3
 
 _VENV_PREFIXES = (".venv", "venv-")
 
@@ -287,6 +289,7 @@ def _load_scan_index(path: Path, *, settings_fingerprint: str) -> ScanIndexState
                     relative_path=str(record_raw.get("relative_path", "")),
                     repo_label=str(record_raw.get("repo_label", "")),
                     repo_root=str(record_raw.get("repo_root", "")),
+                    role=str(record_raw.get("role", "")),
                 )
             except (TypeError, ValueError):
                 record = None
@@ -388,6 +391,7 @@ def _load_scan_index_sqlite(db_path: Path, *, settings_fingerprint: str) -> Scan
                         relative_path=str(rd.get("relative_path", "")),
                         repo_label=str(rd.get("repo_label", "")),
                         repo_root=str(rd.get("repo_root", "")),
+                        role=str(rd.get("role", "")),
                     )
                 except (TypeError, ValueError, KeyError):
                     record = None

--- a/redcon/schemas/models.py
+++ b/redcon/schemas/models.py
@@ -25,10 +25,18 @@ class FileRecord:
     relative_path: str = ""
     repo_label: str = ""
     repo_root: str = ""
+    # Path-derived file role (prod/test/docs/example/config/generated). Computed
+    # once at scan time and cached in the scan index so it is not recomputed per
+    # run. Empty means "not yet classified"; __post_init__ fills it in.
+    role: str = ""
 
     def __post_init__(self) -> None:
         if not self.relative_path:
             self.relative_path = self.path
+        if not self.role:
+            from redcon.scorers.file_roles import classify_file_role
+
+            self.role = classify_file_role(self.path)
 
 
 @dataclass(slots=True)
@@ -41,6 +49,8 @@ class RankedFile:
     historical_score: float = 0.0
     reasons: list[str] = field(default_factory=list)
     score_breakdown: dict[str, float] = field(default_factory=dict)
+    # Path-derived file role carried from the ranked file's FileRecord.
+    role: str = "prod"
 
 
 @dataclass(slots=True)

--- a/redcon/scorers/relevance.py
+++ b/redcon/scorers/relevance.py
@@ -9,7 +9,6 @@ from collections import defaultdict
 from redcon.config import ScoreSettings
 from redcon.core.text import task_keywords
 from redcon.schemas.models import FileRecord, RankedFile
-from redcon.scorers.file_roles import classify_file_role
 from redcon.scorers.history import TaskSimilarityCallable, compute_historical_adjustments
 from redcon.scorers.import_graph import build_import_graph
 
@@ -202,7 +201,8 @@ def score_files(
     if cfg.role_multipliers:
         keywords_lower = {k.lower() for k in keywords}
         for record in files:
-            role = classify_file_role(record.path)
+            # record.role is populated at scan time and cached in the index.
+            role = record.role
             multiplier = cfg.role_multipliers.get(role, 1.0)
             # Override: when task keywords mention the role's domain, boost
             # instead of penalizing (e.g. "test" keyword boosts test files).
@@ -390,6 +390,7 @@ def score_files(
                 historical_score=round(historical_value, 3),
                 reasons=reasons[:6],
                 score_breakdown={k: round(v, 3) for k, v in bd.items()},
+                role=record.role,
             )
         )
 

--- a/redcon/stages/workflow.py
+++ b/redcon/stages/workflow.py
@@ -62,6 +62,7 @@ def _serialize_ranked_file(item: RankedFile) -> dict:
         "historical_score": item.historical_score,
         "reasons": item.reasons,
         "line_count": item.file.line_count,
+        "role": item.role,
         "score_breakdown": {k: item.score_breakdown[k] for k in sorted(item.score_breakdown)},
     }
     if item.file.repo_label:

--- a/tests/test_role_persistence.py
+++ b/tests/test_role_persistence.py
@@ -1,0 +1,98 @@
+"""File-role persistence.
+
+A file's role (prod/test/docs/example/config/generated) is classified once at
+scan time, cached on FileRecord in the scan index, and carried onto RankedFile
+so it appears in run.json and plan output without being recomputed per run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import redcon.scorers.file_roles as file_roles
+from redcon.core import pipeline
+from redcon.core.render import render_plan_markdown
+from redcon.scanners.incremental import load_scan_index, refresh_scan_index
+from redcon.schemas.models import SCAN_INDEX_FILE, FileRecord
+from redcon.stages.workflow import as_json_dict
+
+
+def _record(path: str, role: str = "") -> FileRecord:
+    return FileRecord(
+        path=path,
+        absolute_path=f"/x/{path}",
+        extension=".py",
+        size_bytes=1,
+        line_count=1,
+        content_hash="h",
+        content_preview="",
+        role=role,
+    )
+
+
+def _seed(repo: Path) -> None:
+    (repo / "auth").mkdir(parents=True, exist_ok=True)
+    (repo / "tests").mkdir(parents=True, exist_ok=True)
+    (repo / "auth" / "login.py").write_text("def login(t):\n    return bool(t)\n")
+    (repo / "tests" / "test_login.py").write_text("def test_login():\n    assert True\n")
+
+
+def test_file_record_classifies_role_on_construction() -> None:
+    assert _record("auth/login.py").role == "prod"
+    assert _record("tests/test_login.py").role == "test"
+
+
+def test_explicit_cached_role_is_not_overwritten() -> None:
+    # A role loaded from the index is preserved rather than reclassified.
+    assert _record("tests/test_login.py", role="config").role == "config"
+
+
+def test_run_plan_serializes_role(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    data = pipeline.run_plan("fix login auth", tmp_path)
+    by_path = {r["path"]: r for r in data["ranked_files"]}
+    assert by_path["auth/login.py"]["role"] == "prod"
+    assert by_path["tests/test_login.py"]["role"] == "test"
+
+
+def test_run_pack_serializes_role(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    data = as_json_dict(pipeline.run_pack("fix login auth", tmp_path, max_tokens=5000))
+    assert data["ranked_files"]
+    assert all("role" in rf for rf in data["ranked_files"])
+
+
+def test_plan_markdown_shows_role_tag(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    md = render_plan_markdown(pipeline.run_plan("fix login auth", tmp_path))
+    assert "[test]" in md
+    assert "[prod]" in md
+
+
+def test_scan_index_caches_role_json(tmp_path: Path) -> None:
+    _seed(tmp_path)
+    refresh_scan_index(tmp_path, use_sqlite=False)
+    index = load_scan_index(tmp_path / SCAN_INDEX_FILE)
+    roles = {e["record"]["path"]: e["record"]["role"] for e in index["entries"]}
+    assert roles["tests/test_login.py"] == "test"
+    assert roles["auth/login.py"] == "prod"
+
+
+def test_cached_role_is_not_recomputed_on_reload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed(tmp_path)
+    refresh_scan_index(tmp_path)  # first scan populates and persists role
+
+    def boom(path: str) -> str:
+        raise AssertionError(f"role recomputed for {path}")
+
+    monkeypatch.setattr(file_roles, "classify_file_role", boom)
+    # Unchanged tree: records load from the cache with role already present, so
+    # the classifier must not be called again.
+    result = refresh_scan_index(tmp_path)
+    roles = {r.path: r.role for r in result.records}
+    assert roles["tests/test_login.py"] == "test"
+    assert roles["auth/login.py"] == "prod"


### PR DESCRIPTION
Close the two open ROADMAP Phase 3 follow-ups: store the file role on ranked files, and cache it in the scan index instead of recomputing per run.

## Role on RankedFile -> run.json / plan
- `RankedFile` gains a `role` field, set in `score_files` from the record.
- `_serialize_ranked_file` emits `"role"`, so it flows to `run.json`, plan `run.json` and the agent-plan artifact through the single serializer.
- The human `plan` view shows it as a `[role]` tag on each ranked file.

## Role cached in the scan index
- `FileRecord` gains a `role` field. Because the role is purely path-derived, `__post_init__` classifies it once (via `classify_file_role`, lazily imported to avoid any import cycle) only when empty, so:
  - fresh records get classified at scan time,
  - records loaded from the index keep their cached role - no reclassification.
- Both scan-index loaders (SQLite and JSON) read `role` back; `asdict` on the save paths persists it automatically.
- `INDEX_FORMAT_VERSION` bumped 2 -> 3 so existing v2 indexes are discarded and rebuilt with the role populated (same pattern the v1 -> v2 `import_specs` bump used).
- `score_files` now reads `record.role` instead of calling `classify_file_role` per run.

## ROADMAP
Both Phase 3 follow-ups flipped to done, with what landed.

## Tests
`tests/test_role_persistence.py`: role classified on `FileRecord` construction, an explicit cached role is not overwritten, role serialized in `run_plan` and `run_pack` output, the `[role]` tag appears in plan Markdown, role persisted in the JSON index, and - the key caching guarantee - reloading an unchanged tree does **not** call the classifier (monkeypatched to raise). Full suite: 1126 passed, 19 skipped.

Independent of #219-#222.