### PR TITLE
Release 1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-08-03
+
+### Added
+
+- Junie CLI as a first-class `redcon mcp install` target: registers the redcon
+  MCP server under `mcpServers` in `.junie/mcp/mcp.json` (project) or
+  `~/.junie/mcp/mcp.json` (global). Detected when a `.junie` directory exists.
+- Cline and Zed as first-class install targets. Cline uses its VS Code
+  global-storage `cline_mcp_settings.json` (per-OS path); Zed uses the
+  `context_servers` key in `~/.config/zed/settings.json`.
+- Versioned JSON Schemas (draft 2020-12) for the `pack` (run), `diff` and
+  `benchmark` artifacts under `redcon/schemas/json/v1/`, plus `redcon validate
+  <artifact.json>`: picks the schema from the artifact's `command` field, exits
+  0 or 1, and can emit machine-readable errors with `--json`. Validation uses a
+  built-in checker with no new hard dependency; installing `redcon[validate]`
+  swaps in `jsonschema` for full-spec coverage.
+- `redcon benchmark --baseline <earlier-benchmark.json>`: a deterministic
+  per-strategy delta (input tokens, saved tokens, runtime) against a previous
+  benchmark, in the JSON (`baseline_comparison`), Markdown and run summary.
+- `redcon benchmark --csv`: an optional per-strategy CSV artifact alongside the
+  JSON and Markdown, with baseline and delta columns when `--baseline` is given.
+- Each ranked file now carries its `role` (prod/test/docs/example/config/
+  generated) in `run.json` and plan output, shown as a `[role]` tag in the
+  human plan view.
+
+### Changed
+
+- The file role is classified once at scan time and cached in the scan index
+  (`INDEX_FORMAT_VERSION` bumped to 3) instead of being recomputed per run.
+- `redcon mcp install` refuses to overwrite a config file that exists but does
+  not parse as JSON (for example a Zed `settings.json` with comments), reporting
+  a failed status with manual-add instructions instead of replacing the user's
+  configuration. Missing or empty files are still created or filled.
+
 ## [1.12.0] - 2026-08-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redcon"
-version = "1.12.0"
+version = "1.13.0"
 description = "Deterministic context budgeting for coding-agent workflows"
 readme = "README.md"
 keywords = [

--- a/redcon/schemas/json/v1/benchmark.schema.json
+++ b/redcon/schemas/json/v1/benchmark.schema.json
@@ -15,6 +15,10 @@
     "scan_runtime_ms": { "type": "integer" },
     "generated_at": { "type": "string" },
     "failed_strategies": { "type": "array", "items": { "type": "string" } },
+    "baseline_comparison": {
+      "type": "object",
+      "description": "Present when --baseline is given: per-strategy deltas against an earlier benchmark."
+    },
     "strategies": {
       "type": "array",
       "items": {

--- a/redcon/schemas/json/v1/run.schema.json
+++ b/redcon/schemas/json/v1/run.schema.json
@@ -55,6 +55,10 @@
           "heuristic_score": { "type": "number" },
           "historical_score": { "type": "number" },
           "line_count": { "type": "integer" },
+          "role": {
+            "type": "string",
+            "description": "Path-derived file role (prod/test/docs/example/config/generated)."
+          },
           "reasons": { "type": "array", "items": { "type": "string" } },
           "score_breakdown": {
             "type": "object",

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/natiixnt/redcon",
     "source": "github"
   },
-  "version": "1.12.0",
+  "version": "1.13.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "redcon",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Cut 1.13.0, theme "agents and contracts". All five feature PRs (#219, #220, #221, #222, #223) are merged; this is the release bump.

## Changes
- `pyproject.toml`: version 1.12.0 -> 1.13.0 (license stays `{ file = "LICENSE" }`; the SPDX form is what broke 1.12.0 at twine, so it is deliberately not reintroduced).
- `CHANGELOG.md`: `[Unreleased]` cut into `[1.13.0]` covering Junie/Cline/Zed install targets, JSON Schemas + `validate`, benchmark `--baseline`/`--csv`, the ranked-file `role`, role caching in the scan index, and the install-time JSONC overwrite guard.
- `server.json`: 1.12.0 -> 1.13.0 (both version fields) for `mcp-publisher publish`.
- Schemas: added `role` to `run.schema.json` and `baseline_comparison` to `benchmark.schema.json` so the schemas document the full contract (the review nit).

## Pre-flight (done locally)
- `python -m build` + `twine check` (twine 7) PASS for both the wheel and sdist - the 1.12.0 metadata failure does not recur.
- Wheel is `redcon-1.13.0`; the three v1 schema files ship in it.
- Validation tests pass against the updated schemas.

After green CI and rebase-merge, the `v1.13.0` tag drives `release.yml` to publish to PyPI and create the GitHub Release. Wheel verification and `mcp-publisher publish` are the planner-side follow-ups.