### PR TITLE
Add self-contained HTML reports for run, diff and benchmark

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -75,6 +75,14 @@ Plan the same lifecycle-aware workflow across multiple local repositories or mon
 ### `redcon pack <task> --repo <path> [--max-tokens N] [--top-files N]`
 Build compressed context package and write `run.json` + `run.md` by default.
 
+`--html` additionally writes a self-contained `run.html`: one file with inline
+CSS and no external requests, readable as dark text on a light background when
+printed. It carries the run's budget, files, ranked files with their
+`score_breakdown` signals and `[role]` tags, and the `prompt_cache_key`. The
+JSON and Markdown outputs are unchanged. `redcon diff` and `redcon benchmark`
+accept the same `--html` flag (the benchmark HTML includes `baseline_comparison`
+when `--baseline` is given).
+
 `--compression-profile max` switches to the max-compression profile: tighter
 tier thresholds that pack roughly 20% fewer input tokens at the same budget and
 reported quality risk (measured on this repository). It can also be set

--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -14,6 +14,11 @@ from pathlib import Path
 from redcon import __version__ as _redcon_version
 from redcon.agents.middleware import RedconMiddleware
 from redcon.config import RedconConfig, load_config, validate_config
+from redcon.core.html_report import (
+    render_benchmark_html,
+    render_diff_html,
+    render_run_html,
+)
 from redcon.core.policy import (
     default_strict_policy,
     load_policy,
@@ -800,6 +805,10 @@ def cmd_pack(args: argparse.Namespace) -> int:
 
     _qprint(args, f"Wrote run JSON: {json_path}")
     _qprint(args, f"Wrote run Markdown: {md_path}")
+    if getattr(args, "html", False):
+        html_path = Path(f"{base}.html")
+        html_path.write_text(render_run_html(data), encoding="utf-8")
+        _qprint(args, f"Wrote run HTML: {html_path}")
     _qprint(
         args,
         "Budget: "
@@ -1190,6 +1199,10 @@ def cmd_diff(args: argparse.Namespace) -> int:
 
     print(f"Wrote diff JSON: {json_path}")
     print(f"Wrote diff Markdown: {md_path}")
+    if getattr(args, "html", False):
+        html_path = Path(f"{base}.html")
+        html_path.write_text(render_diff_html(diff_data), encoding="utf-8")
+        print(f"Wrote diff HTML: {html_path}")
     return 0
 
 
@@ -1322,6 +1335,11 @@ def cmd_benchmark(args: argparse.Namespace) -> int:
     write_json(json_path, benchmark_data)
     md_path.write_text(markdown, encoding="utf-8")
 
+    html_path = None
+    if getattr(args, "html", False):
+        html_path = Path(f"{base}.html")
+        html_path.write_text(render_benchmark_html(benchmark_data), encoding="utf-8")
+
     csv_path = None
     if args.csv:
         from redcon.core.benchmark import benchmark_csv_rows
@@ -1377,6 +1395,8 @@ def cmd_benchmark(args: argparse.Namespace) -> int:
     print(f"Wrote benchmark Markdown: {md_path}")
     if csv_path is not None:
         print(f"Wrote benchmark CSV: {csv_path}")
+    if html_path is not None:
+        print(f"Wrote benchmark HTML: {html_path}")
     return 0
 
 
@@ -3018,6 +3038,11 @@ def _register_packing_commands(sub: argparse._SubParsersAction) -> None:
     )
     pack.add_argument("--out-prefix", help="Output file prefix for JSON/Markdown", default="run")
     pack.add_argument(
+        "--html",
+        action="store_true",
+        help="Also write a self-contained HTML report alongside the JSON/Markdown.",
+    )
+    pack.add_argument(
         "--strict",
         action="store_true",
         help="Enable strict policy enforcement (non-zero exit on violations).",
@@ -3136,6 +3161,11 @@ def _register_reporting_commands(sub: argparse._SubParsersAction) -> None:
     diff.add_argument("old_run_json", help="Path to older run JSON")
     diff.add_argument("new_run_json", help="Path to newer run JSON")
     diff.add_argument("--out-prefix", help="Output prefix for diff JSON/Markdown")
+    diff.add_argument(
+        "--html",
+        action="store_true",
+        help="Also write a self-contained HTML report alongside the JSON/Markdown.",
+    )
     diff.set_defaults(func=cmd_diff)
 
     validate = sub.add_parser(
@@ -3197,6 +3227,11 @@ def _register_reporting_commands(sub: argparse._SubParsersAction) -> None:
         "--config", help="Optional path to config TOML (default: <repo>/redcon.toml)."
     )
     benchmark.add_argument("--out-prefix", help="Output file prefix for benchmark JSON/Markdown")
+    benchmark.add_argument(
+        "--html",
+        action="store_true",
+        help="Also write a self-contained HTML report alongside the JSON/Markdown.",
+    )
     benchmark.add_argument(
         "--baseline",
         help="Path to an earlier benchmark JSON to compare against; adds a delta summary.",

--- a/redcon/core/html_report.py
+++ b/redcon/core/html_report.py
@@ -1,0 +1,253 @@
+"""Self-contained HTML reports for run, diff and benchmark artifacts.
+
+Each renderer returns one complete HTML document with inline CSS and no
+external requests, readable as dark text on a light background when printed.
+The content mirrors the Markdown reports and additionally surfaces per-file
+``score_breakdown`` and ``role``, the run ``prompt_cache_key``, and the
+benchmark ``baseline_comparison``. The JSON and Markdown outputs are untouched;
+HTML is an additional, opt-in artifact.
+"""
+
+from __future__ import annotations
+
+from html import escape
+from typing import Any
+
+_STYLE = """
+:root { color-scheme: light; }
+* { box-sizing: border-box; }
+body {
+  margin: 0 auto; max-width: 960px; padding: 2rem 1.25rem;
+  font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  color: #14181f; background: #ffffff;
+}
+h1 { font-size: 1.6rem; margin: 0 0 0.25rem; }
+h2 { font-size: 1.15rem; margin: 1.8rem 0 0.6rem; border-bottom: 1px solid #d7dbe0; padding-bottom: 0.2rem; }
+.meta { color: #55606d; margin: 0.1rem 0; }
+code, .mono { font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace; font-size: 0.88em; }
+code { background: #f2f4f7; padding: 0.05rem 0.3rem; border-radius: 3px; }
+table { border-collapse: collapse; width: 100%; margin: 0.5rem 0 1rem; }
+th, td { border: 1px solid #d7dbe0; padding: 0.35rem 0.55rem; text-align: left; vertical-align: top; }
+th { background: #f2f4f7; }
+td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+ul { margin: 0.3rem 0 1rem; padding-left: 1.3rem; }
+.tag { display: inline-block; background: #e7edf5; color: #24405f; border-radius: 3px; padding: 0 0.35rem; font-size: 0.8em; }
+.signals { color: #55606d; font-size: 0.85em; }
+.key { background: #f2f4f7; padding: 0.5rem 0.7rem; border-radius: 4px; display: inline-block; }
+.empty { color: #55606d; font-style: italic; }
+@media print { body { max-width: none; padding: 0; } h2 { break-after: avoid; } table { break-inside: auto; } }
+"""
+
+
+def _esc(value: Any) -> str:
+    return escape(str(value), quote=True)
+
+
+def _doc(title: str, body: str) -> str:
+    return (
+        "<!doctype html>\n"
+        '<html lang="en">\n<head>\n<meta charset="utf-8">\n'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        f"<title>{_esc(title)}</title>\n<style>{_STYLE}</style>\n</head>\n"
+        f"<body>\n{body}\n</body>\n</html>\n"
+    )
+
+
+def _table(headers: list[str], rows: list[list[str]], *, numeric: set[int] | None = None) -> str:
+    numeric = numeric or set()
+
+    def cell(tag: str, i: int, value: str) -> str:
+        cls = ' class="num"' if i in numeric else ""
+        return f"<{tag}{cls}>{value}</{tag}>"
+
+    head = "".join(cell("th", i, _esc(h)) for i, h in enumerate(headers))
+    body_rows = "".join(
+        "<tr>" + "".join(cell("td", i, c) for i, c in enumerate(row)) + "</tr>" for row in rows
+    )
+    return f"<table>\n<thead><tr>{head}</tr></thead>\n<tbody>{body_rows}</tbody>\n</table>"
+
+
+def _code(value: Any) -> str:
+    return f"<code>{_esc(value)}</code>"
+
+
+def _file_list(paths: list[str]) -> str:
+    if not paths:
+        return '<p class="empty">None</p>'
+    items = "".join(f"<li>{_code(p)}</li>" for p in paths)
+    return f"<ul>{items}</ul>"
+
+
+def render_run_html(data: dict) -> str:
+    """Render a pack run artifact to a self-contained HTML document."""
+    budget = data.get("budget", {})
+    parts: list[str] = ["<h1>Redcon Pack Report</h1>"]
+    parts.append(f'<p class="meta">Task: {_esc(data.get("task", ""))}</p>')
+    parts.append(f'<p class="meta">Repository: {_code(data.get("repo", ""))}</p>')
+    parts.append(f'<p class="meta">Max tokens: {_esc(data.get("max_tokens", 0))}</p>')
+
+    cache_key = data.get("prompt_cache_key")
+    if cache_key:
+        parts.append("<h2>Prompt Cache Key</h2>")
+        parts.append(f'<p><span class="key mono">{_esc(cache_key)}</span></p>')
+
+    parts.append("<h2>Budget</h2>")
+    parts.append(
+        _table(
+            ["Metric", "Value"],
+            [
+                ["Estimated input tokens", _esc(budget.get("estimated_input_tokens", 0))],
+                ["Estimated saved tokens", _esc(budget.get("estimated_saved_tokens", 0))],
+                ["Duplicate reads prevented", _esc(budget.get("duplicate_reads_prevented", 0))],
+                ["Quality risk estimate", _esc(budget.get("quality_risk_estimate", "unknown"))],
+            ],
+            numeric={1},
+        )
+    )
+
+    parts.append("<h2>Files Included</h2>")
+    parts.append(_file_list(data.get("files_included", [])))
+    parts.append("<h2>Files Skipped</h2>")
+    parts.append(_file_list(data.get("files_skipped", [])))
+
+    parts.append("<h2>Ranked Relevant Files</h2>")
+    ranked = data.get("ranked_files", [])
+    if ranked:
+        rows = []
+        for item in ranked:
+            role = item.get("role", "")
+            role_html = f'<span class="tag">{_esc(role)}</span>' if role else ""
+            breakdown = item.get("score_breakdown") or {}
+            signals = ", ".join(f"{_esc(k)} {_esc(v)}" for k, v in sorted(breakdown.items()))
+            signals_html = f'<div class="signals">{signals}</div>' if signals else ""
+            rows.append(
+                [
+                    _code(item.get("path", ""))
+                    + (" " + role_html if role_html else "")
+                    + signals_html,
+                    _esc(round(float(item.get("score", 0)), 3)),
+                ]
+            )
+        parts.append(_table(["File", "Score"], rows, numeric={1}))
+    else:
+        parts.append('<p class="empty">No files ranked.</p>')
+
+    return _doc("Redcon Pack Report", "\n".join(parts))
+
+
+def render_diff_html(data: dict) -> str:
+    """Render a diff artifact to a self-contained HTML document."""
+    parts: list[str] = ["<h1>Redcon Diff Report</h1>"]
+    parts.append(f'<p class="meta">Old run: {_code(data.get("old_run", ""))}</p>')
+    parts.append(f'<p class="meta">New run: {_code(data.get("new_run", ""))}</p>')
+
+    task_diff = data.get("task_diff", {})
+    parts.append("<h2>Task</h2>")
+    parts.append(
+        _table(
+            ["Field", "Value"],
+            [
+                ["Old task", _esc(task_diff.get("old_task", ""))],
+                ["New task", _esc(task_diff.get("new_task", ""))],
+                ["Changed", _esc(task_diff.get("changed", False))],
+            ],
+        )
+    )
+
+    context = data.get("context_diff", {})
+    parts.append("<h2>Context</h2>")
+    parts.append(f'<p class="meta">Added ({_esc(context.get("added_count", 0))}):</p>')
+    parts.append(_file_list(context.get("files_added", [])))
+    parts.append(f'<p class="meta">Removed ({_esc(context.get("removed_count", 0))}):</p>')
+    parts.append(_file_list(context.get("files_removed", [])))
+
+    changes = data.get("ranked_score_changes", [])
+    parts.append("<h2>Ranked Score Changes</h2>")
+    if changes:
+        rows = [
+            [
+                _code(c.get("path", "")),
+                _esc(c.get("change_type", "")),
+                _esc(c.get("old_score")),
+                _esc(c.get("new_score")),
+                _esc(c.get("delta")),
+            ]
+            for c in changes
+        ]
+        parts.append(_table(["File", "Change", "Old", "New", "Delta"], rows, numeric={2, 3, 4}))
+    else:
+        parts.append('<p class="empty">No score changes.</p>')
+
+    return _doc("Redcon Diff Report", "\n".join(parts))
+
+
+def render_benchmark_html(data: dict) -> str:
+    """Render a benchmark artifact to a self-contained HTML document."""
+    parts: list[str] = ["<h1>Redcon Benchmark Report</h1>"]
+    parts.append(f'<p class="meta">Task: {_esc(data.get("task", ""))}</p>')
+    parts.append(f'<p class="meta">Repository: {_code(data.get("repo", ""))}</p>')
+    parts.append(
+        f'<p class="meta">Baseline full-context tokens: '
+        f"{_esc(data.get('baseline_full_context_tokens', 0))}</p>"
+    )
+    parts.append(f'<p class="meta">Token budget: {_esc(data.get("max_tokens", 0))}</p>')
+
+    parts.append("<h2>Strategy Comparison</h2>")
+    strategies = data.get("strategies", [])
+    if strategies:
+        rows = [
+            [
+                _esc(s.get("strategy", "")),
+                _esc(s.get("estimated_input_tokens", 0)),
+                _esc(s.get("estimated_saved_tokens", 0)),
+                _esc(len(s.get("files_included", []))),
+                _esc(s.get("quality_risk_estimate", "unknown")),
+                _esc(s.get("runtime_ms", 0)),
+            ]
+            for s in strategies
+        ]
+        parts.append(
+            _table(
+                [
+                    "Strategy",
+                    "Input Tokens",
+                    "Saved Tokens",
+                    "Files",
+                    "Quality Risk",
+                    "Runtime (ms)",
+                ],
+                rows,
+                numeric={1, 2, 3, 5},
+            )
+        )
+    else:
+        parts.append('<p class="empty">No strategies.</p>')
+
+    comparison = data.get("baseline_comparison")
+    if comparison:
+        parts.append("<h2>Baseline Comparison</h2>")
+        full = comparison.get("baseline_full_context_tokens", {})
+        parts.append(
+            f'<p class="meta">Baseline task: {_esc(comparison.get("baseline_task", ""))} '
+            f"(full-context tokens {_esc(full.get('baseline'))} to {_esc(full.get('current'))})</p>"
+        )
+        rows = []
+        for row in comparison.get("strategies", []):
+            rows.append(
+                [
+                    _esc(row.get("strategy", "")),
+                    _esc(row.get("status", "")),
+                    _esc(row.get("estimated_input_tokens", {}).get("delta")),
+                    _esc(row.get("estimated_saved_tokens", {}).get("delta")),
+                    _esc(row.get("runtime_ms", {}).get("delta")),
+                ]
+            )
+        parts.append(
+            _table(
+                ["Strategy", "Status", "Input Delta", "Saved Delta", "Runtime Delta"],
+                rows,
+                numeric={2, 3, 4},
+            )
+        )
+
+    return _doc("Redcon Benchmark Report", "\n".join(parts))

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -1,0 +1,177 @@
+"""Self-contained HTML reports for run, diff and benchmark artifacts.
+
+The `--html` flag adds an HTML report alongside the JSON/Markdown outputs. The
+HTML must be a single self-contained document (inline CSS, no external
+requests) and must carry the key sections, including score_breakdown, role and
+prompt_cache_key for runs and baseline_comparison for benchmarks.
+"""
+
+from __future__ import annotations
+
+from html.parser import HTMLParser
+from pathlib import Path
+
+from redcon.core.html_report import render_benchmark_html, render_diff_html, render_run_html
+
+
+class _TagCollector(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.tags: set[str] = set()
+
+    def handle_starttag(self, tag: str, attrs: object) -> None:
+        self.tags.add(tag)
+
+
+def _parse_tags(html: str) -> set[str]:
+    parser = _TagCollector()
+    parser.feed(html)  # raises if the markup is not parseable
+    return parser.tags
+
+
+def _assert_self_contained(html: str) -> None:
+    lowered = html.lower()
+    assert html.lstrip().startswith("<!doctype html>")
+    assert "<style>" in lowered
+    for external in ("http://", "https://", "<link", "src=", "<script"):
+        assert external not in lowered, f"HTML is not self-contained: found {external!r}"
+
+
+def _run_data() -> dict:
+    return {
+        "command": "pack",
+        "task": "harden auth",
+        "repo": "/tmp/example",
+        "max_tokens": 5000,
+        "prompt_cache_key": "abcd1234ef567890",
+        "budget": {"estimated_input_tokens": 120, "estimated_saved_tokens": 900},
+        "files_included": ["auth/login.py"],
+        "files_skipped": ["auth/legacy.py"],
+        "ranked_files": [
+            {
+                "path": "auth/login.py",
+                "score": 4.2,
+                "role": "prod",
+                "score_breakdown": {"path_keyword": 2.0, "import_graph": 0.9},
+            }
+        ],
+    }
+
+
+def test_run_html_is_self_contained_and_parses() -> None:
+    html = render_run_html(_run_data())
+    _assert_self_contained(html)
+    tags = _parse_tags(html)
+    assert {"html", "head", "body", "table", "h1"} <= tags
+
+
+def test_run_html_carries_required_sections() -> None:
+    html = render_run_html(_run_data())
+    assert "Redcon Pack Report" in html
+    assert "abcd1234ef567890" in html  # prompt_cache_key
+    assert "auth/login.py" in html
+    assert "prod" in html  # role tag
+    assert "path_keyword" in html and "import_graph" in html  # score_breakdown signals
+
+
+def test_run_html_escapes_content() -> None:
+    data = _run_data()
+    data["task"] = "fix <script>alert(1)</script> & co"
+    html = render_run_html(data)
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_diff_html_renders_sections() -> None:
+    data = {
+        "command": "diff",
+        "old_run": "old.json",
+        "new_run": "new.json",
+        "task_diff": {"old_task": "a", "new_task": "b", "changed": True},
+        "context_diff": {
+            "files_added": ["x.py"],
+            "files_removed": ["y.py"],
+            "added_count": 1,
+            "removed_count": 1,
+        },
+        "ranked_score_changes": [
+            {
+                "path": "x.py",
+                "old_score": None,
+                "new_score": 3.0,
+                "delta": 3.0,
+                "change_type": "added",
+            }
+        ],
+        "budget_delta": {},
+    }
+    html = render_diff_html(data)
+    _assert_self_contained(html)
+    assert {"table", "body"} <= _parse_tags(html)
+    assert "Redcon Diff Report" in html
+    assert "x.py" in html and "added" in html
+
+
+def test_benchmark_html_includes_baseline_comparison() -> None:
+    data = {
+        "command": "benchmark",
+        "task": "demo",
+        "repo": "/tmp/example",
+        "max_tokens": 5000,
+        "baseline_full_context_tokens": 1000,
+        "strategies": [
+            {
+                "strategy": "compressed_pack",
+                "estimated_input_tokens": 300,
+                "estimated_saved_tokens": 700,
+                "files_included": ["a.py"],
+                "quality_risk_estimate": "low",
+                "runtime_ms": 12,
+            }
+        ],
+        "baseline_comparison": {
+            "baseline_task": "demo",
+            "baseline_full_context_tokens": {"baseline": 1100, "current": 1000, "delta": -100},
+            "strategies": [
+                {
+                    "strategy": "compressed_pack",
+                    "status": "compared",
+                    "estimated_input_tokens": {"delta": -50},
+                    "estimated_saved_tokens": {"delta": 50},
+                    "runtime_ms": {"delta": -2},
+                }
+            ],
+        },
+    }
+    html = render_benchmark_html(data)
+    _assert_self_contained(html)
+    assert "Redcon Benchmark Report" in html
+    assert "compressed_pack" in html
+    assert "Baseline Comparison" in html
+
+
+def test_html_written_alongside_outputs(tmp_path: Path) -> None:
+    from redcon.cli import build_parser
+
+    (tmp_path / "auth").mkdir()
+    (tmp_path / "auth" / "login.py").write_text("def login(t):\n    return bool(t)\n")
+    out = tmp_path / "run"
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "pack",
+            "fix login",
+            "--repo",
+            str(tmp_path),
+            "--max-tokens",
+            "5000",
+            "--out-prefix",
+            str(out),
+            "--html",
+        ]
+    )
+    assert int(args.func(args)) == 0
+    assert Path(f"{out}.json").exists()
+    assert Path(f"{out}.md").exists()
+    assert Path(f"{out}.html").exists()
+    _assert_self_contained(Path(f"{out}.html").read_text())


### PR DESCRIPTION
Launch backlog issue 7: HTML renderer for run, diff and benchmark reports.

Adds an opt-in `--html` flag to `pack`, `diff` and `benchmark` that writes one self-contained HTML file alongside the current outputs.

## What it produces
- `redcon/core/html_report.py`: `render_run_html`, `render_diff_html`, `render_benchmark_html`. Each returns a single document with **inline CSS and no external requests** (no CDN, no `<link>`, no `<script>`, no remote images), readable as dark text on a light background and print-friendly (`@media print`).
- Rendered **directly from the data dict**, so it is a superset of the Markdown: the run report includes each ranked file's `score_breakdown` signals and `[role]` tag and the `prompt_cache_key`; the benchmark report includes `baseline_comparison` when `--baseline` is given. (The current Markdown does not carry these, and Markdown/JSON stay byte-identical.)
- All content is HTML-escaped.

## Design note
I render from data rather than converting the Markdown because `render_pack_markdown` today omits `score_breakdown`, `role` and `prompt_cache_key`, and the requirement is to keep Markdown unchanged while the HTML shows them. Rendering from data also keeps the HTML deterministic (no `_Rendered in X ms_` timing footer).

## Tests (`tests/test_html_report.py`)
- The HTML parses (via `html.parser`) and contains the expected tags.
- Self-contained: no `http://`/`https://`/`<link>`/`src=`/`<script>`.
- Required sections present: prompt_cache_key, role, score_breakdown for runs; baseline_comparison for benchmarks.
- Content is escaped (a `<script>` in the task does not appear unescaped).
- End-to-end: `pack --html` writes `run.html` next to `run.json`/`run.md`.

## Docs
`docs/cli.md` documents `--html` under `pack`, noting `diff`/`benchmark` accept it too.