### PR TITLE
Add local cache TTL and a cache prune command

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -38,6 +38,43 @@ duplicate_hash_cache_enabled = true
 
 `cache_hits` remains as a compatibility field for existing consumers.
 
+### TTL freshness
+
+The local cache does not expire entries by default, so behavior is unchanged
+unless you opt in. Set a positive `local_ttl_seconds` under `[cache]` to treat
+entries older than that many seconds as stale (a cache miss), mirroring the
+Redis backend's `redis_ttl_seconds`. `0` disables expiry.
+
+```toml
+[cache]
+backend = "local_file"
+local_ttl_seconds = 86400   # expire local cache entries after 24 hours; 0 = never
+```
+
+Entries written before TTL was enabled have no recorded timestamp and are
+treated as fresh, so turning TTL on never retroactively drops existing entries.
+
+### Pruning
+
+`redcon cache prune` removes stale entries from the local cache:
+
+```bash
+redcon cache prune --repo .            # remove expired and orphaned entries
+redcon cache prune --repo . --dry-run  # report what would be removed, change nothing
+redcon cache prune --repo . --json     # machine-readable summary
+```
+
+It removes two kinds of entries:
+
+- **Expired** - older than `local_ttl_seconds` (only when TTL is enabled).
+- **Orphaned** - the file the entry was cached for no longer exists in the repo.
+  A wrong or empty repository path never removes orphaned entries, so prune
+  cannot wipe the whole cache by mistake.
+
+The command prints how many entries were removed and how many bytes were freed
+(`entries_removed`, `bytes_freed`, `expired`, `orphaned`). Running it on a cache
+with nothing expired or orphaned is a no-op and leaves the file untouched.
+
 ## Redis Shared Cache Cluster
 
 The `redis` backend enables multiple agents or CI runs to share cached summaries, context slices, and compressed fragments across machines.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,6 +14,12 @@ Environment diagnostics: Python version, optional extras (`tokenizers`,
 config validity, cache directory, git and disk space. Exit code reflects
 failures, so it works as a CI gate too.
 
+### `redcon cache prune [--repo <path>] [--dry-run] [--json]`
+Remove stale entries from the local summary cache: entries past
+`[cache].local_ttl_seconds` (when TTL is enabled) and entries whose source file
+no longer exists. Prints how many entries were removed and bytes freed;
+`--dry-run` reports without changing anything. See [cache](cache.md).
+
 ### `redcon mcp install | status | uninstall | serve`
 Manage the MCP server registration for coding agents. `serve` runs the
 stdio server itself (agents invoke it; you rarely run it by hand).

--- a/redcon/cache/backends.py
+++ b/redcon/cache/backends.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import time
 import zlib
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
@@ -244,16 +245,35 @@ def _cache_file_lock(lock_path: Path):
         handle.close()
 
 
+def _empty_local_cache() -> dict[str, Any]:
+    return {
+        "summaries": {},
+        "fragments": {},
+        "slices": {},
+        "timestamps": {"summaries": {}, "fragments": {}, "slices": {}},
+    }
+
+
 class LocalFileSummaryCacheBackend(SummaryCacheBackend):
     """Persistent local summary cache backed by a JSON file."""
 
     backend_name = "local_file"
 
-    def __init__(self, repo_path: Path, cache_file: str = CACHE_FILE, enabled: bool = True) -> None:
+    _STORES = ("summaries", "fragments", "slices")
+
+    def __init__(
+        self,
+        repo_path: Path,
+        cache_file: str = CACHE_FILE,
+        enabled: bool = True,
+        ttl_seconds: int = 0,
+    ) -> None:
         super().__init__(enabled=enabled)
         self.repo_path = repo_path
         self.cache_path = repo_path / cache_file
-        self._data: dict[str, Any] = {"summaries": {}, "fragments": {}, "slices": {}}
+        # 0 (or negative) disables expiry, matching the Redis convention.
+        self.ttl_seconds = ttl_seconds
+        self._data: dict[str, Any] = _empty_local_cache()
         self._load()
 
     def _load(self) -> None:
@@ -264,13 +284,12 @@ class LocalFileSummaryCacheBackend(SummaryCacheBackend):
         try:
             raw_data = json.loads(self.cache_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
-            self._data = {"summaries": {}, "fragments": {}, "slices": {}}
+            self._data = _empty_local_cache()
             return
-        self._data = (
-            raw_data
-            if isinstance(raw_data, dict)
-            else {"summaries": {}, "fragments": {}, "slices": {}}
-        )
+        self._data = raw_data if isinstance(raw_data, dict) else _empty_local_cache()
+
+    def _now(self) -> float:
+        return time.time()
 
     def _store(self, name: str) -> dict[str, str]:
         raw = self._data.get(name)
@@ -280,53 +299,130 @@ class LocalFileSummaryCacheBackend(SummaryCacheBackend):
         self._data[name] = summaries
         return summaries
 
+    def _timestamps(self, name: str) -> dict[str, float]:
+        root = self._data.get("timestamps")
+        if not isinstance(root, dict):
+            root = {}
+            self._data["timestamps"] = root
+        store_ts = root.get(name)
+        if not isinstance(store_ts, dict):
+            store_ts = {}
+            root[name] = store_ts
+        return store_ts
+
+    def _touch(self, name: str, key: str) -> None:
+        self._timestamps(name)[key] = self._now()
+
+    def _is_expired(self, name: str, key: str) -> bool:
+        # A missing timestamp (entry written before TTL was used) is treated as
+        # fresh, so enabling TTL never retroactively drops existing entries.
+        if self.ttl_seconds <= 0:
+            return False
+        ts = self._timestamps(name).get(key)
+        return ts is not None and (self._now() - ts) > self.ttl_seconds
+
     def _get_summary(self, key: str) -> str | None:
+        if self._is_expired("summaries", key):
+            return None
         summaries = self._store("summaries")
-        if key in summaries:
-            return str(summaries[key])
-        return None
+        return str(summaries[key]) if key in summaries else None
 
     def _put_summary(self, key: str, summary: str) -> bool:
         summaries = self._store("summaries")
         is_new_key = key not in summaries
         summaries[key] = summary
+        self._touch("summaries", key)
         return is_new_key
 
     def _get_fragment(self, key: str) -> str | None:
+        if self._is_expired("fragments", key):
+            return None
         fragments = self._store("fragments")
-        if key in fragments:
-            return str(fragments[key])
-        return None
+        return str(fragments[key]) if key in fragments else None
 
     def _put_fragment(self, key: str, reference: str) -> bool:
         fragments = self._store("fragments")
         is_new_key = key not in fragments
         fragments[key] = reference
+        self._touch("fragments", key)
         return is_new_key
 
     def _get_slice(self, key: str) -> str | None:
+        if self._is_expired("slices", key):
+            return None
         slices = self._store("slices")
-        if key in slices:
-            return str(slices[key])
-        return None
+        return str(slices[key]) if key in slices else None
 
     def _put_slice(self, key: str, data: str) -> bool:
         slices = self._store("slices")
         is_new_key = key not in slices
         slices[key] = data
+        self._touch("slices", key)
         return is_new_key
 
     def _invalidate(self, key: str) -> bool:
         removed = False
-        for store_name in ("summaries", "fragments", "slices"):
+        for store_name in self._STORES:
             store = self._store(store_name)
             if key in store:
                 del store[key]
+                self._timestamps(store_name).pop(key, None)
                 removed = True
         return removed
 
     def _clear(self) -> None:
-        self._data = {"summaries": {}, "fragments": {}, "slices": {}}
+        self._data = _empty_local_cache()
+
+    def iter_entries(self):
+        """Yield (store, key, value) for every cached entry."""
+        for store_name in self._STORES:
+            for key, value in list(self._store(store_name).items()):
+                yield store_name, key, str(value)
+
+    def prune(self, *, live_paths: set[str] | None = None, dry_run: bool = False) -> dict[str, int]:
+        """Remove expired and orphaned entries and return a summary.
+
+        Expired = older than ``ttl_seconds`` (only when TTL is enabled).
+        Orphaned = the entry's referenced file path no longer appears among
+        ``live_paths`` (only applied when a non-empty ``live_paths`` is given, so
+        a wrong or empty repo path can never wipe the whole cache). Expired takes
+        precedence when an entry matches both.
+        """
+        now = self._now()
+        check_orphans = bool(live_paths)
+        to_remove: list[tuple[str, str]] = []
+        bytes_freed = 0
+        expired = 0
+        orphaned = 0
+        for store_name in self._STORES:
+            store = self._store(store_name)
+            timestamps = self._timestamps(store_name)
+            for key, value in list(store.items()):
+                is_expired = (
+                    self.ttl_seconds > 0
+                    and timestamps.get(key) is not None
+                    and (now - timestamps[key]) > self.ttl_seconds
+                )
+                is_orphaned = check_orphans and not any(path in key for path in live_paths)
+                if not (is_expired or is_orphaned):
+                    continue
+                to_remove.append((store_name, key))
+                bytes_freed += len(str(value).encode("utf-8"))
+                if is_expired:
+                    expired += 1
+                else:
+                    orphaned += 1
+        if not dry_run and to_remove:
+            for store_name, key in to_remove:
+                self._store(store_name).pop(key, None)
+                self._timestamps(store_name).pop(key, None)
+            self._write_current()
+        return {
+            "entries_removed": len(to_remove),
+            "bytes_freed": bytes_freed,
+            "expired": expired,
+            "orphaned": orphaned,
+        }
 
     def _merge_with_disk(self) -> dict[str, Any]:
         """Fold this process's in-memory entries into whatever is on disk now.
@@ -356,6 +452,21 @@ class LocalFileSummaryCacheBackend(SummaryCacheBackend):
             if isinstance(mem_store, dict):
                 combined.update(mem_store)  # in-memory wins per key
             merged[store] = combined
+        # Merge per-entry timestamps the same way so a concurrent writer's fresh
+        # timestamps are not discarded.
+        disk_ts = disk.get("timestamps") if isinstance(disk.get("timestamps"), dict) else {}
+        mem_ts = (
+            self._data.get("timestamps") if isinstance(self._data.get("timestamps"), dict) else {}
+        )
+        merged_ts: dict[str, dict[str, float]] = {}
+        for store in ("summaries", "fragments", "slices"):
+            combined_ts: dict[str, float] = {}
+            if isinstance(disk_ts.get(store), dict):
+                combined_ts.update(disk_ts[store])
+            if isinstance(mem_ts.get(store), dict):
+                combined_ts.update(mem_ts[store])
+            merged_ts[store] = combined_ts
+        merged["timestamps"] = merged_ts
         # Carry over any extra top-level keys this process holds (forward-compat).
         for key, value in self._data.items():
             merged.setdefault(key, value)
@@ -371,6 +482,24 @@ class LocalFileSummaryCacheBackend(SummaryCacheBackend):
                     json.dumps(merged, indent=2, sort_keys=True),
                 )
                 self._data = merged
+        except OSError:
+            return
+
+    def _write_current(self) -> None:
+        """Overwrite the cache file with the in-memory state, without merging.
+
+        The normal _save() unions with the on-disk copy so concurrent writers do
+        not clobber each other, but that union would resurrect the entries prune
+        just removed. Prune is authoritative maintenance, so it writes the
+        reduced state directly under the file lock.
+        """
+        lock_path = self.cache_path.with_name(self.cache_path.name + ".lock")
+        try:
+            with _cache_file_lock(lock_path):
+                atomic_write_text(
+                    self.cache_path,
+                    json.dumps(self._data, indent=2, sort_keys=True),
+                )
         except OSError:
             return
 
@@ -933,6 +1062,7 @@ def create_summary_cache_backend(
     backend: str = LocalFileSummaryCacheBackend.backend_name,
     cache_file: str = CACHE_FILE,
     enabled: bool = True,
+    local_ttl_seconds: int = 0,
     redis_url: str = "redis://localhost:6379/0",
     redis_namespace: str = "redcon",
     redis_ttl_seconds: int = 86400,
@@ -942,7 +1072,10 @@ def create_summary_cache_backend(
     backend_name = normalize_cache_backend_name(backend)
     if backend_name == LocalFileSummaryCacheBackend.backend_name:
         return LocalFileSummaryCacheBackend(
-            repo_path=repo_path, cache_file=cache_file, enabled=enabled
+            repo_path=repo_path,
+            cache_file=cache_file,
+            enabled=enabled,
+            ttl_seconds=local_ttl_seconds,
         )
     if backend_name == SQLiteSummaryCacheBackend.backend_name:
         return SQLiteSummaryCacheBackend(

--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -2707,6 +2707,41 @@ def cmd_cmd_quality(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_cache(args: argparse.Namespace) -> int:
+    repo_path = Path(args.repo).resolve()
+    if not repo_path.is_dir():
+        print(f"Error: repo path not found: {repo_path}", file=sys.stderr)
+        return 2
+
+    from redcon.cache.backends import LocalFileSummaryCacheBackend
+    from redcon.scanners.repository import scan_repository
+
+    cfg = load_config(repo_path)
+    backend = LocalFileSummaryCacheBackend(
+        repo_path=repo_path,
+        cache_file=cfg.cache.cache_file,
+        ttl_seconds=cfg.cache.local_ttl_seconds,
+    )
+    live_paths = {record.path for record in scan_repository(repo_path)}
+    summary = backend.prune(live_paths=live_paths, dry_run=args.dry_run)
+
+    if args.json:
+        print(
+            _json_mod.dumps({"repo": str(repo_path), "dry_run": args.dry_run, **summary}, indent=2)
+        )
+        return 0
+
+    verb = "Would remove" if args.dry_run else "Removed"
+    print(
+        f"{verb} {summary['entries_removed']} cache entries "
+        f"({summary['expired']} expired, {summary['orphaned']} orphaned), "
+        f"freeing {summary['bytes_freed']} bytes."
+    )
+    if cfg.cache.local_ttl_seconds <= 0 and summary["expired"] == 0:
+        print("Note: [cache].local_ttl_seconds is 0, so entries do not expire by age.")
+    return 0
+
+
 def _register_setup_commands(sub: argparse._SubParsersAction) -> None:
     doctor = sub.add_parser(
         "doctor", help="Check environment health, dependencies, and configuration"
@@ -2727,6 +2762,24 @@ def _register_setup_commands(sub: argparse._SubParsersAction) -> None:
         help="Print raw JSON to stdout (shorthand for --format json).",
     )
     doctor.set_defaults(func=cmd_doctor)
+
+    cache = sub.add_parser("cache", help="Maintain the local summary cache")
+    cache.add_argument("action", choices=["prune"], help="Cache maintenance action to run")
+    cache.add_argument("--repo", default=".", help="Repository path (default: current directory).")
+    cache.add_argument(
+        "--dry-run",
+        dest="dry_run",
+        action="store_true",
+        default=False,
+        help="Show what would be removed without modifying the cache.",
+    )
+    cache.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help="Print a machine-readable JSON summary.",
+    )
+    cache.set_defaults(func=cmd_cache)
 
     license_parser = sub.add_parser(
         "license", help="Show, activate, or remove your redcon Pro license"

--- a/redcon/config.py
+++ b/redcon/config.py
@@ -185,6 +185,10 @@ class CacheSettings:
     history_file: str = RUN_HISTORY_FILE
     history_db: str = ".redcon/history.db"
     history_max_entries: int = 200
+    # Local (file/sqlite) cache freshness. 0 disables TTL, so entries never
+    # expire and current behaviour is unchanged; a positive value expires local
+    # cache entries older than that many seconds, mirroring the Redis TTL.
+    local_ttl_seconds: int = 0
     # Redis backend settings
     redis_url: str = "redis://localhost:6379/0"
     redis_namespace: str = "redcon"
@@ -630,6 +634,8 @@ def _apply_cache_overrides(settings: CacheSettings, data: Mapping[str, Any]) -> 
         settings.history_db = str(data["history_db"])
     if "history_max_entries" in data:
         settings.history_max_entries = int(data["history_max_entries"])
+    if "local_ttl_seconds" in data:
+        settings.local_ttl_seconds = int(data["local_ttl_seconds"])
     # Redis backend settings
     if "redis_url" in data:
         settings.redis_url = str(data["redis_url"]).strip()

--- a/redcon/stages/workflow.py
+++ b/redcon/stages/workflow.py
@@ -284,6 +284,7 @@ def run_cache_stage(repo: Path, config: RedconConfig) -> SummaryCacheBackend:
         backend=config.cache.backend,
         cache_file=config.cache.cache_file,
         enabled=config.cache.summary_cache_enabled,
+        local_ttl_seconds=config.cache.local_ttl_seconds,
         redis_url=config.cache.redis_url,
         redis_namespace=config.cache.redis_namespace,
         redis_ttl_seconds=config.cache.redis_ttl_seconds,

--- a/tests/test_cache_ttl_prune.py
+++ b/tests/test_cache_ttl_prune.py
@@ -1,0 +1,131 @@
+"""Local cache TTL freshness and the `redcon cache prune` command.
+
+TTL is disabled by default (local_ttl_seconds = 0), so existing behaviour is
+unchanged. When enabled, local cache entries older than the TTL are treated as
+misses. `cache prune` removes expired entries and entries whose referenced file
+no longer exists, and is a no-op when nothing qualifies.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from redcon.cache.backends import LocalFileSummaryCacheBackend
+from redcon.cli import build_parser
+from redcon.config import load_config
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_ttl_disabled_by_default_keeps_entries(tmp_path: Path) -> None:
+    backend = LocalFileSummaryCacheBackend(repo_path=tmp_path)  # ttl_seconds defaults to 0
+    backend.put_summary("k", "v")
+    # Even far in the "future", a disabled TTL never expires an entry.
+    backend._now = lambda: 10**12
+    assert backend.get_summary("k") == "v"
+
+
+def test_ttl_expires_stale_entries(tmp_path: Path) -> None:
+    backend = LocalFileSummaryCacheBackend(repo_path=tmp_path, ttl_seconds=100)
+    base = backend._now()
+    backend.put_summary("k", "v")
+    backend._now = lambda: base + 50
+    assert backend.get_summary("k") == "v"  # within TTL
+    backend._now = lambda: base + 200
+    assert backend.get_summary("k") is None  # expired -> miss
+
+
+def test_prune_removes_orphaned_keeps_live(tmp_path: Path) -> None:
+    backend = LocalFileSummaryCacheBackend(repo_path=tmp_path)
+    backend.put_summary("auth/login.py:10:h1:summary", "LIVE")
+    backend.put_summary("deleted/gone.py:5:h2:summary", "ORPHAN")
+    result = backend.prune(live_paths={"auth/login.py"})
+    assert result["entries_removed"] == 1
+    assert result["orphaned"] == 1
+    assert result["bytes_freed"] > 0
+    assert backend.get_summary("auth/login.py:10:h1:summary") == "LIVE"
+    assert backend.get_summary("deleted/gone.py:5:h2:summary") is None
+
+
+def test_prune_removes_expired(tmp_path: Path) -> None:
+    backend = LocalFileSummaryCacheBackend(repo_path=tmp_path, ttl_seconds=100)
+    backend.put_summary("auth/login.py:10:h1:summary", "OLD")
+    # Backdate the timestamp so the entry is past its TTL.
+    backend._timestamps("summaries")["auth/login.py:10:h1:summary"] = backend._now() - 1000
+    result = backend.prune(live_paths={"auth/login.py"})
+    assert result["expired"] == 1
+    assert result["entries_removed"] == 1
+
+
+def test_prune_with_no_expired_or_orphaned_is_noop(tmp_path: Path) -> None:
+    backend = LocalFileSummaryCacheBackend(repo_path=tmp_path)
+    backend.put_summary("auth/login.py:10:h1:summary", "LIVE")
+    backend._save()
+    before = (tmp_path / ".redcon_cache.json").read_text()
+    result = backend.prune(live_paths={"auth/login.py"})
+    assert result == {"entries_removed": 0, "bytes_freed": 0, "expired": 0, "orphaned": 0}
+    assert (tmp_path / ".redcon_cache.json").read_text() == before
+
+
+def test_prune_dry_run_does_not_write(tmp_path: Path) -> None:
+    backend = LocalFileSummaryCacheBackend(repo_path=tmp_path)
+    backend.put_summary("gone/x.py:1:h:summary", "ORPHAN")
+    backend._save()
+    before = (tmp_path / ".redcon_cache.json").read_text()
+    result = backend.prune(live_paths={"auth/login.py"}, dry_run=True)
+    assert result["entries_removed"] == 1
+    assert (tmp_path / ".redcon_cache.json").read_text() == before  # unchanged
+
+
+def test_prune_empty_live_paths_skips_orphan_removal(tmp_path: Path) -> None:
+    # A wrong or empty repo must not wipe the whole cache.
+    backend = LocalFileSummaryCacheBackend(repo_path=tmp_path)
+    backend.put_summary("auth/login.py:10:h1:summary", "LIVE")
+    result = backend.prune(live_paths=set())
+    assert result["entries_removed"] == 0
+    assert backend.get_summary("auth/login.py:10:h1:summary") == "LIVE"
+
+
+def test_config_local_ttl_seconds_loads(tmp_path: Path) -> None:
+    _write(tmp_path / "redcon.toml", "[cache]\nlocal_ttl_seconds = 3600\n")
+    cfg = load_config(tmp_path)
+    assert cfg.cache.local_ttl_seconds == 3600
+    # Default stays disabled.
+    assert load_config(tmp_path / "other").cache.local_ttl_seconds == 0
+
+
+def _run_cli(argv: list[str]) -> int:
+    args = build_parser().parse_args(argv)
+    return int(args.func(args))
+
+
+def test_cli_cache_prune_end_to_end(tmp_path: Path) -> None:
+    _write(tmp_path / "auth" / "login.py", "def login(t):\n    return bool(t)\n")
+    cache_path = tmp_path / ".redcon_cache.json"
+    cache_path.write_text(
+        json.dumps(
+            {
+                "summaries": {
+                    "auth/login.py:10:h1:summary": "LIVE",
+                    "deleted/gone.py:5:h2:summary": "ORPHAN",
+                },
+                "fragments": {},
+                "slices": {},
+                "timestamps": {"summaries": {}, "fragments": {}, "slices": {}},
+            }
+        )
+    )
+    # Dry run leaves the file untouched.
+    before = cache_path.read_text()
+    assert _run_cli(["cache", "prune", "--repo", str(tmp_path), "--dry-run"]) == 0
+    assert cache_path.read_text() == before
+
+    # Real run removes the orphan, keeps the live entry.
+    assert _run_cli(["cache", "prune", "--repo", str(tmp_path)]) == 0
+    remaining = json.loads(cache_path.read_text())["summaries"]
+    assert "auth/login.py:10:h1:summary" in remaining
+    assert "deleted/gone.py:5:h2:summary" not in remaining


### PR DESCRIPTION
Launch backlog issue 5: local cache TTL and a prune command.

## TTL freshness
- New `[cache].local_ttl_seconds` (default `0` = disabled, so current behaviour is unchanged), following the `redis_ttl_seconds` naming/convention (`0` = no expiry).
- The `local_file` backend records a per-entry timestamp (a sidecar `timestamps` map in `.redcon_cache.json`, merged the same way the stores are so concurrent writers are not lost) and treats entries older than the TTL as a cache miss.
- Entries written before TTL was enabled have no timestamp and are treated as fresh, so turning TTL on never retroactively drops existing entries.

## `redcon cache prune [--repo <path>] [--dry-run] [--json]`
- Removes **expired** entries (past `local_ttl_seconds`, when enabled) and **orphaned** entries (the cached file no longer exists in the repo, matched by path against a fresh scan).
- Prints `entries_removed`, `bytes_freed`, `expired`, `orphaned`; `--dry-run` changes nothing; `--json` is machine-readable.
- Follows the existing `mcp`/`hooks` action-positional CLI pattern (`cache prune`) and the `pack --dry-run` flag convention.

## Design notes for the reviewer
- **Prune writes authoritatively.** The normal `_save()` unions with the on-disk copy (so concurrent packers do not clobber each other); using it for prune would resurrect the entries just removed. Prune therefore overwrites the reduced state directly under the same file lock. This was caught in testing - the first cut "removed" entries that reappeared.
- **Orphaned = referenced file path gone.** Cache keys embed both a content hash and the file path, but their exact shapes differ per store (summary vs fragment), so I match on the file path being absent rather than parsing keys. Conservative: an **empty** `live_paths` (wrong/empty repo) skips orphan removal entirely, so prune can never wipe the whole cache by accident.
- TTL/prune target the `local_file` cache (the default and what "local cache" means); Redis keeps its native TTL.

## Tests (`tests/test_cache_ttl_prune.py`)
TTL disabled-by-default keeps entries; TTL expires stale entries; prune removes orphaned/expired; **prune with nothing expired or orphaned is a no-op that leaves the file byte-identical**; dry-run does not write; empty `live_paths` skips orphan removal; config loads `local_ttl_seconds`; and an end-to-end CLI test. Full suite: 1172 passed.