### PR TITLE
Add a policy rule for skipped critical files

### DIFF
--- a/.github/redcon-policy.toml
+++ b/.github/redcon-policy.toml
@@ -5,3 +5,6 @@ max_estimated_input_tokens = 30000
 max_files_included = 12
 max_quality_risk_level = "medium"
 min_estimated_savings_percentage = 0.0
+# Fail if a file matching [score] critical_path_keywords is scanned but skipped.
+# No-op unless critical_path_keywords is configured. Off by default.
+forbid_skipped_critical_files = false

--- a/docs/ci-recipes.md
+++ b/docs/ci-recipes.md
@@ -132,6 +132,8 @@ max_estimated_input_tokens = 30000
 max_files_included = 12
 max_quality_risk_level = "medium"
 min_estimated_savings_percentage = 0.0
+# Fail if a file matching [score] critical_path_keywords is scanned but skipped.
+forbid_skipped_critical_files = true
 ```
 
 On a violation, `pack` prints `Policy check: FAIL` with the offending rules and

--- a/docs/policy-and-ci.md
+++ b/docs/policy-and-ci.md
@@ -16,6 +16,20 @@ Supported checks:
 - max files included
 - max quality risk level
 - minimum estimated savings percentage
+- max context size bytes
+- forbid skipped critical files
+
+`forbid_skipped_critical_files = true` fails the check when a file whose path
+matches the run's `[score] critical_path_keywords` was scanned but skipped
+(ranked out of the budget). The keywords travel on the run artifact, so
+`redcon report <run.json> --policy` enforces the same rule against a recorded
+run. With no critical keywords configured the rule has nothing to match and
+passes. It is off unless set, so existing policies are unaffected.
+
+```toml
+[policy]
+forbid_skipped_critical_files = true
+```
 
 ## Existing GitHub Action
 

--- a/redcon/core/policy.py
+++ b/redcon/core/policy.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Strict budget policy loading and enforcement helpers."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
@@ -32,6 +32,10 @@ class PolicySpec:
     max_quality_risk_level: str | None = None
     min_estimated_savings_percentage: float | None = None
     max_context_size_bytes: int | None = None
+    # When True, fail if any file whose path matches the run's
+    # critical_path_keywords was scanned but skipped (not included). None or
+    # False leaves the rule disabled, so existing policies are unaffected.
+    forbid_skipped_critical_files: bool | None = None
 
 
 @dataclass(slots=True)
@@ -74,16 +78,15 @@ def _risk_value(label: str | None) -> int:
 
 def _parse_policy_dict(raw: dict[str, Any]) -> PolicySpec:
     policy_block = raw.get("policy")
-    if isinstance(policy_block, dict):
-        data = policy_block
-    else:
-        data = raw
+    data = policy_block if isinstance(policy_block, dict) else raw
 
     max_input_tokens = _to_int(data.get("max_estimated_input_tokens"))
     max_files = _to_int(data.get("max_files_included"))
     max_quality_risk = _normalize_risk(data.get("max_quality_risk_level"))
     min_savings = _to_float(data.get("min_estimated_savings_percentage"))
     max_context_size_bytes = _to_int(data.get("max_context_size_bytes"))
+    forbid_raw = data.get("forbid_skipped_critical_files")
+    forbid_skipped = bool(forbid_raw) if forbid_raw is not None else None
 
     return PolicySpec(
         max_estimated_input_tokens=max_input_tokens,
@@ -91,6 +94,7 @@ def _parse_policy_dict(raw: dict[str, Any]) -> PolicySpec:
         max_quality_risk_level=max_quality_risk,
         min_estimated_savings_percentage=min_savings,
         max_context_size_bytes=max_context_size_bytes,
+        forbid_skipped_critical_files=forbid_skipped,
     )
 
 
@@ -100,9 +104,7 @@ def _validate_percentage_thresholds(spec: PolicySpec) -> list[str]:
     if spec.min_estimated_savings_percentage is not None:
         val = spec.min_estimated_savings_percentage
         if val < 0 or val > 100:
-            errors.append(
-                f"min_estimated_savings_percentage must be between 0 and 100, got {val}"
-            )
+            errors.append(f"min_estimated_savings_percentage must be between 0 and 100, got {val}")
     return errors
 
 
@@ -143,8 +145,7 @@ def load_policy(path: Path) -> PolicySpec:
     validation_errors = _validate_percentage_thresholds(spec)
     if validation_errors:
         raise ValueError(
-            f"Policy file '{path}' has invalid thresholds: "
-            + "; ".join(validation_errors)
+            f"Policy file '{path}' has invalid thresholds: " + "; ".join(validation_errors)
         )
 
     return spec
@@ -164,16 +165,15 @@ def _extract_metrics(run_data: dict[str, Any]) -> dict[str, Any]:
     files_included = effective.get("files_included", [])
     if not isinstance(files_included, list):
         files_included = []
-    estimated_input_tokens = int(effective.get("estimated_input_tokens", budget.get("estimated_input_tokens", 0)) or 0)
+    estimated_input_tokens = int(
+        effective.get("estimated_input_tokens", budget.get("estimated_input_tokens", 0)) or 0
+    )
     estimated_saved_tokens = int(
         effective.get("estimated_saved_tokens", budget.get("estimated_saved_tokens", 0)) or 0
     )
 
     total_tokens = estimated_input_tokens + estimated_saved_tokens
-    if total_tokens > 0:
-        savings_pct = (estimated_saved_tokens / total_tokens) * 100.0
-    else:
-        savings_pct = 0.0
+    savings_pct = (estimated_saved_tokens / total_tokens) * 100.0 if total_tokens > 0 else 0.0
 
     compressed_context = run_data.get("compressed_context", [])
     context_size_bytes = 0
@@ -232,7 +232,11 @@ def evaluate_policy(run_data: dict[str, Any], policy: PolicySpec) -> PolicyResul
         actual = float(metrics["estimated_savings_percentage"])
         limit = float(policy.min_estimated_savings_percentage)
         passed = actual >= limit
-        checks["min_estimated_savings_percentage"] = {"actual": actual, "limit": limit, "passed": passed}
+        checks["min_estimated_savings_percentage"] = {
+            "actual": actual,
+            "limit": limit,
+            "passed": passed,
+        }
         if not passed:
             violations.append(f"estimated savings {actual:.2f}% is below minimum {limit:.2f}%")
 
@@ -243,6 +247,27 @@ def evaluate_policy(run_data: dict[str, Any], policy: PolicySpec) -> PolicyResul
         checks["max_context_size_bytes"] = {"actual": actual, "limit": limit, "passed": passed}
         if not passed:
             violations.append(f"context size {actual} bytes exceeds max {limit} bytes")
+
+    if policy.forbid_skipped_critical_files:
+        keywords = [
+            str(kw).lower()
+            for kw in run_data.get("critical_path_keywords", [])
+            if isinstance(kw, str) and kw
+        ]
+        skipped = run_data.get("files_skipped", [])
+        offenders = sorted(
+            path
+            for path in (skipped if isinstance(skipped, list) else [])
+            if isinstance(path, str) and any(kw in path.lower() for kw in keywords)
+        )
+        passed = not offenders
+        checks["forbid_skipped_critical_files"] = {
+            "actual": len(offenders),
+            "limit": 0,
+            "passed": passed,
+        }
+        if not passed:
+            violations.append(f"critical files were skipped: {', '.join(offenders)}")
 
     return PolicyResult(passed=not violations, violations=violations, checks=checks)
 

--- a/redcon/schemas/json/v1/run.schema.json
+++ b/redcon/schemas/json/v1/run.schema.json
@@ -32,6 +32,11 @@
     },
     "files_included": { "type": "array", "items": { "type": "string" } },
     "files_skipped": { "type": "array", "items": { "type": "string" } },
+    "critical_path_keywords": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Critical-path keywords in effect for this run, used by the forbid_skipped_critical_files policy rule."
+    },
     "budget": {
       "type": "object",
       "required": ["max_tokens", "estimated_input_tokens"],

--- a/redcon/schemas/models.py
+++ b/redcon/schemas/models.py
@@ -332,6 +332,10 @@ class RunReport:
     # picking the right files.
     context_baseline_tokens: int = 0
     files_scanned: int = 0
+    # The critical-path keywords in effect for this run, carried on the artifact
+    # so a policy check (for example forbid_skipped_critical_files) can see which
+    # files counted as critical without re-deriving the scoring config.
+    critical_path_keywords: list[str] = field(default_factory=list)
     # Which compression profile shaped this run's tier thresholds: "default"
     # or "max" (the max-compression preset). An unknown profile name falls
     # back to "default" - what actually ran.

--- a/redcon/stages/workflow.py
+++ b/redcon/stages/workflow.py
@@ -367,6 +367,7 @@ def run_render_stage(
         prompt_cache_key=_prompt_cache_key(serialized_context),
         files_included=compressed.files_included,
         files_skipped=compressed.files_skipped,
+        critical_path_keywords=list(config.score.critical_path_keywords),
         budget={
             "max_tokens": max_tokens,
             "estimated_input_tokens": compressed.estimated_input_tokens,
@@ -492,6 +493,7 @@ def as_json_dict(report: RunReport | AgentPlanReport) -> dict:
         "token_estimator",
         "model_profile",
         "delta",
+        "critical_path_keywords",
     ):
         if not data.get(key):
             data.pop(key, None)

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -10,7 +10,9 @@ def _write(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
-def _run_payload(*, input_tokens: int, saved_tokens: int, files_included: list[str], risk: str) -> dict:
+def _run_payload(
+    *, input_tokens: int, saved_tokens: int, files_included: list[str], risk: str
+) -> dict:
     return {
         "files_included": files_included,
         "budget": {
@@ -79,3 +81,62 @@ def test_evaluate_policy_passes_when_thresholds_met() -> None:
     result = evaluate_policy(run, policy)
     assert result.passed is True
     assert result.violations == []
+
+
+def _critical_payload(*, skipped: list[str], keywords: list[str]) -> dict:
+    return {
+        "files_included": ["auth/login.py"],
+        "files_skipped": skipped,
+        "critical_path_keywords": keywords,
+        "budget": {"estimated_input_tokens": 100, "quality_risk_estimate": "low"},
+    }
+
+
+def test_forbid_skipped_critical_files_fails_when_critical_skipped() -> None:
+    run = _critical_payload(skipped=["auth/legacy.py", "utils/misc.py"], keywords=["auth"])
+    from redcon.core.policy import PolicySpec
+
+    result = evaluate_policy(run, PolicySpec(forbid_skipped_critical_files=True))
+    assert result.passed is False
+    assert any(
+        "critical files were skipped" in v and "auth/legacy.py" in v for v in result.violations
+    )
+    assert result.checks["forbid_skipped_critical_files"]["actual"] == 1
+
+
+def test_forbid_skipped_critical_files_passes_when_none_critical_skipped() -> None:
+    run = _critical_payload(skipped=["utils/misc.py"], keywords=["auth"])
+    from redcon.core.policy import PolicySpec
+
+    result = evaluate_policy(run, PolicySpec(forbid_skipped_critical_files=True))
+    assert result.passed is True
+    assert result.checks["forbid_skipped_critical_files"]["passed"] is True
+
+
+def test_forbid_skipped_critical_files_disabled_by_default() -> None:
+    run = _critical_payload(skipped=["auth/legacy.py"], keywords=["auth"])
+    from redcon.core.policy import PolicySpec
+
+    # None (default) leaves the rule off, so a skipped critical file is fine.
+    result = evaluate_policy(run, PolicySpec())
+    assert result.passed is True
+    assert "forbid_skipped_critical_files" not in result.checks
+
+
+def test_load_forbid_skipped_critical_files_from_toml(tmp_path: Path) -> None:
+    path = tmp_path / "policy.toml"
+    _write(path, "[policy]\nforbid_skipped_critical_files = true\n")
+    policy = load_policy(path)
+    assert policy.forbid_skipped_critical_files is True
+
+
+def test_run_pack_artifact_carries_critical_path_keywords(tmp_path: Path) -> None:
+    from redcon.config import default_config
+    from redcon.core import pipeline
+    from redcon.stages.workflow import as_json_dict
+
+    _write(tmp_path / "auth" / "login.py", "def login(t):\n    return bool(t)\n")
+    cfg = default_config()
+    cfg.score.critical_path_keywords = ["auth"]
+    data = as_json_dict(pipeline.run_pack("harden auth", tmp_path, max_tokens=5000, config=cfg))
+    assert data.get("critical_path_keywords") == ["auth"]


### PR DESCRIPTION
Launch backlog issue 8: a policy rule that fails when critical files are skipped.

## Field shape (as proposed)
- `PolicySpec.forbid_skipped_critical_files: bool | None = None`. `None`/`False` = disabled (backward compatible); `True` enables the rule. It follows the existing optional-rule convention.
- The rule fails when a path in `files_skipped` matches any of the run's `critical_path_keywords` (substring match on the lowercased path, the same match scoring uses). Violation: `critical files were skipped: <paths>`; the check is named `forbid_skipped_critical_files` in the policy output.

## Where the keywords come from (design choice)
`critical_path_keywords` live in `[score]` config, but `evaluate_policy(run_data, policy)` only gets the artifact + spec - and `redcon report <run.json> --policy` runs against a bare artifact with no repo/config in scope. So I **carry the keywords on the run artifact** (`RunReport.critical_path_keywords`, populated from `config.score.critical_path_keywords`, dropped from `run.json` when empty). The rule reads them from `run_data`, so it works identically for `pack --strict --policy` and `report --policy`, using the keywords that were in effect when the run was produced.

## Wiring
- Parsed from `[policy]` TOML in `load_policy`; evaluated in `evaluate_policy` alongside the existing rules; strict mode still exits `2` on violation and `report --policy` behaves the same.

## Tests (`tests/test_policy.py`)
Fail (critical file skipped), pass (only non-critical skipped), disabled-by-default (no `checks` entry), TOML load, and an end-to-end test that a real `run_pack` artifact carries `critical_path_keywords`.

## Docs
`policy-and-ci.md`, the `.github/redcon-policy.toml` example, and the `ci-recipes.md` policy block. `run.schema.json` documents the new artifact field.

## Note
Reordered the policy module header (docstring before `from __future__`) and converted two pre-existing `if/else` blocks to ternaries to satisfy ruff, now that the file is edited. No behavior change from those.