### PR TITLE
Add a realistic example service repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ redcon pr-audit --repo . --base origin/main --head HEAD
 
 Output goes to `run.json` (machine-readable) and `run.md` (human-readable). Use them in CI, or feed the compressed context directly into your agent.
 
+For a full end-to-end walkthrough on a realistic service repo (plan, pack, validate, with deterministic output), see [examples/service-repo](examples/service-repo/README.md).
+
 ## How It Works
 
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,17 @@
 # Example Scenarios
 
+## Service repo (end-to-end)
+
+A small, realistic orders service (API, business logic, persistence, auth,
+events, tests, config) with a walkthrough of `plan`, `pack` and `validate` and
+their deterministic output. See [service-repo/README.md](service-repo/README.md).
+
+```bash
+redcon plan "add an order cancellation endpoint" --repo examples/service-repo
+redcon pack "add an order cancellation endpoint" --repo examples/service-repo --max-tokens 8000
+redcon validate run.json
+```
+
 ## Small feature
 
 ```bash

--- a/examples/service-repo/.gitignore
+++ b/examples/service-repo/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+run.json
+run.md
+run.html
+.redcon_cache.json

--- a/examples/service-repo/README.md
+++ b/examples/service-repo/README.md
@@ -1,0 +1,81 @@
+# Example service repo
+
+A small, deterministic orders service used to show redcon on a realistic
+codebase: a layered Python service (API, business logic, persistence, auth,
+events) with tests and config. Everything here is fixed, so the commands below
+reproduce the same output every time.
+
+## Layout
+
+```
+service-repo/
+  redcon.toml            # critical_path_keywords = ["auth"], local cache TTL
+  pyproject.toml
+  src/orders/
+    api.py               # request handlers        -> service, auth
+    service.py           # create / pay / cancel    -> repository, events, models
+    repository.py        # persistence              -> db, models
+    auth.py              # bearer-token auth (critical path)
+    models.py  db.py  events.py  config.py  errors.py
+    main.py              # entrypoint wiring it together
+  tests/                 # test_api / service / repository / auth / models
+```
+
+The modules import each other (api -> service -> repository -> db), so redcon's
+import graph propagates relevance across the layers.
+
+## Reproduce
+
+Run these from the repository root. All outputs are deterministic.
+
+### 1. Rank the files a task touches
+
+```bash
+redcon plan "add an order cancellation endpoint" --repo examples/service-repo
+```
+
+The top-ranked files, in order, are:
+
+```
+1. src/orders/api.py
+2. src/orders/repository.py
+3. src/orders/service.py
+4. src/orders/main.py
+5. src/orders/models.py
+```
+
+`api.py` (the handler layer), `service.py` (which owns `cancel_order`) and
+their import neighbours rise to the top; the leaf `models.py` follows.
+
+### 2. Pack context under a budget
+
+```bash
+redcon pack "add an order cancellation endpoint" --repo examples/service-repo --max-tokens 8000
+```
+
+Writes `run.json` and `run.md`. The pack fits the whole service (18 files) well
+under the 8000-token budget and reports a `low` quality risk. Add `--html` for a
+self-contained `run.html` report.
+
+### 3. Validate the artifact
+
+```bash
+redcon validate run.json
+```
+
+Prints `valid run artifact` and exits `0`, so the pack output can be gated in CI.
+
+## What the config demonstrates
+
+`redcon.toml` sets `critical_path_keywords = ["auth"]`, so `auth.py` is treated
+as a critical path. Combined with a policy that sets
+`forbid_skipped_critical_files = true`, a pack that ranked `auth.py` out of the
+budget would fail the check. It also sets `local_ttl_seconds`, so
+`redcon cache prune --repo examples/service-repo` reports and removes stale
+cache entries.
+
+## Determinism
+
+redcon is deterministic: the same tree and task always produce the same ranking
+and the same `prompt_cache_key`, so this example's output does not drift. The
+project test suite pins the ranking above.

--- a/examples/service-repo/pyproject.toml
+++ b/examples/service-repo/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "orders-service"
+version = "0.1.0"
+description = "A small deterministic orders service used as a redcon example."
+requires-python = ">=3.10"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/examples/service-repo/redcon.toml
+++ b/examples/service-repo/redcon.toml
@@ -1,0 +1,10 @@
+# Redcon configuration for the example orders service.
+
+[score]
+# Auth is the security-critical path here: flag it if a matching file is
+# scanned but skipped, in combination with a policy that forbids that.
+critical_path_keywords = ["auth"]
+
+[cache]
+# Local cache with a one-day freshness window; prune with `redcon cache prune`.
+local_ttl_seconds = 86400

--- a/examples/service-repo/src/orders/__init__.py
+++ b/examples/service-repo/src/orders/__init__.py
@@ -1,0 +1,4 @@
+"""A small deterministic orders service used as a redcon example repository."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/examples/service-repo/src/orders/api.py
+++ b/examples/service-repo/src/orders/api.py
@@ -1,0 +1,29 @@
+"""HTTP-style request handlers mapping requests onto the order service."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from orders.auth import require_role
+from orders.errors import OrderError
+from orders.models import OrderItem
+from orders.service import OrderService
+
+
+class OrderApi:
+    def __init__(self, service: OrderService) -> None:
+        self._service = service
+
+    def create(self, token: str, body: dict[str, Any]) -> dict[str, Any]:
+        require_role(token, "user")
+        items = [OrderItem(**item) for item in body.get("items", [])]
+        order = self._service.create_order(body["id"], body["customer_id"], items)
+        return {"id": order.id, "status": order.status, "total_cents": order.total_cents()}
+
+    def cancel(self, token: str, order_id: str) -> dict[str, Any]:
+        require_role(token, "admin")
+        try:
+            order = self._service.cancel_order(order_id)
+        except OrderError as exc:
+            return {"error": str(exc)}
+        return {"id": order.id, "status": order.status}

--- a/examples/service-repo/src/orders/auth.py
+++ b/examples/service-repo/src/orders/auth.py
@@ -1,0 +1,22 @@
+"""Authentication for the orders service (a critical-path module)."""
+
+from __future__ import annotations
+
+from orders.errors import AuthError
+
+_VALID_TOKENS = {"tok_admin": "admin", "tok_user": "user"}
+
+
+def authenticate(token: str) -> str:
+    """Return the role for a bearer token or raise AuthError."""
+    role = _VALID_TOKENS.get(token)
+    if role is None:
+        raise AuthError("invalid or missing token")
+    return role
+
+
+def require_role(token: str, needed: str) -> None:
+    """Raise AuthError unless the token grants at least the needed role."""
+    role = authenticate(token)
+    if needed == "admin" and role != "admin":
+        raise AuthError("admin role required")

--- a/examples/service-repo/src/orders/config.py
+++ b/examples/service-repo/src/orders/config.py
@@ -1,0 +1,17 @@
+"""Runtime settings for the orders service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Settings:
+    currency: str = "USD"
+    max_items_per_order: int = 50
+    allow_guest_checkout: bool = False
+
+
+def load_settings() -> Settings:
+    """Return default settings. Real deployments would read the environment."""
+    return Settings()

--- a/examples/service-repo/src/orders/db.py
+++ b/examples/service-repo/src/orders/db.py
@@ -1,0 +1,24 @@
+"""In-memory storage backend for the orders service."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class Database:
+    """A tiny in-memory table keyed by string id."""
+
+    def __init__(self) -> None:
+        self._rows: dict[str, Any] = {}
+
+    def get(self, key: str) -> Any | None:
+        return self._rows.get(key)
+
+    def put(self, key: str, value: Any) -> None:
+        self._rows[key] = value
+
+    def delete(self, key: str) -> bool:
+        return self._rows.pop(key, None) is not None
+
+    def all(self) -> list[Any]:
+        return list(self._rows.values())

--- a/examples/service-repo/src/orders/errors.py
+++ b/examples/service-repo/src/orders/errors.py
@@ -1,0 +1,17 @@
+"""Domain errors for the orders service."""
+
+
+class OrderError(Exception):
+    """Base class for all order errors."""
+
+
+class OrderNotFound(OrderError):
+    """Raised when an order id does not exist."""
+
+
+class InvalidTransition(OrderError):
+    """Raised when an order status change is not allowed."""
+
+
+class AuthError(OrderError):
+    """Raised when a request is not authenticated or authorized."""

--- a/examples/service-repo/src/orders/events.py
+++ b/examples/service-repo/src/orders/events.py
@@ -1,0 +1,21 @@
+"""In-process event publishing for order lifecycle changes."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from orders.models import Order
+
+Listener = Callable[[str, Order], None]
+
+
+class EventBus:
+    def __init__(self) -> None:
+        self._listeners: list[Listener] = []
+
+    def subscribe(self, listener: Listener) -> None:
+        self._listeners.append(listener)
+
+    def publish(self, event: str, order: Order) -> None:
+        for listener in self._listeners:
+            listener(event, order)

--- a/examples/service-repo/src/orders/main.py
+++ b/examples/service-repo/src/orders/main.py
@@ -1,0 +1,28 @@
+"""Entrypoint that wires the orders service together."""
+
+from __future__ import annotations
+
+from orders.api import OrderApi
+from orders.config import load_settings
+from orders.db import Database
+from orders.events import EventBus
+from orders.repository import OrderRepository
+from orders.service import OrderService
+
+
+def build_api() -> OrderApi:
+    settings = load_settings()
+    assert settings.max_items_per_order > 0
+    events = EventBus()
+    repository = OrderRepository(Database())
+    service = OrderService(repository, events)
+    return OrderApi(service)
+
+
+def main() -> None:
+    api = build_api()
+    api.create("tok_user", {"id": "o1", "customer_id": "c1", "items": []})
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/service-repo/src/orders/models.py
+++ b/examples/service-repo/src/orders/models.py
@@ -1,0 +1,35 @@
+"""Data models for the orders service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+OPEN = "open"
+PAID = "paid"
+CANCELLED = "cancelled"
+
+_ALLOWED = {OPEN: {PAID, CANCELLED}, PAID: {CANCELLED}, CANCELLED: set()}
+
+
+@dataclass
+class OrderItem:
+    sku: str
+    quantity: int
+    unit_price_cents: int
+
+    def subtotal_cents(self) -> int:
+        return self.quantity * self.unit_price_cents
+
+
+@dataclass
+class Order:
+    id: str
+    customer_id: str
+    status: str = OPEN
+    items: list[OrderItem] = field(default_factory=list)
+
+    def total_cents(self) -> int:
+        return sum(item.subtotal_cents() for item in self.items)
+
+    def can_transition_to(self, status: str) -> bool:
+        return status in _ALLOWED.get(self.status, set())

--- a/examples/service-repo/src/orders/repository.py
+++ b/examples/service-repo/src/orders/repository.py
@@ -1,0 +1,25 @@
+"""Persistence for orders, layered over the in-memory database."""
+
+from __future__ import annotations
+
+from orders.db import Database
+from orders.errors import OrderNotFound
+from orders.models import Order
+
+
+class OrderRepository:
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    def save(self, order: Order) -> Order:
+        self._db.put(order.id, order)
+        return order
+
+    def get(self, order_id: str) -> Order:
+        order = self._db.get(order_id)
+        if order is None:
+            raise OrderNotFound(order_id)
+        return order
+
+    def list_for_customer(self, customer_id: str) -> list[Order]:
+        return [o for o in self._db.all() if o.customer_id == customer_id]

--- a/examples/service-repo/src/orders/service.py
+++ b/examples/service-repo/src/orders/service.py
@@ -1,0 +1,35 @@
+"""Order business logic: create, pay, and cancel orders."""
+
+from __future__ import annotations
+
+from orders.errors import InvalidTransition
+from orders.events import EventBus
+from orders.models import CANCELLED, PAID, Order, OrderItem
+from orders.repository import OrderRepository
+
+
+class OrderService:
+    def __init__(self, repository: OrderRepository, events: EventBus) -> None:
+        self._repository = repository
+        self._events = events
+
+    def create_order(self, order_id: str, customer_id: str, items: list[OrderItem]) -> Order:
+        order = Order(id=order_id, customer_id=customer_id, items=list(items))
+        self._repository.save(order)
+        self._events.publish("order.created", order)
+        return order
+
+    def pay_order(self, order_id: str) -> Order:
+        return self._transition(order_id, PAID, "order.paid")
+
+    def cancel_order(self, order_id: str) -> Order:
+        return self._transition(order_id, CANCELLED, "order.cancelled")
+
+    def _transition(self, order_id: str, status: str, event: str) -> Order:
+        order = self._repository.get(order_id)
+        if not order.can_transition_to(status):
+            raise InvalidTransition(f"{order.status} -> {status}")
+        order.status = status
+        self._repository.save(order)
+        self._events.publish(event, order)
+        return order

--- a/examples/service-repo/tests/test_api.py
+++ b/examples/service-repo/tests/test_api.py
@@ -1,0 +1,27 @@
+import pytest
+
+from orders.api import OrderApi
+from orders.db import Database
+from orders.errors import AuthError
+from orders.events import EventBus
+from orders.repository import OrderRepository
+from orders.service import OrderService
+
+
+def _api():
+    return OrderApi(OrderService(OrderRepository(Database()), EventBus()))
+
+
+def test_create_returns_total():
+    api = _api()
+    result = api.create(
+        "tok_user",
+        {"id": "o1", "customer_id": "c1", "items": [{"sku": "a", "quantity": 2, "unit_price_cents": 250}]},
+    )
+    assert result["total_cents"] == 500
+
+
+def test_cancel_requires_admin():
+    api = _api()
+    with pytest.raises(AuthError):
+        api.cancel("tok_user", "o1")

--- a/examples/service-repo/tests/test_auth.py
+++ b/examples/service-repo/tests/test_auth.py
@@ -1,0 +1,13 @@
+import pytest
+
+from orders.auth import authenticate, require_role
+from orders.errors import AuthError
+
+
+def test_authenticate_valid():
+    assert authenticate("tok_admin") == "admin"
+
+
+def test_require_admin_rejects_user():
+    with pytest.raises(AuthError):
+        require_role("tok_user", "admin")

--- a/examples/service-repo/tests/test_models.py
+++ b/examples/service-repo/tests/test_models.py
@@ -1,0 +1,15 @@
+from orders.models import CANCELLED, OPEN, PAID, Order, OrderItem
+
+
+def test_total_cents_sums_items():
+    order = Order(id="o1", customer_id="c1", items=[OrderItem("a", 2, 500), OrderItem("b", 1, 300)])
+    assert order.total_cents() == 1300
+
+
+def test_transition_rules():
+    order = Order(id="o1", customer_id="c1")
+    assert order.status == OPEN
+    assert order.can_transition_to(PAID)
+    assert order.can_transition_to(CANCELLED)
+    order.status = CANCELLED
+    assert not order.can_transition_to(PAID)

--- a/examples/service-repo/tests/test_repository.py
+++ b/examples/service-repo/tests/test_repository.py
@@ -1,0 +1,18 @@
+import pytest
+
+from orders.db import Database
+from orders.errors import OrderNotFound
+from orders.models import Order
+from orders.repository import OrderRepository
+
+
+def test_save_and_get():
+    repo = OrderRepository(Database())
+    repo.save(Order(id="o1", customer_id="c1"))
+    assert repo.get("o1").customer_id == "c1"
+
+
+def test_get_missing_raises():
+    repo = OrderRepository(Database())
+    with pytest.raises(OrderNotFound):
+        repo.get("nope")

--- a/examples/service-repo/tests/test_service.py
+++ b/examples/service-repo/tests/test_service.py
@@ -1,0 +1,16 @@
+from orders.db import Database
+from orders.events import EventBus
+from orders.models import CANCELLED, OrderItem
+from orders.repository import OrderRepository
+from orders.service import OrderService
+
+
+def _service():
+    return OrderService(OrderRepository(Database()), EventBus())
+
+
+def test_create_and_cancel():
+    service = _service()
+    service.create_order("o1", "c1", [OrderItem("a", 1, 100)])
+    cancelled = service.cancel_order("o1")
+    assert cancelled.status == CANCELLED

--- a/tests/test_example_service_repo.py
+++ b/tests/test_example_service_repo.py
@@ -1,0 +1,50 @@
+"""Pin the example service repo's documented output so it cannot drift.
+
+`examples/service-repo/README.md` shows a fixed ranking and a validating pack.
+These tests reproduce those commands against a temp copy of the repo (so the
+committed example is never touched by scan/cache artifacts) and assert the
+documented results.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from redcon.engine import RedconEngine
+from redcon.validation import validate_artifact
+
+_EXAMPLE = Path(__file__).resolve().parent.parent / "examples" / "service-repo"
+_TASK = "add an order cancellation endpoint"
+
+
+def _copy(dest: Path) -> Path:
+    shutil.copytree(_EXAMPLE, dest)
+    return dest
+
+
+def test_example_repo_ranking_matches_readme(tmp_path: Path) -> None:
+    repo = _copy(tmp_path / "repo")
+    data = RedconEngine().plan(task=_TASK, repo=str(repo))
+    paths = [r["path"] for r in data["ranked_files"]]
+    assert paths[:5] == [
+        "src/orders/api.py",
+        "src/orders/repository.py",
+        "src/orders/service.py",
+        "src/orders/main.py",
+        "src/orders/models.py",
+    ]
+
+
+def test_example_repo_pack_validates(tmp_path: Path) -> None:
+    repo = _copy(tmp_path / "repo")
+    run = RedconEngine().pack(task=_TASK, repo=str(repo), max_tokens=8000)
+    # The packed artifact conforms to the published run schema.
+    assert validate_artifact(run) == []
+    assert run["files_skipped"] == []  # everything fits the 8000-token budget
+
+
+def test_example_repo_pack_is_deterministic(tmp_path: Path) -> None:
+    first = RedconEngine().pack(task=_TASK, repo=str(_copy(tmp_path / "a")), max_tokens=8000)
+    second = RedconEngine().pack(task=_TASK, repo=str(_copy(tmp_path / "b")), max_tokens=8000)
+    assert first["prompt_cache_key"] == second["prompt_cache_key"]


### PR DESCRIPTION
Launch backlog issue 9: a realistic example service repo.

Adds `examples/service-repo`, a small deterministic orders service (20 files): a layered Python service - `api -> service -> repository -> db`, plus `auth`, `events`, `models`, `config`, `errors`, an entrypoint, five tests, and `redcon.toml`/`pyproject.toml`. The modules import each other so redcon's import graph propagates relevance across layers.

## README walkthrough (reproducible, deterministic)
`examples/service-repo/README.md` documents `plan`, `pack --max-tokens 8000` and `validate` with the exact recorded ranking:
```
1. src/orders/api.py
2. src/orders/repository.py
3. src/orders/service.py
4. src/orders/main.py
5. src/orders/models.py
```

## Drift protection
`tests/test_example_service_repo.py` (in the main suite) copies the repo to a temp dir (so the committed example is never touched by scan/cache artifacts) and pins: the top-5 ranking above, that the packed artifact **validates** against the run schema with nothing skipped under budget, and that two packs share a `prompt_cache_key`. If the ranking ever changes, the test fails and forces the README to be updated with it.

## Notes for the reviewer
- The main suite has `testpaths = ["tests"]`, so the example's own `tests/` are **not** collected by the project run (verified). The example is ruff-excluded like the other `examples/`.
- The `redcon.toml` sets `critical_path_keywords = ["auth"]` and a local cache TTL, tying the example to the other 1.14 features (the README shows how a `forbid_skipped_critical_files` policy and `cache prune` apply).
- Wired into `examples/README.md` and the top-level `README.md`.