### PR TITLE
Release 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-08-03
+
+### Added
+
+- `redcon cache prune [--repo <path>] [--dry-run] [--json]`: remove expired and
+  orphaned entries from the local cache, reporting entries removed and bytes
+  freed. Plus `[cache].local_ttl_seconds` (default `0`, disabled) for TTL-based
+  freshness of the local cache, mirroring the Redis backend.
+- `--html` on `pack`, `diff` and `benchmark`: write a self-contained HTML report
+  (inline CSS, no external requests) alongside the JSON and Markdown. The run
+  report surfaces per-file `score_breakdown` and `role` and the
+  `prompt_cache_key`; the benchmark report includes `baseline_comparison`.
+- Policy rule `forbid_skipped_critical_files`: fail when a file matching the
+  run's `[score] critical_path_keywords` is scanned but skipped. Disabled unless
+  set. The run artifact now carries `critical_path_keywords` so
+  `redcon report --policy` can enforce the rule against a recorded run.
+- `examples/service-repo`: a small, deterministic orders service with a
+  walkthrough of `plan`, `pack` and `validate`, pinned by a test so the docs
+  cannot drift.
+
 ## [1.13.0] - 2026-08-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redcon"
-version = "1.13.0"
+version = "1.14.0"
 description = "Deterministic context budgeting for coding-agent workflows"
 readme = "README.md"
 keywords = [

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/natiixnt/redcon",
     "source": "github"
   },
-  "version": "1.13.0",
+  "version": "1.14.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "redcon",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Cut 1.14.0, theme "operability and show, don't tell". All four feature PRs (#230, #231, #232, #233) are merged; this is the release bump.

## Changes
- `pyproject.toml`: 1.13.0 -> 1.14.0 (license stays `{ file = "LICENSE" }`).
- `CHANGELOG.md`: `[Unreleased]` cut into `[1.14.0]` covering cache TTL + `cache prune`, `--html` reports, the `forbid_skipped_critical_files` policy rule, and the example service repo.
- `server.json`: 1.13.0 -> 1.14.0 (both version fields) for `mcp-publisher publish`.

## Pre-flight (done locally)
- Full suite on merged `main`: 1186 passed, 20 skipped.
- `python -m build` + `twine check` (twine 7) PASS for both the wheel and sdist - no metadata failure.
- Wheel is `redcon-1.14.0`; the three v1 schema files ship in it.

After green CI and rebase-merge, the `v1.14.0` tag drives `release.yml` to publish to PyPI and create the GitHub Release. Wheel verification and `mcp-publisher publish` are the planner-side follow-ups.

No VS Code extension change, so no `vsce`.