### PR TITLE
Merge cache state from disk before applying prune removals

### DIFF
--- a/redcon/cache/backends.py
+++ b/redcon/cache/backends.py
@@ -387,7 +387,32 @@ class LocalFileSummaryCacheBackend(SummaryCacheBackend):
         ``live_paths`` (only applied when a non-empty ``live_paths`` is given, so
         a wrong or empty repo path can never wipe the whole cache). Expired takes
         precedence when an entry matches both.
+
+        The whole read-modify-write runs under the cache file lock: the on-disk
+        state is re-merged first, so entries a concurrent process wrote after
+        this backend loaded are folded in rather than discarded by the
+        authoritative write. Removals are computed on that merged view and only
+        then written. A dry run merges and reports but writes nothing.
         """
+        lock_path = self.cache_path.with_name(self.cache_path.name + ".lock")
+        with _cache_file_lock(lock_path):
+            self._data = self._merge_with_disk()
+            summary, to_remove = self._collect_prunable(live_paths)
+            if not dry_run and to_remove:
+                for store_name, key in to_remove:
+                    self._store(store_name).pop(key, None)
+                    self._timestamps(store_name).pop(key, None)
+                with contextlib.suppress(OSError):
+                    atomic_write_text(
+                        self.cache_path,
+                        json.dumps(self._data, indent=2, sort_keys=True),
+                    )
+        return summary
+
+    def _collect_prunable(
+        self, live_paths: set[str] | None
+    ) -> tuple[dict[str, int], list[tuple[str, str]]]:
+        """Compute expired/orphaned entries and the removal summary on the current state."""
         now = self._now()
         check_orphans = bool(live_paths)
         to_remove: list[tuple[str, str]] = []
@@ -412,17 +437,13 @@ class LocalFileSummaryCacheBackend(SummaryCacheBackend):
                     expired += 1
                 else:
                     orphaned += 1
-        if not dry_run and to_remove:
-            for store_name, key in to_remove:
-                self._store(store_name).pop(key, None)
-                self._timestamps(store_name).pop(key, None)
-            self._write_current()
-        return {
+        summary = {
             "entries_removed": len(to_remove),
             "bytes_freed": bytes_freed,
             "expired": expired,
             "orphaned": orphaned,
         }
+        return summary, to_remove
 
     def _merge_with_disk(self) -> dict[str, Any]:
         """Fold this process's in-memory entries into whatever is on disk now.
@@ -482,24 +503,6 @@ class LocalFileSummaryCacheBackend(SummaryCacheBackend):
                     json.dumps(merged, indent=2, sort_keys=True),
                 )
                 self._data = merged
-        except OSError:
-            return
-
-    def _write_current(self) -> None:
-        """Overwrite the cache file with the in-memory state, without merging.
-
-        The normal _save() unions with the on-disk copy so concurrent writers do
-        not clobber each other, but that union would resurrect the entries prune
-        just removed. Prune is authoritative maintenance, so it writes the
-        reduced state directly under the file lock.
-        """
-        lock_path = self.cache_path.with_name(self.cache_path.name + ".lock")
-        try:
-            with _cache_file_lock(lock_path):
-                atomic_write_text(
-                    self.cache_path,
-                    json.dumps(self._data, indent=2, sort_keys=True),
-                )
         except OSError:
             return
 

--- a/tests/test_cache_ttl_prune.py
+++ b/tests/test_cache_ttl_prune.py
@@ -98,6 +98,34 @@ def test_config_local_ttl_seconds_loads(tmp_path: Path) -> None:
     assert load_config(tmp_path / "other").cache.local_ttl_seconds == 0
 
 
+def test_prune_preserves_entries_written_concurrently(tmp_path: Path) -> None:
+    """An entry a concurrent process appends after prune loads is not discarded."""
+    backend = LocalFileSummaryCacheBackend(repo_path=tmp_path)
+    backend.put_summary("auth/login.py:1:h:summary", "LIVE")
+    backend.put_summary("deleted/gone.py:1:g:summary", "ORPHAN")
+    backend._save()
+
+    # Simulate another process appending a fresh entry straight to the file
+    # after this backend loaded its snapshot.
+    cache_path = tmp_path / ".redcon_cache.json"
+    disk = json.loads(cache_path.read_text())
+    disk["summaries"]["auth/session.py:1:s:summary"] = "CONCURRENT"
+    disk.setdefault("timestamps", {}).setdefault("summaries", {})["auth/session.py:1:s:summary"] = (
+        backend._now()
+    )
+    cache_path.write_text(json.dumps(disk))
+
+    result = backend.prune(live_paths={"auth/login.py", "auth/session.py"})
+
+    on_disk = json.loads(cache_path.read_text())["summaries"]
+    # The concurrently-added entry survives even though the backend never held it.
+    assert "auth/session.py:1:s:summary" in on_disk
+    # Live entry kept, orphan still removed.
+    assert "auth/login.py:1:h:summary" in on_disk
+    assert "deleted/gone.py:1:g:summary" not in on_disk
+    assert result["orphaned"] == 1
+
+
 def _run_cli(argv: list[str]) -> int:
     args = build_parser().parse_args(argv)
     return int(args.func(args))


### PR DESCRIPTION
Fix a data-loss window in `LocalFileSummaryCacheBackend.prune`.

## Problem
`prune` built its removal list from the in-memory snapshot taken when the backend loaded, then wrote the reduced state authoritatively under the lock. If a concurrent process appended an entry to the cache file between that load and the write, the entry was silently dropped by the authoritative overwrite even though it was neither expired nor orphaned. (Flagged as the 1.15 nit on the 1.14 cache PR.)

## Fix (`redcon/cache/backends.py`)
The whole read-modify-write now runs inside the cache file lock: `prune` re-merges the on-disk state first (the same union merge `_save` uses, so a concurrent writer's fresh entries are folded in), computes expired/orphaned on the merged view, and only then writes the reduced state directly. The write is inlined so it does not re-acquire the lock (which would deadlock nested). `--dry-run` still merges and reports but writes nothing. The removal-detection logic moved unchanged into a `_collect_prunable` helper, and the former standalone authoritative writer was removed since prune was its only caller.

## Test (`tests/test_cache_ttl_prune.py`)
`test_prune_preserves_entries_written_concurrently`: after the backend loads and persists its state, append a fresh entry straight to the cache file (simulating another process), then prune with that entry's path live. Asserts the concurrent entry survives, the live entry is kept, and a real orphan is still removed. The existing 9 prune/TTL tests are unchanged and green. Full local suite: 1187 passed.