### PR TITLE
Release 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.0] - 2026-08-03
+
+### Added
+
+- `redcon doctor` now also reports the license tier and status (never the key or
+  its path), the scan-index presence, format version and file count, and the
+  cache backend, entry count and TTL with a write-access probe. It additionally
+  checks the `pro`, `validate` and `heavy_compression` optional extras.
+
+### Fixed
+
+- `redcon cache prune` no longer drops entries a concurrent process wrote after
+  it loaded: the whole read-modify-write runs under the cache file lock and
+  re-merges the on-disk state before applying removals.
+
+### Changed
+
+- The launch backlog and roadmap status lines are refreshed to record all 20
+  backlog issues as delivered through 1.14.0.
+
 ## [1.14.0] - 2026-08-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redcon"
-version = "1.14.0"
+version = "1.15.0"
 description = "Deterministic context budgeting for coding-agent workflows"
 readme = "README.md"
 keywords = [

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/natiixnt/redcon",
     "source": "github"
   },
-  "version": "1.14.0",
+  "version": "1.15.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "redcon",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Cut 1.15.0. The three feature PRs (#236, #237, #238) are merged; this is the release bump.

## Changes
- `pyproject.toml`: 1.14.0 -> 1.15.0 (license stays `{ file = "LICENSE" }`).
- `CHANGELOG.md`: `[Unreleased]` cut into `[1.15.0]` - Added (extended `redcon doctor`: license/scan-index/cache checks + pro/validate/heavy_compression extras), Fixed (`cache prune` concurrency data loss), Changed (backlog/roadmap status refresh).
- `server.json`: 1.14.0 -> 1.15.0 (both version fields) for `mcp-publisher publish`.

## Pre-flight (done locally)
- Full suite on merged `main`: 1195 passed, 20 skipped.
- `python -m build` + `twine check` (twine 7) PASS for both the wheel and sdist.
- Wheel is `redcon-1.15.0`.

After green CI and rebase-merge, the `v1.15.0` tag drives `release.yml` to publish to PyPI and create the GitHub Release. Wheel verification and `mcp-publisher publish` are the planner-side follow-ups. No extension change, so no `vsce`.