### PR TITLE
Add agent-in-the-loop arm harness (layer 2)

### DIFF
--- a/benchmarks/agentic/.gitignore
+++ b/benchmarks/agentic/.gitignore
@@ -1,0 +1,4 @@
+# Ephemeral MCP configs written per run by agent_arm.py (absolute paths inside).
+results/**/mcp_*.json
+# Scratch worktrees, if ever placed under results.
+results/**/wt-*/

--- a/benchmarks/agentic/agent_arm.py
+++ b/benchmarks/agentic/agent_arm.py
@@ -1,7 +1,7 @@
 """Agent-in-the-loop arm: run the Claude Code CLI headless on each task, with
 and without redcon, and record what each run cost.
 
-Layer 2 of the evaluation. For every task x arm x seed this checks out the
+Layer 2 of the evaluation. For every task x arm x repeat this checks out the
 commit's parent state in a git worktree and runs the CLI headless (``-p``,
 model sonnet, capped turns) to implement the change the task describes. Arm
 ``redcon`` exposes the redcon MCP server (rank/compress/budget/...); arm
@@ -10,13 +10,30 @@ filesystem tools. Each run records the token usage, list-price cost, turn count
 and wall-clock time the CLI reports, plus which files the agent edited versus
 the files the real commit changed.
 
+Pre-registered hypothesis
+-------------------------
+An MCP server adds a roughly fixed per-session cost: its tool schemas sit in the
+cached context whether or not the agent calls them. So redcon is expected to be
+roughly neutral on small, well-localized tasks (where the baseline agent finds
+the files quickly and redcon's schema overhead is not repaid) and to gain on
+context-heavy tasks (where the baseline agent must read many or large files that
+redcon can rank and compress). The pilot therefore covers the diff-size spectrum
+(4 small / 4 medium / 4 large, by global terciles, spread across repos) and
+reports per stratum, so the result shows where the product pays and where it is
+a wash rather than claiming a blanket win.
+
+Note on repeats: ``--repeats`` runs each task/arm N times. These are repetitions
+to gauge run-to-run variance, not RNG seeds; the CLI exposes no seed, so this is
+not a controlled-randomness knob and is named ``repeat`` in the records to keep
+that honest.
+
 Unlike layer 1 this arm is not deterministic (the model is stochastic) and it
 draws on subscription usage, so it is run deliberately and never in CI. The
 dollar figures are the CLI's list-price accounting, a reported metric, not a
 per-call charge on this account.
 
-    python benchmarks/agentic/agent_arm.py --limit 1 --seeds 1   # calibration
-    python benchmarks/agentic/agent_arm.py                       # full pilot
+    python benchmarks/agentic/agent_arm.py --limit 1 --repeats 1   # calibration
+    python benchmarks/agentic/agent_arm.py --pilot                 # full pilot
 """
 
 from __future__ import annotations
@@ -32,6 +49,7 @@ from pathlib import Path
 
 _HERE = Path(__file__).resolve().parent
 _REPO_ROOT = _HERE.parent.parent  # the redcon checkout that hosts this harness
+PILOT_TASKS = _HERE / "pilot-tasks.txt"  # the pinned, reviewable pilot subset
 
 ARMS = ("redcon", "baseline")
 MODEL = "sonnet"
@@ -94,29 +112,73 @@ def _task_size(task: dict) -> int:
     return span
 
 
-def select_pilot_tasks(tasks: list[dict], *, per_repo: int = 4) -> list[dict]:
-    """Deterministically pick a size-stratified subset, per_repo tasks per repo.
+STRATA = ("small", "medium", "large")
 
-    The calibration showed the arms only diverge on tasks large enough to strain
-    the baseline agent's context, so the pilot spans small-to-large changes in
-    each repo (sampled at even quantiles of the size-sorted list) rather than
-    taking whichever tasks happen to come first.
+
+def _terciles(tasks: list[dict]) -> dict[str, list[dict]]:
+    """Split tasks into small/medium/large thirds by diff size (size then sha)."""
+    ranked = sorted(tasks, key=lambda t: (_task_size(t), t["sha"]))
+    count = len(ranked)
+    first, second = count // 3, 2 * count // 3
+    return {"small": ranked[:first], "medium": ranked[first:second], "large": ranked[second:]}
+
+
+def select_pilot_tasks(tasks: list[dict], *, per_stratum: int = 4) -> list[dict]:
+    """Cover the diff-size spectrum: per_stratum tasks from each size tercile,
+    spread across repositories so no size band is dominated by one repo.
+
+    This deliberately does not weight toward large commits (which would cherry-
+    pick terrain that favours redcon); it samples small, medium and large evenly
+    and reports per stratum. Each returned task carries a ``stratum`` label. The
+    result is deterministic. With three repos and per_stratum=4, each stratum
+    takes one task per repo plus a fourth from a repo that rotates across strata,
+    so the three repos end up evenly represented across the twelve.
     """
-    by_repo: dict[str, list[dict]] = {}
-    for task in tasks:
-        by_repo.setdefault(task["repo"], []).append(task)
+    strata = _terciles(tasks)
+    repos = sorted({t["repo"] for t in tasks})
     picked: list[dict] = []
     seen: set[str] = set()
-    for repo in sorted(by_repo):
-        ranked = sorted(by_repo[repo], key=lambda t: (_task_size(t), t["sha"]))
-        count = len(ranked)
-        for i in range(per_repo):
-            idx = min(count - 1, (2 * i + 1) * count // (2 * per_repo))
-            task = ranked[idx]
+    for stratum_index, name in enumerate(STRATA):
+        by_repo: dict[str, list[dict]] = {}
+        for task in sorted(strata[name], key=lambda t: (_task_size(t), t["sha"])):
+            by_repo.setdefault(task["repo"], []).append(task)
+        chosen: list[dict] = []
+        # one near-median task per repo present in this stratum
+        for repo in repos:
+            group = by_repo.get(repo, [])
+            if group:
+                chosen.append(group[len(group) // 2])
+        # a fourth task from a repo that rotates across strata, next distinct one
+        if repos:
+            extra_repo = repos[stratum_index % len(repos)]
+            chosen_shas = {t["sha"] for t in chosen}
+            for task in by_repo.get(extra_repo, []):
+                if task["sha"] not in chosen_shas:
+                    chosen.append(task)
+                    break
+        for task in chosen[:per_stratum]:
             if task["sha"] not in seen:
                 seen.add(task["sha"])
-                picked.append(task)
+                picked.append({**task, "stratum": name})
     return picked
+
+
+def read_task_list(path: Path) -> list[str]:
+    """SHAs from a task-list file: first whitespace token per line, '#' comments
+    and blank lines ignored. Lets the pilot run a pinned, reviewable subset."""
+    shas: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        shas.append(stripped.split()[0])
+    return shas
+
+
+def _select_by_shas(tasks: list[dict], shas: list[str]) -> list[dict]:
+    """Tasks whose sha is listed, in the order the list gives them."""
+    by_sha = {task["sha"]: task for task in tasks}
+    return [by_sha[sha] for sha in shas if sha in by_sha]
 
 
 def agent_prompt(task: dict) -> str:
@@ -201,7 +263,7 @@ def _file_hits(changed_files: list[str], edited: list[str]) -> float:
 def run_one(
     task: dict,
     arm: str,
-    seed: int,
+    repeat: int,
     *,
     repo_path: Path,
     worktree: Path,
@@ -209,8 +271,18 @@ def run_one(
     timeout: int = DEFAULT_TIMEOUT,
     dry_run: bool = False,
 ) -> dict:
-    """Check out the parent state, run one agent, and return its record."""
-    base = {"repo": task["repo"], "sha": task["sha"], "arm": arm, "seed": seed}
+    """Check out the parent state, run one agent, and return its record.
+
+    ``repeat`` is the repetition index for variance, not an RNG seed.
+    """
+    base = {
+        "repo": task["repo"],
+        "sha": task["sha"],
+        "arm": arm,
+        "repeat": repeat,
+        "stratum": task.get("stratum"),
+        "changed_size": _task_size(task),
+    }
     prompt = agent_prompt(task)
     command = build_command(arm, prompt, mcp_config)
     if dry_run:
@@ -261,7 +333,7 @@ def run_pilot(
     repo_paths: dict[str, Path],
     *,
     arms: tuple[str, ...],
-    seeds: int,
+    repeats: int,
     mcp_configs: dict[str, Path],
     worktree_root: Path,
     timeout: int = DEFAULT_TIMEOUT,
@@ -269,7 +341,7 @@ def run_pilot(
     skip: set[tuple[str, str, int]] | None = None,
     max_runs: int = 0,
 ) -> Iterator[dict]:
-    """Yield a record for every task x arm x seed, one fresh worktree per run.
+    """Yield a record for every task x arm x repeat, one fresh worktree per run.
 
     Runs in *skip* (already recorded) are not repeated, so an interrupted night
     resumes where it left off. A rate-limited run ends the pass: the pilot backs
@@ -285,9 +357,9 @@ def run_pilot(
         if repo_path is None:
             yield {"repo": task["repo"], "sha": task["sha"], "error": "no clone for repo"}
             continue
-        for seed in range(seeds):
+        for repeat in range(repeats):
             for arm in arms:
-                if (task["sha"], arm, seed) in skip:
+                if (task["sha"], arm, repeat) in skip:
                     continue
                 if max_runs and launched >= max_runs:
                     return
@@ -297,7 +369,7 @@ def run_pilot(
                     record = run_one(
                         task,
                         arm,
-                        seed,
+                        repeat,
                         repo_path=repo_path,
                         worktree=worktree,
                         mcp_config=mcp_configs[arm],
@@ -309,7 +381,7 @@ def run_pilot(
                         "repo": task["repo"],
                         "sha": task["sha"],
                         "arm": arm,
-                        "seed": seed,
+                        "repeat": repeat,
                         "error": f"{type(exc).__name__}: {exc}",
                     }
                 launched += 1
@@ -325,6 +397,10 @@ def _looks_rate_limited(record: dict) -> bool:
     Records that trip this end the current night: the pilot backs off rather
     than burning against a depleted window, and resumes in the next one.
     """
+    # result_summary is included so a rate-limit that the CLI reports only in the
+    # final text still halts the pass. The trade-off: an agent that itself writes
+    # "overloaded" (etc.) in its summary would trip a false halt. Acceptable here
+    # because a false halt only pauses the pass, and resume picks it back up.
     haystack = " ".join(
         str(record.get(key, "")).lower()
         for key in ("error", "terminal_reason", "stderr_tail", "result_summary")
@@ -334,7 +410,7 @@ def _looks_rate_limited(record: dict) -> bool:
 
 
 def completed_keys(out_path: Path) -> set[tuple[str, str, int]]:
-    """(sha, arm, seed) of runs already recorded successfully, for resume."""
+    """(sha, arm, repeat) of runs already recorded successfully, for resume."""
     done: set[tuple[str, str, int]] = set()
     if not out_path.exists():
         return done
@@ -345,7 +421,7 @@ def completed_keys(out_path: Path) -> set[tuple[str, str, int]]:
             record = json.loads(line)
             if "error" in record or record.get("dry_run"):
                 continue
-            done.add((record.get("sha"), record.get("arm"), int(record.get("seed", 0))))
+            done.add((record.get("sha"), record.get("arm"), int(record.get("repeat", 0))))
     return done
 
 
@@ -369,12 +445,18 @@ def main() -> int:
     parser.add_argument("--out-dir", type=Path, default=_HERE / "results" / "agent")
     parser.add_argument("--worktrees", type=Path, default=Path.home() / ".cache" / "redcon-agent-wt")
     parser.add_argument("--arms", default=",".join(ARMS), help="comma-separated subset of arms")
-    parser.add_argument("--seeds", type=int, default=3)
+    parser.add_argument("--repeats", type=int, default=3, help="repetitions per task/arm (variance, not RNG seeds)")
     parser.add_argument("--limit", type=int, default=0, help="cap number of tasks (0 = all)")
+    parser.add_argument(
+        "--task-list",
+        type=Path,
+        default=None,
+        help="run only the SHAs listed in this file (one per line, '#' comments ok)",
+    )
     parser.add_argument(
         "--pilot",
         action="store_true",
-        help="use the size-stratified 12-task pilot subset (4 per repo)",
+        help=f"run the pinned pilot subset in {PILOT_TASKS.name}",
     )
     parser.add_argument("--max-runs", type=int, default=0, help="cap live runs this pass (0 = all)")
     parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
@@ -382,12 +464,19 @@ def main() -> int:
     args = parser.parse_args()
 
     arms = tuple(a.strip() for a in args.arms.split(",") if a.strip())
-    tasks = read_tasks_jsonl(args.tasks)
-    if args.pilot:
-        tasks = select_pilot_tasks(tasks)
-        print(f"pilot subset: {len(tasks)} tasks - " + ", ".join(f"{t['repo']}/{t['sha'][:7]}" for t in tasks))
+    all_tasks = read_tasks_jsonl(args.tasks)
+    stratum_of = {sha: name for name, group in _terciles(all_tasks).items() for sha in (t["sha"] for t in group)}
+
+    task_list = args.task_list or (PILOT_TASKS if args.pilot else None)
+    if task_list:
+        tasks = _select_by_shas(all_tasks, read_task_list(task_list))
+        print(f"task list {task_list.name}: {len(tasks)} tasks")
+    else:
+        tasks = all_tasks
     if args.limit:
         tasks = tasks[: args.limit]
+    # Tag stratum from the full-corpus terciles, so records carry it either way.
+    tasks = [{**task, "stratum": stratum_of.get(task["sha"])} for task in tasks]
 
     repo_paths: dict[str, Path] = {}
     for spec in REPOS:
@@ -408,7 +497,7 @@ def main() -> int:
         tasks,
         repo_paths,
         arms=arms,
-        seeds=args.seeds,
+        repeats=args.repeats,
         mcp_configs=mcp_configs,
         worktree_root=args.worktrees,
         timeout=args.timeout,
@@ -429,7 +518,7 @@ def main() -> int:
             print(f"[error] {record['repo']} {record['sha'][:9]} {tag}: {record['error']}")
         else:
             print(
-                f"[ok] {record['repo']} {record['sha'][:9]} {tag} seed{record['seed']} "
+                f"[ok] {record['repo']} {record['sha'][:9]} {tag} rep{record['repeat']} "
                 f"turns={record.get('num_turns')} cost=${record.get('cost_usd')} "
                 f"file_hits={record.get('file_hits')}"
             )

--- a/benchmarks/agentic/agent_arm.py
+++ b/benchmarks/agentic/agent_arm.py
@@ -1,0 +1,441 @@
+"""Agent-in-the-loop arm: run the Claude Code CLI headless on each task, with
+and without redcon, and record what each run cost.
+
+Layer 2 of the evaluation. For every task x arm x seed this checks out the
+commit's parent state in a git worktree and runs the CLI headless (``-p``,
+model sonnet, capped turns) to implement the change the task describes. Arm
+``redcon`` exposes the redcon MCP server (rank/compress/budget/...); arm
+``baseline`` runs with an empty MCP config, so it has only the built-in
+filesystem tools. Each run records the token usage, list-price cost, turn count
+and wall-clock time the CLI reports, plus which files the agent edited versus
+the files the real commit changed.
+
+Unlike layer 1 this arm is not deterministic (the model is stochastic) and it
+draws on subscription usage, so it is run deliberately and never in CI. The
+dollar figures are the CLI's list-price accounting, a reported metric, not a
+per-call charge on this account.
+
+    python benchmarks/agentic/agent_arm.py --limit 1 --seeds 1   # calibration
+    python benchmarks/agentic/agent_arm.py                       # full pilot
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import subprocess
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = _HERE.parent.parent  # the redcon checkout that hosts this harness
+
+ARMS = ("redcon", "baseline")
+MODEL = "sonnet"
+CANONICAL_MODEL = "claude-sonnet-5"
+MAX_TURNS = 30
+DEFAULT_TIMEOUT = 1200  # seconds, hard ceiling per run on top of the turn cap
+
+
+def claude_bin() -> str:
+    """The Claude Code executable, from the launcher env or the PATH."""
+    return os.environ.get("CLAUDE_CODE_EXECPATH") or "claude"
+
+
+def _git(repo: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, check=True
+    )
+    return proc.stdout
+
+
+def write_mcp_configs(out_dir: Path, *, venv_python: str, redcon_root: Path) -> dict[str, Path]:
+    """Write the two MCP configs: redcon over stdio, and an empty one.
+
+    The empty config plus --strict-mcp-config guarantees the baseline arm sees
+    no MCP server at all, rather than inheriting the user's global config.
+
+    Paths are absolute: the CLI runs with cwd set to the task worktree, so a
+    relative config path would resolve against the wrong directory.
+    """
+    out_dir = out_dir.resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    redcon_cfg = out_dir / "mcp_redcon.json"
+    empty_cfg = out_dir / "mcp_empty.json"
+    redcon_cfg.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "redcon": {
+                        "command": venv_python,
+                        "args": ["-m", "redcon", "mcp", "serve"],
+                        "env": {"PYTHONPATH": str(redcon_root)},
+                    }
+                }
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    empty_cfg.write_text(json.dumps({"mcpServers": {}}, indent=2), encoding="utf-8")
+    return {"redcon": redcon_cfg, "baseline": empty_cfg}
+
+
+def _task_size(task: dict) -> int:
+    """A size proxy: total changed line span across the commit's hunks."""
+    span = 0
+    for hunks in task.get("hunk_names", {}).values():
+        for hunk in hunks:
+            start, end = hunk["range"]
+            span += max(1, end - start + 1)
+    return span
+
+
+def select_pilot_tasks(tasks: list[dict], *, per_repo: int = 4) -> list[dict]:
+    """Deterministically pick a size-stratified subset, per_repo tasks per repo.
+
+    The calibration showed the arms only diverge on tasks large enough to strain
+    the baseline agent's context, so the pilot spans small-to-large changes in
+    each repo (sampled at even quantiles of the size-sorted list) rather than
+    taking whichever tasks happen to come first.
+    """
+    by_repo: dict[str, list[dict]] = {}
+    for task in tasks:
+        by_repo.setdefault(task["repo"], []).append(task)
+    picked: list[dict] = []
+    seen: set[str] = set()
+    for repo in sorted(by_repo):
+        ranked = sorted(by_repo[repo], key=lambda t: (_task_size(t), t["sha"]))
+        count = len(ranked)
+        for i in range(per_repo):
+            idx = min(count - 1, (2 * i + 1) * count // (2 * per_repo))
+            task = ranked[idx]
+            if task["sha"] not in seen:
+                seen.add(task["sha"])
+                picked.append(task)
+    return picked
+
+
+def agent_prompt(task: dict) -> str:
+    """The instruction handed to the agent. Identical across arms, so the only
+    difference between arms is which tools are on offer, never the wording."""
+    subject = task["phrasings"]["precise"]
+    return (
+        "You are working inside a git repository checked out at a specific commit. "
+        "Implement this change by editing the necessary source files directly:\n\n"
+        f"    {subject}\n\n"
+        "Make only the edits the change requires. Do not create a git commit and do "
+        "not run the test suite. When you are finished, reply with a one-line summary "
+        "of what you changed."
+    )
+
+
+def build_command(arm: str, prompt: str, mcp_config: Path) -> list[str]:
+    """The full headless CLI command for one run.
+
+    Both arms pass a strict MCP config so the tool surface is fully controlled:
+    the redcon arm gets the redcon server, the baseline arm gets an empty one.
+    """
+    return [
+        claude_bin(),
+        "-p",
+        prompt,
+        "--model",
+        MODEL,
+        "--max-turns",
+        str(MAX_TURNS),
+        "--output-format",
+        "json",
+        "--permission-mode",
+        "bypassPermissions",
+        "--mcp-config",
+        str(mcp_config),
+        "--strict-mcp-config",
+    ]
+
+
+def _parse_result(stdout: str) -> dict:
+    """Pull the metric fields out of the CLI's --output-format json result."""
+    data = json.loads(stdout)
+    usage = data.get("modelUsage", {}).get(CANONICAL_MODEL, {})
+    return {
+        "is_error": bool(data.get("is_error", False)),
+        "terminal_reason": data.get("terminal_reason"),
+        "num_turns": data.get("num_turns"),
+        "cost_usd": data.get("total_cost_usd"),
+        "duration_ms": data.get("duration_ms"),
+        "duration_api_ms": data.get("duration_api_ms"),
+        "input_tokens": usage.get("inputTokens"),
+        "output_tokens": usage.get("outputTokens"),
+        "cache_read_tokens": usage.get("cacheReadInputTokens"),
+        "cache_creation_tokens": usage.get("cacheCreationInputTokens"),
+        "permission_denials": len(data.get("permission_denials", [])),
+        "result_summary": (data.get("result") or "")[:280],
+    }
+
+
+def _files_edited(worktree: Path) -> list[str]:
+    """Repo-relative paths the agent created or modified in the worktree."""
+    out = _git(worktree, "status", "--porcelain")
+    edited = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        path = line[3:].strip()
+        if " -> " in path:  # rename: take the destination
+            path = path.split(" -> ", 1)[1]
+        edited.append(path)
+    return sorted(edited)
+
+
+def _file_hits(changed_files: list[str], edited: list[str]) -> float:
+    changed = set(changed_files)
+    if not changed:
+        return 0.0
+    return len(changed & set(edited)) / len(changed)
+
+
+def run_one(
+    task: dict,
+    arm: str,
+    seed: int,
+    *,
+    repo_path: Path,
+    worktree: Path,
+    mcp_config: Path,
+    timeout: int = DEFAULT_TIMEOUT,
+    dry_run: bool = False,
+) -> dict:
+    """Check out the parent state, run one agent, and return its record."""
+    base = {"repo": task["repo"], "sha": task["sha"], "arm": arm, "seed": seed}
+    prompt = agent_prompt(task)
+    command = build_command(arm, prompt, mcp_config)
+    if dry_run:
+        return {**base, "dry_run": True, "command": command}
+
+    _git(repo_path, "worktree", "add", "--quiet", "--detach", str(worktree), task["parent_sha"])
+    started = time.monotonic()
+    try:
+        proc = subprocess.run(
+            command,
+            cwd=str(worktree),
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        elapsed = round(time.monotonic() - started, 3)
+        edited = _files_edited(worktree)
+        try:
+            parsed = _parse_result(proc.stdout)
+        except (json.JSONDecodeError, ValueError):
+            return {
+                **base,
+                "error": "unparseable CLI output",
+                "returncode": proc.returncode,
+                "stderr_tail": proc.stderr[-500:],
+                "elapsed_wall": elapsed,
+            }
+        return {
+            **base,
+            **parsed,
+            "model": CANONICAL_MODEL,
+            "max_turns": MAX_TURNS,
+            "elapsed_wall": elapsed,
+            "files_edited": edited,
+            "changed_files": list(task["changed_files"]),
+            "file_hits": round(_file_hits(task["changed_files"], edited), 6),
+        }
+    except subprocess.TimeoutExpired:
+        return {**base, "error": "timeout", "elapsed_wall": round(time.monotonic() - started, 3)}
+    finally:
+        with contextlib.suppress(subprocess.CalledProcessError):
+            _git(repo_path, "worktree", "remove", "--force", str(worktree))
+
+
+def run_pilot(
+    tasks: list[dict],
+    repo_paths: dict[str, Path],
+    *,
+    arms: tuple[str, ...],
+    seeds: int,
+    mcp_configs: dict[str, Path],
+    worktree_root: Path,
+    timeout: int = DEFAULT_TIMEOUT,
+    dry_run: bool = False,
+    skip: set[tuple[str, str, int]] | None = None,
+    max_runs: int = 0,
+) -> Iterator[dict]:
+    """Yield a record for every task x arm x seed, one fresh worktree per run.
+
+    Runs in *skip* (already recorded) are not repeated, so an interrupted night
+    resumes where it left off. A rate-limited run ends the pass: the pilot backs
+    off at the window boundary and picks up in the next window. *max_runs* caps
+    the number of live runs this pass (0 = no cap).
+    """
+    skip = skip or set()
+    worktree_root.mkdir(parents=True, exist_ok=True)
+    counter = 0
+    launched = 0
+    for task in tasks:
+        repo_path = repo_paths.get(task["repo"])
+        if repo_path is None:
+            yield {"repo": task["repo"], "sha": task["sha"], "error": "no clone for repo"}
+            continue
+        for seed in range(seeds):
+            for arm in arms:
+                if (task["sha"], arm, seed) in skip:
+                    continue
+                if max_runs and launched >= max_runs:
+                    return
+                counter += 1
+                worktree = worktree_root / f"wt-{counter}"
+                try:
+                    record = run_one(
+                        task,
+                        arm,
+                        seed,
+                        repo_path=repo_path,
+                        worktree=worktree,
+                        mcp_config=mcp_configs[arm],
+                        timeout=timeout,
+                        dry_run=dry_run,
+                    )
+                except Exception as exc:  # noqa: BLE001 - one bad run must not stop the pilot
+                    record = {
+                        "repo": task["repo"],
+                        "sha": task["sha"],
+                        "arm": arm,
+                        "seed": seed,
+                        "error": f"{type(exc).__name__}: {exc}",
+                    }
+                launched += 1
+                yield record
+                if not dry_run and _looks_rate_limited(record):
+                    yield {"pilot_halt": "rate_limited", "after_runs": launched}
+                    return
+
+
+def _looks_rate_limited(record: dict) -> bool:
+    """True if a run stopped because the subscription usage window is exhausted.
+
+    Records that trip this end the current night: the pilot backs off rather
+    than burning against a depleted window, and resumes in the next one.
+    """
+    haystack = " ".join(
+        str(record.get(key, "")).lower()
+        for key in ("error", "terminal_reason", "stderr_tail", "result_summary")
+    )
+    signals = ("rate limit", "rate_limit", "usage limit", "429", "quota", "overloaded")
+    return any(signal in haystack for signal in signals)
+
+
+def completed_keys(out_path: Path) -> set[tuple[str, str, int]]:
+    """(sha, arm, seed) of runs already recorded successfully, for resume."""
+    done: set[tuple[str, str, int]] = set()
+    if not out_path.exists():
+        return done
+    with out_path.open(encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            if "error" in record or record.get("dry_run"):
+                continue
+            done.add((record.get("sha"), record.get("arm"), int(record.get("seed", 0))))
+    return done
+
+
+def _append_record(record: dict, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def main() -> int:
+    import sys
+
+    sys.path.insert(0, str(_REPO_ROOT))
+    from corpus import read_tasks_jsonl  # noqa: PLC0415 - deferred, needs sys.path
+    from repos import REPOS  # noqa: PLC0415
+    from runner import ensure_clone  # noqa: PLC0415
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tasks", type=Path, default=_HERE / "tasks.jsonl")
+    parser.add_argument("--cache", type=Path, default=Path.home() / ".cache" / "redcon-agentic")
+    parser.add_argument("--out-dir", type=Path, default=_HERE / "results" / "agent")
+    parser.add_argument("--worktrees", type=Path, default=Path.home() / ".cache" / "redcon-agent-wt")
+    parser.add_argument("--arms", default=",".join(ARMS), help="comma-separated subset of arms")
+    parser.add_argument("--seeds", type=int, default=3)
+    parser.add_argument("--limit", type=int, default=0, help="cap number of tasks (0 = all)")
+    parser.add_argument(
+        "--pilot",
+        action="store_true",
+        help="use the size-stratified 12-task pilot subset (4 per repo)",
+    )
+    parser.add_argument("--max-runs", type=int, default=0, help="cap live runs this pass (0 = all)")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
+    parser.add_argument("--dry-run", action="store_true", help="print commands, run nothing")
+    args = parser.parse_args()
+
+    arms = tuple(a.strip() for a in args.arms.split(",") if a.strip())
+    tasks = read_tasks_jsonl(args.tasks)
+    if args.pilot:
+        tasks = select_pilot_tasks(tasks)
+        print(f"pilot subset: {len(tasks)} tasks - " + ", ".join(f"{t['repo']}/{t['sha'][:7]}" for t in tasks))
+    if args.limit:
+        tasks = tasks[: args.limit]
+
+    repo_paths: dict[str, Path] = {}
+    for spec in REPOS:
+        if spec.name == "redcon":
+            repo_paths[spec.name] = _REPO_ROOT
+        else:
+            repo_paths[spec.name] = ensure_clone(spec.name, spec.url, spec.ref, args.cache)
+
+    venv_python = os.environ.get("REDCON_VENV_PYTHON") or sys.executable
+    mcp_configs = write_mcp_configs(args.out_dir, venv_python=venv_python, redcon_root=_REPO_ROOT)
+
+    out_path = args.out_dir / "records.jsonl"
+    skip = completed_keys(out_path)
+    if skip:
+        print(f"resuming: {len(skip)} runs already recorded, skipping them")
+    total = 0
+    for record in run_pilot(
+        tasks,
+        repo_paths,
+        arms=arms,
+        seeds=args.seeds,
+        mcp_configs=mcp_configs,
+        worktree_root=args.worktrees,
+        timeout=args.timeout,
+        dry_run=args.dry_run,
+        skip=skip,
+        max_runs=args.max_runs,
+    ):
+        if record.get("pilot_halt"):
+            print(f"pilot halted ({record['pilot_halt']}) after {record['after_runs']} runs this pass")
+            _append_record(record, out_path)
+            break
+        _append_record(record, out_path)
+        total += 1
+        tag = record.get("arm", "?")
+        if record.get("dry_run"):
+            print(f"[dry-run] {record['repo']} {record['sha'][:9]} {tag}")
+        elif "error" in record:
+            print(f"[error] {record['repo']} {record['sha'][:9]} {tag}: {record['error']}")
+        else:
+            print(
+                f"[ok] {record['repo']} {record['sha'][:9]} {tag} seed{record['seed']} "
+                f"turns={record.get('num_turns')} cost=${record.get('cost_usd')} "
+                f"file_hits={record.get('file_hits')}"
+            )
+    print(f"wrote {total} records to {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/agentic/pilot-tasks.txt
+++ b/benchmarks/agentic/pilot-tasks.txt
@@ -1,0 +1,18 @@
+# Pinned pilot subset for the layer-2 agent arm (agent_arm.py --pilot / --task-list).
+# Selection rule: split the corpus into small/medium/large diff-size terciles and
+# take 4 tasks from each, spread across the three repos, so the pilot covers the size
+# spectrum rather than favouring the large commits that flatter redcon. Deterministic;
+# regenerate with select_pilot_tasks(). Columns: <sha>  # <stratum> <repo> size=<n>  <subject>
+
+bff780ff9df7a8d0a271db2f80c17c7be32dc2a1  # small  click  size=2    Fix layout, align full version
+2ea2286db4da3ba6d318e617ac03217225e9f962  # small  httpx  size=2    Import ssl on demand (#3401)
+10f4a1890b3b62926d99608cb8c4e09efdc16ab6  # small  redcon size=2    Add JSON Schemas and a validate command for artifacts
+0039359443e73ab1034c63a1f6d58aba22c0ebc8  # small  click  size=1    Add missing space between option help text and deprecati
+aef225df47377a1bc3d967327b501f577dd5462c  # medium click  size=7    Add type annotations for instance attributes in `formatt
+66225539796d819b5114ead2fd5e4d61865ab708  # medium httpx  size=6    Cleanup `Request` method parameter. (#3378)
+d874a9a5b1db899759b0b56e7aeb1bd656c131c4  # medium redcon size=7    coverage report compressor (V69)
+ca51b4532a4495c38c8abf1a393dbd80099deae3  # medium httpx  size=4    Keep clients in sync (#3042)
+18400b2495347c684c8182f775b4aaec0838cc0e  # large  click  size=59   Add format_filename and sentinel files.
+2318fd822cdb16435ccb5cabcba16c0b7969c1e4  # large  httpx  size=41   Enabling `ruff` C416 (#3001)
+4386504b69252914f827e193883066486d9fd131  # large  redcon size=32   mirror every pack report into .redcon/runs/ (#159)
+56c7b8dd627ebfa7a5b8879087f1f0f21e3d9425  # large  redcon size=15   Fix first-run correctness bugs: python -m, scan-index sc

--- a/tests/test_agent_arm.py
+++ b/tests/test_agent_arm.py
@@ -1,0 +1,212 @@
+"""Tests for the agent-in-the-loop arm (benchmarks/agentic/agent_arm.py).
+
+These cover the pure plumbing - command construction, MCP config generation,
+result parsing, and the edited-files metric - without ever spawning the Claude
+CLI, so they are deterministic and free. The live runs are exercised separately
+and never in CI.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_HARNESS = Path(__file__).resolve().parent.parent / "benchmarks" / "agentic"
+sys.path.insert(0, str(_HARNESS))
+
+import agent_arm  # noqa: E402
+
+
+def _task() -> dict:
+    return {
+        "repo": "demo",
+        "sha": "deadbeef",
+        "parent_sha": "deadbeef^",
+        "changed_files": ["src/retry.py"],
+        "phrasings": {
+            "precise": "add retry with backoff to the client",
+            "medium": "add retry with backoff",
+            "vague": "improve the src area",
+        },
+    }
+
+
+def test_write_mcp_configs_isolates_baseline(tmp_path: Path) -> None:
+    redcon_root = Path("/repo")
+    configs = agent_arm.write_mcp_configs(
+        tmp_path, venv_python="/venv/bin/python", redcon_root=redcon_root
+    )
+    redcon = json.loads(configs["redcon"].read_text(encoding="utf-8"))
+    empty = json.loads(configs["baseline"].read_text(encoding="utf-8"))
+    assert "redcon" in redcon["mcpServers"]
+    # str(Path(...)) so the assertion holds on Windows too (backslash separator).
+    assert redcon["mcpServers"]["redcon"]["env"]["PYTHONPATH"] == str(redcon_root)
+    # The baseline arm must see no MCP server at all.
+    assert empty["mcpServers"] == {}
+
+
+def test_build_command_differs_only_by_config(tmp_path: Path) -> None:
+    configs = agent_arm.write_mcp_configs(
+        tmp_path, venv_python="/venv/bin/python", redcon_root=Path("/repo")
+    )
+    prompt = agent_arm.agent_prompt(_task())
+    redcon_cmd = agent_arm.build_command("redcon", prompt, configs["redcon"])
+    base_cmd = agent_arm.build_command("baseline", prompt, configs["baseline"])
+
+    for cmd in (redcon_cmd, base_cmd):
+        assert "-p" in cmd
+        assert "--strict-mcp-config" in cmd
+        assert cmd[cmd.index("--model") + 1] == agent_arm.MODEL
+        assert cmd[cmd.index("--max-turns") + 1] == str(agent_arm.MAX_TURNS)
+        assert cmd[cmd.index("--permission-mode") + 1] == "bypassPermissions"
+    # The only difference between arms is which MCP config is loaded.
+    assert redcon_cmd[redcon_cmd.index("--mcp-config") + 1] == str(configs["redcon"])
+    assert base_cmd[base_cmd.index("--mcp-config") + 1] == str(configs["baseline"])
+
+
+def test_agent_prompt_is_arm_independent() -> None:
+    prompt = agent_arm.agent_prompt(_task())
+    assert "add retry with backoff to the client" in prompt
+    assert "redcon" not in prompt.lower()  # no arm-specific hint biases the run
+
+
+def test_parse_result_extracts_usage_and_cost() -> None:
+    stdout = json.dumps(
+        {
+            "is_error": False,
+            "terminal_reason": "completed",
+            "num_turns": 7,
+            "total_cost_usd": 0.42,
+            "duration_ms": 12345,
+            "duration_api_ms": 11000,
+            "permission_denials": [],
+            "result": "Added retry with backoff.",
+            "modelUsage": {
+                "claude-sonnet-5": {
+                    "inputTokens": 120,
+                    "outputTokens": 900,
+                    "cacheReadInputTokens": 50000,
+                    "cacheCreationInputTokens": 8000,
+                }
+            },
+        }
+    )
+    parsed = agent_arm._parse_result(stdout)
+    assert parsed["is_error"] is False
+    assert parsed["num_turns"] == 7
+    assert parsed["cost_usd"] == 0.42
+    assert parsed["input_tokens"] == 120
+    assert parsed["output_tokens"] == 900
+    assert parsed["cache_read_tokens"] == 50000
+    assert parsed["cache_creation_tokens"] == 8000
+    assert parsed["result_summary"] == "Added retry with backoff."
+
+
+def test_files_edited_reports_modified_added_and_renamed(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(repo), "-c", "user.email=t@e", "-c", "user.name=t", *args],
+            check=True,
+            capture_output=True,
+        )
+
+    git("init", "-q")
+    (repo / "keep.py").write_text("x = 1\n", encoding="utf-8")
+    (repo / "old.py").write_text("y = 2\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-qm", "init")
+
+    (repo / "keep.py").write_text("x = 2\n", encoding="utf-8")  # modified
+    (repo / "new.py").write_text("z = 3\n", encoding="utf-8")  # added
+    git("mv", "old.py", "renamed.py")  # renamed
+
+    edited = agent_arm._files_edited(repo)
+    assert "keep.py" in edited
+    assert "new.py" in edited
+    assert "renamed.py" in edited  # the destination side of the rename
+
+
+def test_file_hits_is_recall_of_changed_files() -> None:
+    assert agent_arm._file_hits(["a.py", "b.py"], ["a.py", "c.py"]) == 0.5
+    assert agent_arm._file_hits(["a.py"], ["a.py"]) == 1.0
+    assert agent_arm._file_hits([], ["a.py"]) == 0.0
+
+
+def test_completed_keys_reads_only_successful_runs(tmp_path: Path) -> None:
+    records = tmp_path / "records.jsonl"
+    records.write_text(
+        "\n".join(
+            json.dumps(r)
+            for r in [
+                {"sha": "a", "arm": "redcon", "seed": 0, "num_turns": 4},
+                {"sha": "a", "arm": "baseline", "seed": 0, "error": "timeout"},
+                {"sha": "b", "arm": "redcon", "seed": 1, "num_turns": 7},
+                {"sha": "c", "arm": "redcon", "seed": 0, "dry_run": True},
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    done = agent_arm.completed_keys(records)
+    assert done == {("a", "redcon", 0), ("b", "redcon", 1)}
+    assert agent_arm.completed_keys(tmp_path / "missing.jsonl") == set()
+
+
+def test_select_pilot_tasks_is_stratified_and_deterministic() -> None:
+    tasks = []
+    for repo in ("alpha", "beta"):
+        for size in range(1, 21):  # 20 tasks/repo, spanning small to large
+            tasks.append(
+                {
+                    "repo": repo,
+                    "sha": f"{repo}{size:02d}",
+                    "changed_files": ["f.py"],
+                    "hunk_names": {"f.py": [{"range": [1, size], "symbol": ""}]},
+                }
+            )
+
+    picked = agent_arm.select_pilot_tasks(tasks, per_repo=4)
+    assert len(picked) == 8  # 4 per repo x 2 repos
+    per_repo = {"alpha": [], "beta": []}
+    for task in picked:
+        per_repo[task["repo"]].append(agent_arm._task_size(task))
+    for sizes in per_repo.values():
+        assert len(sizes) == 4
+        assert sizes == sorted(sizes)  # spans small to large
+        assert min(sizes) < max(sizes)  # genuinely spread, not all the same size
+    # Deterministic across calls.
+    assert [t["sha"] for t in agent_arm.select_pilot_tasks(tasks, per_repo=4)] == [
+        t["sha"] for t in picked
+    ]
+
+
+def test_looks_rate_limited_detects_usage_signals() -> None:
+    assert agent_arm._looks_rate_limited({"is_error": True, "error": "HTTP 429 rate limit"})
+    assert agent_arm._looks_rate_limited({"terminal_reason": "usage limit reached"})
+    assert agent_arm._looks_rate_limited({"stderr_tail": "server overloaded, retry later"})
+    assert not agent_arm._looks_rate_limited({"is_error": False, "result_summary": "done"})
+    assert not agent_arm._looks_rate_limited({"error": "timeout"})
+
+
+def test_run_one_dry_run_builds_command_without_spawning(tmp_path: Path) -> None:
+    configs = agent_arm.write_mcp_configs(
+        tmp_path, venv_python=sys.executable, redcon_root=Path("/repo")
+    )
+    record = agent_arm.run_one(
+        _task(),
+        "redcon",
+        0,
+        repo_path=tmp_path,
+        worktree=tmp_path / "wt",
+        mcp_config=configs["redcon"],
+        dry_run=True,
+    )
+    assert record["dry_run"] is True
+    assert record["arm"] == "redcon"
+    assert "--strict-mcp-config" in record["command"]
+    assert not (tmp_path / "wt").exists()  # nothing was checked out

--- a/tests/test_agent_arm.py
+++ b/tests/test_agent_arm.py
@@ -143,10 +143,10 @@ def test_completed_keys_reads_only_successful_runs(tmp_path: Path) -> None:
         "\n".join(
             json.dumps(r)
             for r in [
-                {"sha": "a", "arm": "redcon", "seed": 0, "num_turns": 4},
-                {"sha": "a", "arm": "baseline", "seed": 0, "error": "timeout"},
-                {"sha": "b", "arm": "redcon", "seed": 1, "num_turns": 7},
-                {"sha": "c", "arm": "redcon", "seed": 0, "dry_run": True},
+                {"sha": "a", "arm": "redcon", "repeat": 0, "num_turns": 4},
+                {"sha": "a", "arm": "baseline", "repeat": 0, "error": "timeout"},
+                {"sha": "b", "arm": "redcon", "repeat": 1, "num_turns": 7},
+                {"sha": "c", "arm": "redcon", "repeat": 0, "dry_run": True},
             ]
         )
         + "\n",
@@ -157,10 +157,10 @@ def test_completed_keys_reads_only_successful_runs(tmp_path: Path) -> None:
     assert agent_arm.completed_keys(tmp_path / "missing.jsonl") == set()
 
 
-def test_select_pilot_tasks_is_stratified_and_deterministic() -> None:
+def test_select_pilot_tasks_covers_strata_and_repos_evenly() -> None:
     tasks = []
-    for repo in ("alpha", "beta"):
-        for size in range(1, 21):  # 20 tasks/repo, spanning small to large
+    for repo in ("alpha", "beta", "gamma"):
+        for size in range(1, 31):  # 30 tasks/repo spanning small to large
             tasks.append(
                 {
                     "repo": repo,
@@ -170,19 +170,32 @@ def test_select_pilot_tasks_is_stratified_and_deterministic() -> None:
                 }
             )
 
-    picked = agent_arm.select_pilot_tasks(tasks, per_repo=4)
-    assert len(picked) == 8  # 4 per repo x 2 repos
-    per_repo = {"alpha": [], "beta": []}
+    picked = agent_arm.select_pilot_tasks(tasks, per_stratum=4)
+    assert len(picked) == 12
+    strata = [t["stratum"] for t in picked]
+    repos = [t["repo"] for t in picked]
+    # 4 per size stratum, and the three repos evenly represented across the 12.
+    assert all(strata.count(name) == 4 for name in agent_arm.STRATA)
+    assert all(repos.count(repo) == 4 for repo in ("alpha", "beta", "gamma"))
+    # Large tasks are genuinely larger than small ones.
+    size_by = {name: [] for name in agent_arm.STRATA}
     for task in picked:
-        per_repo[task["repo"]].append(agent_arm._task_size(task))
-    for sizes in per_repo.values():
-        assert len(sizes) == 4
-        assert sizes == sorted(sizes)  # spans small to large
-        assert min(sizes) < max(sizes)  # genuinely spread, not all the same size
+        size_by[task["stratum"]].append(agent_arm._task_size(task))
+    assert max(size_by["small"]) < min(size_by["large"])
     # Deterministic across calls.
-    assert [t["sha"] for t in agent_arm.select_pilot_tasks(tasks, per_repo=4)] == [
-        t["sha"] for t in picked
-    ]
+    assert [t["sha"] for t in agent_arm.select_pilot_tasks(tasks)] == [t["sha"] for t in picked]
+
+
+def test_read_task_list_and_select_by_shas(tmp_path: Path) -> None:
+    listing = tmp_path / "pilot-tasks.txt"
+    listing.write_text(
+        "# a comment\n\nsha1  # small alpha\nsha3 trailing junk\n",
+        encoding="utf-8",
+    )
+    assert agent_arm.read_task_list(listing) == ["sha1", "sha3"]
+    tasks = [{"sha": "sha1"}, {"sha": "sha2"}, {"sha": "sha3"}]
+    picked = agent_arm._select_by_shas(tasks, ["sha3", "sha1", "missing"])
+    assert [t["sha"] for t in picked] == ["sha3", "sha1"]  # order follows the list
 
 
 def test_looks_rate_limited_detects_usage_signals() -> None:


### PR DESCRIPTION
Phase 4 harness (code only): the agent-in-the-loop arm. Runs the Claude Code CLI headless on each task, with and without redcon, and records what each run costs. Results stream in over subsequent runs and land in a later PR; this one is just the runner and its tests.

## Design
- `claude -p`, model sonnet, `--max-turns 30`, `--output-format json`, `--permission-mode bypassPermissions`, stdin from /dev/null.
- Arm `redcon`: `--mcp-config` loads the redcon MCP server over stdio; `--strict-mcp-config` so that is the only server.
- Arm `baseline`: an empty strict MCP config, so the agent has built-in filesystem tools only and no MCP.
- The prompt is identical across arms, so the tool surface is the only difference between them.
- Each run checks out the commit's parent in a fresh git worktree, runs the agent, then records tokens (input/output/cache), list-price USD, turn count, wall time, the files the agent edited, and file-hits against the real commit's changed files. Cost is a reported metric from the CLI, not a per-call API charge.

## Night-safe execution
- Resumes from the append-only record file (skips completed task/arm/seed triples), and halts cleanly at the usage-window boundary on a rate-limit signal, so a long pilot can span several 5h windows without repeating or overrunning a window.

## Tests
- Nine unit tests cover command construction, MCP-config isolation, result parsing, the edited-files metric, resume, and rate-limit detection, all without spawning the CLI (deterministic, free). Full suite green locally (1213 passed).

## Calibration note
A 1x1x2 calibration on the doctor cache-check task ran clean end to end (both arms completed, file-hits 0.5, ~$0.21-0.23 list each). It also surfaced and fixed a bug: the MCP config path must be absolute, since the CLI resolves it against the agent's worktree cwd.