### PR TITLE
Add night-2 harness: three arms, stream-json capture, tool-call metric

### DIFF
--- a/benchmarks/agentic/agent_arm.py
+++ b/benchmarks/agentic/agent_arm.py
@@ -32,8 +32,12 @@ draws on subscription usage, so it is run deliberately and never in CI. The
 dollar figures are the CLI's list-price accounting, a reported metric, not a
 per-call charge on this account.
 
-    python benchmarks/agentic/agent_arm.py --limit 1 --repeats 1   # calibration
-    python benchmarks/agentic/agent_arm.py --pilot                 # full pilot
+    # small-repo pilot (night 1):
+    python benchmarks/agentic/agent_arm.py --pilot
+    # context-heavy night 2, pass 1 (arms A and B, precise):
+    python benchmarks/agentic/agent_arm.py --tasks benchmarks/agentic/tasks-heavy.jsonl \
+        --arms redcon,baseline --phrasing precise --repeats 3 \
+        --cache ~/.cache/redcon-agentic-heavy --out-dir benchmarks/agentic/results/agent-heavy
 """
 
 from __future__ import annotations
@@ -51,7 +55,20 @@ _HERE = Path(__file__).resolve().parent
 _REPO_ROOT = _HERE.parent.parent  # the redcon checkout that hosts this harness
 PILOT_TASKS = _HERE / "pilot-tasks.txt"  # the pinned, reviewable pilot subset
 
-ARMS = ("redcon", "baseline")
+# Three arms. A and Ag both expose the redcon MCP server; Ag adds one neutral
+# line of guidance to the prompt. B has no MCP at all. The A-vs-Ag gap isolates
+# the cost of the agent not adopting the tools; the Ag-vs-B gap isolates the
+# value of the pack once the agent does use it.
+GUIDANCE = (
+    "This repository has redcon MCP tools available; calling redcon_rank or "
+    "redcon_budget first is usually cheaper than searching manually."
+)
+ARM_SPECS = {
+    "redcon": {"mcp": "redcon", "guided": False},  # A
+    "redcon_guided": {"mcp": "redcon", "guided": True},  # Ag
+    "baseline": {"mcp": "baseline", "guided": False},  # B
+}
+ARMS = ("redcon", "redcon_guided", "baseline")
 MODEL = "sonnet"
 CANONICAL_MODEL = "claude-sonnet-5"
 MAX_TURNS = 30
@@ -181,11 +198,12 @@ def _select_by_shas(tasks: list[dict], shas: list[str]) -> list[dict]:
     return [by_sha[sha] for sha in shas if sha in by_sha]
 
 
-def agent_prompt(task: dict) -> str:
-    """The instruction handed to the agent. Identical across arms, so the only
-    difference between arms is which tools are on offer, never the wording."""
-    subject = task["phrasings"]["precise"]
-    return (
+def agent_prompt(task: dict, phrasing: str = "precise", *, guided: bool = False) -> str:
+    """The instruction handed to the agent. The wording is identical across arms
+    except for the optional guidance line (arm Ag), so the tool surface and that
+    single line are the only differences between arms."""
+    subject = task["phrasings"][phrasing]
+    prompt = (
         "You are working inside a git repository checked out at a specific commit. "
         "Implement this change by editing the necessary source files directly:\n\n"
         f"    {subject}\n\n"
@@ -193,13 +211,17 @@ def agent_prompt(task: dict) -> str:
         "not run the test suite. When you are finished, reply with a one-line summary "
         "of what you changed."
     )
+    if guided:
+        prompt += "\n\n" + GUIDANCE
+    return prompt
 
 
-def build_command(arm: str, prompt: str, mcp_config: Path) -> list[str]:
+def build_command(prompt: str, mcp_config: Path) -> list[str]:
     """The full headless CLI command for one run.
 
-    Both arms pass a strict MCP config so the tool surface is fully controlled:
-    the redcon arm gets the redcon server, the baseline arm gets an empty one.
+    Output is stream-json (with --verbose) so the whole transcript is captured
+    and per-run tool usage can be counted; the arm's guidance, if any, is already
+    baked into the prompt. The strict MCP config fully controls the tool surface.
     """
     return [
         claude_bin(),
@@ -210,7 +232,8 @@ def build_command(arm: str, prompt: str, mcp_config: Path) -> list[str]:
         "--max-turns",
         str(MAX_TURNS),
         "--output-format",
-        "json",
+        "stream-json",
+        "--verbose",
         "--permission-mode",
         "bypassPermissions",
         "--mcp-config",
@@ -219,24 +242,46 @@ def build_command(arm: str, prompt: str, mcp_config: Path) -> list[str]:
     ]
 
 
-def _parse_result(stdout: str) -> dict:
-    """Pull the metric fields out of the CLI's --output-format json result."""
-    data = json.loads(stdout)
-    usage = data.get("modelUsage", {}).get(CANONICAL_MODEL, {})
-    return {
-        "is_error": bool(data.get("is_error", False)),
-        "terminal_reason": data.get("terminal_reason"),
-        "num_turns": data.get("num_turns"),
-        "cost_usd": data.get("total_cost_usd"),
-        "duration_ms": data.get("duration_ms"),
-        "duration_api_ms": data.get("duration_api_ms"),
-        "input_tokens": usage.get("inputTokens"),
-        "output_tokens": usage.get("outputTokens"),
-        "cache_read_tokens": usage.get("cacheReadInputTokens"),
-        "cache_creation_tokens": usage.get("cacheCreationInputTokens"),
-        "permission_denials": len(data.get("permission_denials", [])),
-        "result_summary": (data.get("result") or "")[:280],
-    }
+def parse_stream(stdout: str) -> tuple[dict, dict[str, int]]:
+    """Parse a stream-json transcript into (metrics, tool_call_counts).
+
+    Metrics come from the final ``result`` event; the counts tally every
+    ``tool_use`` block across the assistant turns, so ``mcp__redcon__*`` calls
+    can be reported as a first-class adoption metric.
+    """
+    metrics: dict = {}
+    counts: dict[str, int] = {}
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("type") == "result":
+            usage = event.get("modelUsage", {}).get(CANONICAL_MODEL, {})
+            metrics = {
+                "is_error": bool(event.get("is_error", False)),
+                "terminal_reason": event.get("terminal_reason"),
+                "num_turns": event.get("num_turns"),
+                "cost_usd": event.get("total_cost_usd"),
+                "duration_ms": event.get("duration_ms"),
+                "input_tokens": usage.get("inputTokens"),
+                "output_tokens": usage.get("outputTokens"),
+                "cache_read_tokens": usage.get("cacheReadInputTokens"),
+                "cache_creation_tokens": usage.get("cacheCreationInputTokens"),
+                "permission_denials": len(event.get("permission_denials", [])),
+                "result_summary": (event.get("result") or "")[:280],
+            }
+        for block in (event.get("message") or {}).get("content") or []:
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                counts[block.get("name", "?")] = counts.get(block.get("name", "?"), 0) + 1
+    return metrics, counts
+
+
+def _redcon_calls(counts: dict[str, int]) -> int:
+    return sum(v for name, v in counts.items() if str(name).startswith("mcp__redcon__"))
 
 
 def _files_edited(worktree: Path) -> list[str]:
@@ -265,26 +310,33 @@ def run_one(
     arm: str,
     repeat: int,
     *,
+    phrasing: str,
     repo_path: Path,
     worktree: Path,
     mcp_config: Path,
+    transcript_dir: Path | None = None,
     timeout: int = DEFAULT_TIMEOUT,
     dry_run: bool = False,
 ) -> dict:
     """Check out the parent state, run one agent, and return its record.
 
-    ``repeat`` is the repetition index for variance, not an RNG seed.
+    ``repeat`` is the repetition index for variance, not an RNG seed. The whole
+    stream-json transcript is saved (if ``transcript_dir`` is given) and the
+    per-run ``mcp__redcon__*`` call count is recorded.
     """
+    spec = ARM_SPECS[arm]
     base = {
         "repo": task["repo"],
         "sha": task["sha"],
         "arm": arm,
+        "phrasing": phrasing,
         "repeat": repeat,
+        "guided": spec["guided"],
         "stratum": task.get("stratum"),
         "changed_size": _task_size(task),
     }
-    prompt = agent_prompt(task)
-    command = build_command(arm, prompt, mcp_config)
+    prompt = agent_prompt(task, phrasing, guided=spec["guided"])
+    command = build_command(prompt, mcp_config)
     if dry_run:
         return {**base, "dry_run": True, "command": command}
 
@@ -301,22 +353,28 @@ def run_one(
         )
         elapsed = round(time.monotonic() - started, 3)
         edited = _files_edited(worktree)
-        try:
-            parsed = _parse_result(proc.stdout)
-        except (json.JSONDecodeError, ValueError):
+        if transcript_dir is not None:
+            transcript_dir.mkdir(parents=True, exist_ok=True)
+            name = f"{task['sha'][:9]}-{arm}-{phrasing}-r{repeat}.jsonl"
+            (transcript_dir / name).write_text(proc.stdout, encoding="utf-8")
+        metrics, tool_counts = parse_stream(proc.stdout)
+        if not metrics:
             return {
                 **base,
-                "error": "unparseable CLI output",
+                "error": "no result event in stream",
                 "returncode": proc.returncode,
                 "stderr_tail": proc.stderr[-500:],
                 "elapsed_wall": elapsed,
             }
         return {
             **base,
-            **parsed,
+            **metrics,
             "model": CANONICAL_MODEL,
             "max_turns": MAX_TURNS,
             "elapsed_wall": elapsed,
+            "redcon_tool_calls": _redcon_calls(tool_counts),
+            "tool_calls": sum(tool_counts.values()),
+            "tool_counts": tool_counts,
             "files_edited": edited,
             "changed_files": list(task["changed_files"]),
             "file_hits": round(_file_hits(task["changed_files"], edited), 6),
@@ -334,11 +392,13 @@ def run_pilot(
     *,
     arms: tuple[str, ...],
     repeats: int,
+    phrasing: str,
     mcp_configs: dict[str, Path],
     worktree_root: Path,
+    transcript_dir: Path | None = None,
     timeout: int = DEFAULT_TIMEOUT,
     dry_run: bool = False,
-    skip: set[tuple[str, str, int]] | None = None,
+    skip: set[tuple[str, str, str, int]] | None = None,
     max_runs: int = 0,
 ) -> Iterator[dict]:
     """Yield a record for every task x arm x repeat, one fresh worktree per run.
@@ -359,7 +419,7 @@ def run_pilot(
             continue
         for repeat in range(repeats):
             for arm in arms:
-                if (task["sha"], arm, repeat) in skip:
+                if (task["sha"], arm, phrasing, repeat) in skip:
                     continue
                 if max_runs and launched >= max_runs:
                     return
@@ -370,9 +430,11 @@ def run_pilot(
                         task,
                         arm,
                         repeat,
+                        phrasing=phrasing,
                         repo_path=repo_path,
                         worktree=worktree,
-                        mcp_config=mcp_configs[arm],
+                        mcp_config=mcp_configs[ARM_SPECS[arm]["mcp"]],
+                        transcript_dir=transcript_dir,
                         timeout=timeout,
                         dry_run=dry_run,
                     )
@@ -381,6 +443,7 @@ def run_pilot(
                         "repo": task["repo"],
                         "sha": task["sha"],
                         "arm": arm,
+                        "phrasing": phrasing,
                         "repeat": repeat,
                         "error": f"{type(exc).__name__}: {exc}",
                     }
@@ -409,9 +472,13 @@ def _looks_rate_limited(record: dict) -> bool:
     return any(signal in haystack for signal in signals)
 
 
-def completed_keys(out_path: Path) -> set[tuple[str, str, int]]:
-    """(sha, arm, repeat) of runs already recorded successfully, for resume."""
-    done: set[tuple[str, str, int]] = set()
+def completed_keys(out_path: Path) -> set[tuple[str, str, str, int]]:
+    """(sha, arm, phrasing, repeat) of runs already recorded, for resume.
+
+    Phrasing is part of the key so a medium-phrasing addendum does not collide
+    with the precise runs of the same arm.
+    """
+    done: set[tuple[str, str, str, int]] = set()
     if not out_path.exists():
         return done
     with out_path.open(encoding="utf-8") as handle:
@@ -421,7 +488,14 @@ def completed_keys(out_path: Path) -> set[tuple[str, str, int]]:
             record = json.loads(line)
             if "error" in record or record.get("dry_run"):
                 continue
-            done.add((record.get("sha"), record.get("arm"), int(record.get("repeat", 0))))
+            done.add(
+                (
+                    record.get("sha"),
+                    record.get("arm"),
+                    record.get("phrasing", "precise"),
+                    int(record.get("repeat", 0)),
+                )
+            )
     return done
 
 
@@ -437,6 +511,7 @@ def main() -> int:
     sys.path.insert(0, str(_REPO_ROOT))
     from corpus import read_tasks_jsonl  # noqa: PLC0415 - deferred, needs sys.path
     from repos import REPOS  # noqa: PLC0415
+    from repos_heavy import REPOS_HEAVY  # noqa: PLC0415
     from runner import ensure_clone  # noqa: PLC0415
 
     parser = argparse.ArgumentParser(description=__doc__)
@@ -446,6 +521,7 @@ def main() -> int:
     parser.add_argument("--worktrees", type=Path, default=Path.home() / ".cache" / "redcon-agent-wt")
     parser.add_argument("--arms", default=",".join(ARMS), help="comma-separated subset of arms")
     parser.add_argument("--repeats", type=int, default=3, help="repetitions per task/arm (variance, not RNG seeds)")
+    parser.add_argument("--phrasing", default="precise", choices=("precise", "medium", "vague"))
     parser.add_argument("--limit", type=int, default=0, help="cap number of tasks (0 = all)")
     parser.add_argument(
         "--task-list",
@@ -475,15 +551,19 @@ def main() -> int:
         tasks = all_tasks
     if args.limit:
         tasks = tasks[: args.limit]
-    # Tag stratum from the full-corpus terciles, so records carry it either way.
-    tasks = [{**task, "stratum": stratum_of.get(task["sha"])} for task in tasks]
+    # Keep a task's own stratum if the corpus pinned one (heavy corpus does);
+    # otherwise tag from the terciles of the loaded corpus.
+    tasks = [{**task, "stratum": task.get("stratum") or stratum_of.get(task["sha"])} for task in tasks]
 
+    specs = {spec.name: spec for spec in (*REPOS, *REPOS_HEAVY)}
     repo_paths: dict[str, Path] = {}
-    for spec in REPOS:
-        if spec.name == "redcon":
-            repo_paths[spec.name] = _REPO_ROOT
-        else:
-            repo_paths[spec.name] = ensure_clone(spec.name, spec.url, spec.ref, args.cache)
+    for name in sorted({task["repo"] for task in tasks}):
+        spec = specs.get(name)
+        if spec is None:
+            continue  # unknown repo yields a per-task error record downstream
+        repo_paths[name] = _REPO_ROOT if name == "redcon" else ensure_clone(
+            spec.name, spec.url, spec.ref, args.cache
+        )
 
     venv_python = os.environ.get("REDCON_VENV_PYTHON") or sys.executable
     mcp_configs = write_mcp_configs(args.out_dir, venv_python=venv_python, redcon_root=_REPO_ROOT)
@@ -498,8 +578,10 @@ def main() -> int:
         repo_paths,
         arms=arms,
         repeats=args.repeats,
+        phrasing=args.phrasing,
         mcp_configs=mcp_configs,
         worktree_root=args.worktrees,
+        transcript_dir=args.out_dir / "transcripts",
         timeout=args.timeout,
         dry_run=args.dry_run,
         skip=skip,
@@ -518,8 +600,9 @@ def main() -> int:
             print(f"[error] {record['repo']} {record['sha'][:9]} {tag}: {record['error']}")
         else:
             print(
-                f"[ok] {record['repo']} {record['sha'][:9]} {tag} rep{record['repeat']} "
-                f"turns={record.get('num_turns')} cost=${record.get('cost_usd')} "
+                f"[ok] {record['repo']} {record['sha'][:9]} {tag}/{record.get('phrasing')} "
+                f"rep{record['repeat']} turns={record.get('num_turns')} "
+                f"cost=${record.get('cost_usd')} redcon_calls={record.get('redcon_tool_calls')} "
                 f"file_hits={record.get('file_hits')}"
             )
     print(f"wrote {total} records to {out_path}")

--- a/benchmarks/agentic/results/agent-heavy/NIGHT2.md
+++ b/benchmarks/agentic/results/agent-heavy/NIGHT2.md
@@ -1,0 +1,49 @@
+# Agent arm, night 2: context-heavy corpus (pre-registration)
+
+This file is committed before the run: the hypotheses below are registered up
+front, and the results are filled in afterwards under each one.
+
+Night 1 found no end-task benefit from redcon on small repositories and traced
+the one clear loss to a behavioural cause - the agent never called redcon's
+tools and grepped by hand instead. Night 2 separates the two questions night 1
+conflated: does the pack help when it is used, and how often does the agent use
+it unprompted.
+
+## Design
+
+- Corpus: `benchmarks/agentic/tasks-heavy.jsonl` - 12 tasks from django and
+  sympy (large repos, several million tokens each), touching 3-8 files across
+  >= 2 directories, 60-400 line diffs, stratified 4 small / 4 medium / 4 large.
+- Three arms:
+  - **A** (`redcon`): redcon MCP available, prompt identical to baseline.
+  - **Ag** (`redcon_guided`): redcon MCP available, prompt plus one neutral line
+    ("This repository has redcon MCP tools available; calling redcon_rank or
+    redcon_budget first is usually cheaper than searching manually.").
+  - **B** (`baseline`): no MCP at all.
+- Decomposition: **pack value = Ag vs B**; **cost of non-adoption = A vs Ag**.
+- Model sonnet, `--max-turns 30`, window-aware and resumable. Every run is
+  captured as a stream-json transcript (kept under `transcripts/`), and the
+  per-run count of `mcp__redcon__*` calls is recorded as a first-class metric -
+  without it adoption and value cannot be told apart.
+- Passes: pass 1 = 12 x {A, B} x 3 (precise); pass 2 = 12 x Ag x 3 (precise) plus
+  a medium addendum 12 x {Ag, B} x 1.
+
+## Pre-registered hypotheses
+
+1. **Pack value.** On these large repos, Ag beats B on cost at equal or better
+   recall.
+2. **Cost of non-adoption.** A minus Ag is non-trivial and is explained by redcon
+   tool-call counts (A calls the tools rarely, Ag often). This is a
+   tool-description problem, not a pack-value problem.
+3. **Wording sensitivity.** Ag's advantage over B grows from precise to medium.
+
+## Caveat, registered up front
+
+Medium differs from precise for only 8 of the 12 tasks - 4 sympy subjects name no
+file or symbol, so their medium collapses onto precise. The precise-vs-medium
+comparison (hypothesis 3) is therefore reported on that distinguishable subset,
+with the count stated, so the medium addendum is not read as more than it is.
+
+## Results
+
+<!-- Filled in after the passes complete. -->

--- a/tests/test_agent_arm.py
+++ b/tests/test_agent_arm.py
@@ -47,61 +47,74 @@ def test_write_mcp_configs_isolates_baseline(tmp_path: Path) -> None:
     assert empty["mcpServers"] == {}
 
 
-def test_build_command_differs_only_by_config(tmp_path: Path) -> None:
+def test_arms_map_to_configs_and_guidance() -> None:
+    # A and Ag use the redcon server; B uses the empty one. Only Ag is guided.
+    assert agent_arm.ARM_SPECS["redcon"] == {"mcp": "redcon", "guided": False}
+    assert agent_arm.ARM_SPECS["redcon_guided"] == {"mcp": "redcon", "guided": True}
+    assert agent_arm.ARM_SPECS["baseline"] == {"mcp": "baseline", "guided": False}
+    assert set(agent_arm.ARMS) == {"redcon", "redcon_guided", "baseline"}
+
+
+def test_build_command_uses_stream_json(tmp_path: Path) -> None:
     configs = agent_arm.write_mcp_configs(
         tmp_path, venv_python="/venv/bin/python", redcon_root=Path("/repo")
     )
-    prompt = agent_arm.agent_prompt(_task())
-    redcon_cmd = agent_arm.build_command("redcon", prompt, configs["redcon"])
-    base_cmd = agent_arm.build_command("baseline", prompt, configs["baseline"])
-
-    for cmd in (redcon_cmd, base_cmd):
-        assert "-p" in cmd
-        assert "--strict-mcp-config" in cmd
-        assert cmd[cmd.index("--model") + 1] == agent_arm.MODEL
-        assert cmd[cmd.index("--max-turns") + 1] == str(agent_arm.MAX_TURNS)
-        assert cmd[cmd.index("--permission-mode") + 1] == "bypassPermissions"
-    # The only difference between arms is which MCP config is loaded.
-    assert redcon_cmd[redcon_cmd.index("--mcp-config") + 1] == str(configs["redcon"])
-    assert base_cmd[base_cmd.index("--mcp-config") + 1] == str(configs["baseline"])
+    cmd = agent_arm.build_command("a prompt", configs["redcon"])
+    assert "-p" in cmd
+    assert "--strict-mcp-config" in cmd
+    assert cmd[cmd.index("--output-format") + 1] == "stream-json"
+    assert "--verbose" in cmd  # required for stream-json
+    assert cmd[cmd.index("--model") + 1] == agent_arm.MODEL
+    assert cmd[cmd.index("--max-turns") + 1] == str(agent_arm.MAX_TURNS)
+    assert cmd[cmd.index("--mcp-config") + 1] == str(configs["redcon"])
 
 
-def test_agent_prompt_is_arm_independent() -> None:
-    prompt = agent_arm.agent_prompt(_task())
-    assert "add retry with backoff to the client" in prompt
-    assert "redcon" not in prompt.lower()  # no arm-specific hint biases the run
+def test_agent_prompt_guidance_and_phrasing() -> None:
+    plain = agent_arm.agent_prompt(_task(), "precise")
+    assert "add retry with backoff to the client" in plain
+    assert "redcon" not in plain.lower()  # arm A carries no hint
+    guided = agent_arm.agent_prompt(_task(), "precise", guided=True)
+    assert guided.endswith(agent_arm.GUIDANCE)  # arm Ag appends exactly one line
+    assert "add retry with backoff to the client" in guided
+    medium = agent_arm.agent_prompt(_task(), "medium")
+    assert "add retry with backoff" in medium and "to the client" not in medium
 
 
-def test_parse_result_extracts_usage_and_cost() -> None:
-    stdout = json.dumps(
-        {
-            "is_error": False,
-            "terminal_reason": "completed",
-            "num_turns": 7,
-            "total_cost_usd": 0.42,
-            "duration_ms": 12345,
-            "duration_api_ms": 11000,
-            "permission_denials": [],
-            "result": "Added retry with backoff.",
-            "modelUsage": {
-                "claude-sonnet-5": {
-                    "inputTokens": 120,
-                    "outputTokens": 900,
-                    "cacheReadInputTokens": 50000,
-                    "cacheCreationInputTokens": 8000,
-                }
+def test_parse_stream_extracts_metrics_and_tool_counts() -> None:
+    stream = "\n".join(
+        json.dumps(e)
+        for e in [
+            {"type": "system", "subtype": "init"},
+            {"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "Bash"}]}},
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "tool_use", "name": "mcp__redcon__redcon_rank"}]},
             },
-        }
+            {"type": "assistant", "message": {"content": [{"type": "tool_use", "name": "Bash"}]}},
+            {
+                "type": "result",
+                "is_error": False,
+                "num_turns": 7,
+                "total_cost_usd": 0.42,
+                "result": "done",
+                "modelUsage": {
+                    "claude-sonnet-5": {
+                        "inputTokens": 120,
+                        "outputTokens": 900,
+                        "cacheReadInputTokens": 50000,
+                        "cacheCreationInputTokens": 8000,
+                    }
+                },
+            },
+        ]
     )
-    parsed = agent_arm._parse_result(stdout)
-    assert parsed["is_error"] is False
-    assert parsed["num_turns"] == 7
-    assert parsed["cost_usd"] == 0.42
-    assert parsed["input_tokens"] == 120
-    assert parsed["output_tokens"] == 900
-    assert parsed["cache_read_tokens"] == 50000
-    assert parsed["cache_creation_tokens"] == 8000
-    assert parsed["result_summary"] == "Added retry with backoff."
+    metrics, counts = agent_arm.parse_stream(stream)
+    assert metrics["num_turns"] == 7
+    assert metrics["cost_usd"] == 0.42
+    assert metrics["input_tokens"] == 120
+    assert metrics["result_summary"] == "done"
+    assert counts == {"Bash": 2, "mcp__redcon__redcon_rank": 1}
+    assert agent_arm._redcon_calls(counts) == 1
 
 
 def test_files_edited_reports_modified_added_and_renamed(tmp_path: Path) -> None:
@@ -143,17 +156,18 @@ def test_completed_keys_reads_only_successful_runs(tmp_path: Path) -> None:
         "\n".join(
             json.dumps(r)
             for r in [
-                {"sha": "a", "arm": "redcon", "repeat": 0, "num_turns": 4},
-                {"sha": "a", "arm": "baseline", "repeat": 0, "error": "timeout"},
-                {"sha": "b", "arm": "redcon", "repeat": 1, "num_turns": 7},
-                {"sha": "c", "arm": "redcon", "repeat": 0, "dry_run": True},
+                {"sha": "a", "arm": "redcon", "phrasing": "precise", "repeat": 0, "num_turns": 4},
+                {"sha": "a", "arm": "baseline", "phrasing": "precise", "repeat": 0, "error": "t"},
+                {"sha": "b", "arm": "redcon", "phrasing": "medium", "repeat": 1, "num_turns": 7},
+                {"sha": "c", "arm": "redcon", "phrasing": "precise", "repeat": 0, "dry_run": True},
             ]
         )
         + "\n",
         encoding="utf-8",
     )
     done = agent_arm.completed_keys(records)
-    assert done == {("a", "redcon", 0), ("b", "redcon", 1)}
+    # Phrasing is part of the key, so precise and medium runs never collide.
+    assert done == {("a", "redcon", "precise", 0), ("b", "redcon", "medium", 1)}
     assert agent_arm.completed_keys(tmp_path / "missing.jsonl") == set()
 
 
@@ -212,14 +226,19 @@ def test_run_one_dry_run_builds_command_without_spawning(tmp_path: Path) -> None
     )
     record = agent_arm.run_one(
         _task(),
-        "redcon",
+        "redcon_guided",
         0,
+        phrasing="precise",
         repo_path=tmp_path,
         worktree=tmp_path / "wt",
         mcp_config=configs["redcon"],
         dry_run=True,
     )
     assert record["dry_run"] is True
-    assert record["arm"] == "redcon"
+    assert record["arm"] == "redcon_guided"
+    assert record["phrasing"] == "precise"
+    assert record["guided"] is True
+    # The guided arm's prompt carries the guidance line in the command.
+    assert any(agent_arm.GUIDANCE in part for part in record["command"])
     assert "--strict-mcp-config" in record["command"]
     assert not (tmp_path / "wt").exists()  # nothing was checked out


### PR DESCRIPTION
The night-2 runner, per the recorded spec. Code only - nothing runs until you GO. Pre-registers the hypotheses in NIGHT2.md before any measurement.

## Three arms
- A (`redcon`): redcon MCP available, prompt identical to baseline.
- Ag (`redcon_guided`): redcon MCP plus one neutral line - "This repository has redcon MCP tools available; calling redcon_rank or redcon_budget first is usually cheaper than searching manually."
- B (`baseline`): empty strict MCP config, no MCP.

Decomposition: pack value = Ag vs B; cost of non-adoption = A vs Ag.

## Instrumentation
- Capture switched to stream-json from the start; every run's full transcript is saved under `results/agent-heavy/transcripts/`.
- Per-run `mcp__redcon__*` call count parsed into each record as a first-class metric (`redcon_tool_calls`), plus the full per-tool tally. Without it adoption and value cannot be separated - exactly the gap the 56c7 audit exposed.
- New `--phrasing` flag; phrasing is part of the resume key so the medium addendum will not collide with the precise runs. Records also carry `guided`, `stratum`, `changed_size`.
- Heavy-corpus repos (django, sympy) resolved alongside the small ones. Window-aware and resumable unchanged.

## Pre-registration (NIGHT2.md)
1. Pack value: on large repos Ag beats B on cost at equal-or-better recall.
2. Cost of non-adoption: A minus Ag is non-trivial and explained by tool-call counts (a tool-description problem, not a pack-value problem).
3. Wording: Ag's edge over B grows from precise to medium.
Caveat registered up front: medium differs from precise for only 8/12 tasks (the 4 sympy subjects name nothing to strip), so hypothesis 3 is reported on the distinguishable subset with the count stated.

## Planned passes (on your GO)
- Pass 1: 12 x {A, B} x 3 precise = 72. Numbers to you before pass 2.
- Pass 2: 12 x Ag x 3 precise (36) + medium addendum 12 x {Ag, B} x 1 (24).

## Tests
Unit tests updated for the three arms, prompt guidance, stream parsing (metrics + tool counts + redcon count), and the phrasing-aware resume key. Full suite 1219 passed, lint and format clean.