### PR TITLE
Add the agentic-evaluation writeup

### DIFF
--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -76,3 +76,10 @@ default pipeline. Same task, same tree, same day as the table above:
 - Reduction percentages depend on repository shape more than on anything
   else. Run one pack on your own repository; that number is the only one
   that matters for you.
+
+## Agentic evaluation
+
+For a pre-registered, two-layer study on real commits - what the pack contains
+(97.8% file recall at a 96% context reduction) and whether it changes what an
+autonomous agent actually does - see the writeup in
+[docs/research/agentic-eval.md](research/agentic-eval.md).

--- a/docs/research/agentic-eval.md
+++ b/docs/research/agentic-eval.md
@@ -1,0 +1,169 @@
+# Agentic evaluation of redcon
+
+A deterministic, pre-registered evaluation of redcon's context selection, on real
+commits, at two layers: a redcon-only measurement of what the pack contains
+(layer 1), and an agent-in-the-loop measurement of whether the pack changes
+end-task outcomes (layers 2, "night 1" on small repos and "night 2" on large
+ones). Every task is a real commit; the tool sees only the parent state, and the
+files and line ranges the commit changed are the ground truth.
+
+## Abstract
+
+Layer 1, on redcon, httpx and click (1,890 runs), finds redcon's ranker recovers
+the changed files with **97.8% recall (95% CI 97.3-98.3)** while shrinking the
+context to a **mean 96% below the whole-repo baseline**. Layer 2 asks whether that
+selection improves what an autonomous agent actually does. On small repos (night
+1) it did not, and the failure was traced to adoption: the agent never called
+redcon and grepped by hand. On large repos (night 2, django and sympy, 228 agent
+runs) redcon delivered **no measured end-task improvement through any channel
+tested**: the agent will not reach for it (0-11% adoption across three delivery
+channels), and pre-injecting the pack does not beat baseline in a multi-turn loop
+at any coverage (a 0.90-coverage 120k map ties recall at 3.4x cost and half the
+precision). A deterministic sweep shows the coverage ceiling is a **budget limit,
+not a ranking limit** (pack file-hits climb 0.36 to 0.90 from 12k to 120k). The
+layer-1 selection quality stands; the open gap is delivery, and it is specific to
+autonomous multi-turn agents on multi-million-token repos.
+
+## Setup
+
+- **Corpora.** Layer 1 and night 1 use a pinned 210-task corpus from redcon
+  (v1.15.0), httpx and click (small and medium repos). Night 2 uses a 12-task
+  context-heavy corpus from django and sympy (multi-million-token repos), commits
+  touching 3-8 files across >= 2 directories, 60-400 line diffs, stratified into
+  small/medium/large by diff size. Both corpora are pinned to fixed SHAs and
+  committed under `benchmarks/agentic/`.
+- **Harness.** Each task is evaluated at the commit's parent state in a fresh git
+  worktree, so nothing about the change can leak into selection. Layer 1 runs
+  `redcon pack` with default config. Layer 2 runs the Claude Code CLI headless
+  (`-p`, model sonnet, 30-turn cap) to implement the change, and records the
+  tokens, list-price cost, turn count, edited files, and per-run `mcp__redcon__*`
+  call count from the stream-json transcript.
+- **Metrics.** *file recall* (changed files surfaced or edited), *region
+  containment* (changed line ranges surfaced verbatim), *precision* (agent edits
+  that are ground-truth files), *cost* (CLI list-price USD, a reported metric),
+  *adoption* (runs that called a redcon tool), and *pack file-hits* (ground-truth
+  files present in a pre-injected pack).
+
+## Methods
+
+Layer 1 is deterministic: the pack depends only on the parent state, the phrasing
+and the budget, and means carry a seeded 95% bootstrap CI. Layer 2 is stochastic
+(the model is not seeded; repeats gauge variance) and draws on subscription usage,
+so it is run deliberately and never in CI. Hypotheses and interpretations were
+pre-registered before each pass (see `results/agent-heavy/NIGHT2.md`), including
+the four-outcome interpretation table, the two-channel framing for the config arm,
+the push-vs-pull thesis, and the arm-P and arm-P120 hypotheses, so no narrative is
+fitted after the fact.
+
+## Results
+
+### Layer 1: what the pack contains (small and medium repos)
+
+| cut | file recall (95% CI) | region containment (95% CI) |
+|---|---|---|
+| overall | 97.8% [97.3, 98.3] | 37.1% [35.5, 38.8] |
+| budget 12k / 30k / 60k | 95.4 / 98.5 / 99.6% | 35.8 / 37.3 / 38.2% |
+
+Context reduction from the whole-repo baseline averages 96% (95.6-97.4% across
+budgets). Wording sensitivity is reported on the distinguishable subset only
+(medium collapses onto precise when the subject names no file or symbol). The
+pack finds the right files and surfaces about a third of the exact changed lines
+verbatim; it is a map with partial content, not the full text.
+
+### Night 1: agent arm on small repos - no end-task benefit
+
+Twelve tasks x 2 arms x 3 repeats. Redcon (available via MCP) did not beat
+baseline: recall 0.61 vs 0.69 at parity cost. The one clear loss (redcon/56c7b8d)
+was audited from the transcript: the agent called redcon **zero** times, ran ~17
+Bash grep sweeps, and capped out, while layer 1 confirms the pack ranked all four
+changed files. The failure is behavioural (adoption), not ranking.
+
+### Night 2: agent arm on large repos - no value through any channel
+
+228 runs. Arms: **B** baseline (no MCP), **A** redcon MCP unprompted, **Ag** plus
+a one-line prompt hint, **Agc** plus the rule in CLAUDE.md, **P** pre-inject a 30k
+pack, **P120** pre-inject a 120k pack.
+
+| arm | cost/run | recall | precision | adopted |
+|---|---|---|---|---|
+| B baseline | $0.78 | 0.688 | 0.799 | 0/36 |
+| A redcon | $0.82 | 0.618 | 0.822 | 0/36 |
+| Ag guided | $0.91 | 0.617 | 0.814 | 0/36 |
+| Agc config | $0.69 | 0.588 | 0.676 | 4/36 |
+| P (30k) | $1.84 | 0.634 | 0.412 | 0/36 |
+| P120 (120k) | $2.72 | 0.575 | 0.390 | 0/24 |
+
+- **Pull fails on delivery.** Adoption is 0/36 unprompted, 0/36 with a prompt
+  line, and 4/36 via the CLAUDE.md rule - the only channel with any uptake. (The
+  installer writes AGENTS.md, which headless Claude Code does not read; only
+  CLAUDE.md is read - a shipped-guidance delivery bug.) The guided arm was the
+  single worst: unheard guidance sent the agent searching more, not ranking.
+- **Push fails in the loop, at any coverage.** Pre-injection does not beat
+  baseline at 30k (0.64 coverage; the agent anchors on the incomplete map,
+  precision 0.41) or at 120k (0.90 coverage; recall ties B excluding cap-outs, at
+  3.4x cost, half the precision, and a 33% turn-cap rate). More coverage made the
+  map harder to use, not more valuable. The pre-registered context-window caveat
+  did not trigger: failures were turn-caps, not truncation.
+
+The injected map's cost scales with turns (the 30k/120k prefix is re-read every
+turn), so any value push might carry is confined to short, non-interactive flows -
+which these multi-turn runs do not cover.
+
+### Coverage sweep: budget, not ranking
+
+Deterministic layer-1 packs over the heavy corpus:
+
+| budget | 12k | 30k | 60k | 120k |
+|---|---|---|---|---|
+| pack file-hits | 0.358 | 0.627 | 0.738 | 0.896 |
+
+Coverage climbs toward ~1.0, so the default 30k pack under-covers multi-million-
+token repos because of budget, not ranking. redcon finds the files given tokens.
+
+## Threats to validity
+
+- The adoption result is specific to **headless autonomous mode** (`claude -p`)
+  with **model sonnet**. An interactive user can invoke the tools directly, and
+  other models may have different tool-use habits; the claim is "the autonomous
+  sonnet agent does not reach for redcon on its own here", not "agents never use
+  redcon".
+- Layer 2 is stochastic with modest n (n=36 per precise arm, n=24 for P120); the
+  pfh=1.0 subset lead (n=6) was flagged post-hoc and then refuted by P120.
+- The heavy corpus is 12 tasks from two repos; diffs are 60-400 lines, so the
+  "large" band is large for these repos, not for the whole of open source.
+- Layer-1 selection quality does not imply end-task value; measuring that gap is
+  the point of layer 2.
+
+## Open questions (registered)
+
+Two directions the data points to but does not settle:
+
+1. **Single- and few-turn flows.** Every layer-2 run here is a 30-turn loop, where
+   a pre-injected map is re-read many times. The one delivery mode not covered is
+   one-shot or few-turn, non-interactive use (CI checks, review bots, one-shot API
+   calls), where the map is paid for once. This is the only place push might pay,
+   and it is the honest scope for any auto-injection bet.
+2. **P-lite.** Night 2 injected the full pack. The Agc evidence (an early
+   `redcon_rank` helped; a full map in a loop hurt) suggests injecting only the
+   **ranking list** - paths plus a one-line role, a few hundred tokens - may give
+   the "start from the right files" benefit without the anchoring, precision and
+   cost penalties of the full map. Hypothesis: cost ~= baseline, recall above
+   baseline, precision intact.
+
+## Reproduce
+
+Layer 1 is deterministic and free of API cost:
+
+```bash
+python benchmarks/agentic/run.py --out-dir benchmarks/agentic/results
+```
+
+The coverage sweep (also deterministic):
+
+```bash
+python benchmarks/agentic/coverage_sweep.py --cache ~/.cache/redcon-agentic-heavy
+```
+
+The layer-2 agent arms require the Claude Code CLI and draw on subscription usage;
+see `benchmarks/agentic/agent_arm.py` and the pinned `NIGHT1.md` / `NIGHT2.md` for
+exact invocations and per-run records.


### PR DESCRIPTION
Phase 5: the research writeup, `docs/research/agentic-eval.md`, linked from the methodology page. Docs only, no product change. Held for review before merge.

Paper-form: abstract, setup, methods, results with 95% CIs, threats to validity, open questions, one-command repro. Covers layer 1 (deterministic pack quality), night 1 (agent on small repos), night 2 (agent on large repos + P/P120), and the coverage sweep.

Conclusions kept strictly inside the measurements:
- Layer 1: 97.8% file recall (95% CI 97.3-98.3) at a mean 96% context reduction on small/medium repos.
- Layer 2: no measured end-task improvement on large repos through any channel - pull fails on delivery (0-11% adoption), push fails in the loop at any coverage (P120 at 0.90 coverage ties recall at 3.4x cost, half precision).
- Coverage is a budget limit not a ranking limit (0.36 to 0.90 across 12k-120k).

Open questions registered: (a) single-/few-turn non-interactive flows - the only untested push branch; (b) P-lite - inject only the ranking list, not the full map.