### PR TITLE
Write the redcon instruction block to CLAUDE.md when it is missing

### DIFF
--- a/redcon/mcp/instructions.py
+++ b/redcon/mcp/instructions.py
@@ -6,8 +6,10 @@ the agent prefer them over its own grep and whole-file reads. A short
 instruction block in the repo's agent guidance files closes that gap.
 
 AGENTS.md is the cross-agent convention (Codex, Cursor, Gemini CLI and
-others read it) and is created when missing. CLAUDE.md belongs to the
-user, so redcon only appends to it when the file already exists.
+others read it). CLAUDE.md is what Claude Code reads. Both are created
+when missing, because headless Claude Code (claude -p) reads CLAUDE.md
+but not AGENTS.md, so writing only AGENTS.md left the guidance invisible
+to it.
 
 The block is delimited by marker comments and rewritten in place, so
 repeated runs are idempotent and user content around it is preserved.
@@ -40,9 +42,15 @@ files.
 {_END}"""
 
 # (filename, create when missing)
+#
+# CLAUDE.md is created when missing, not only appended: headless Claude Code
+# (claude -p) reads CLAUDE.md but not AGENTS.md, so writing only AGENTS.md left
+# the guidance invisible to that agent. The block is marker-delimited and
+# idempotent, so a created CLAUDE.md holds only the redcon block and stays easy
+# to remove.
 _TARGET_FILES: list[tuple[str, bool]] = [
     ("AGENTS.md", True),
-    ("CLAUDE.md", False),
+    ("CLAUDE.md", True),
 ]
 
 

--- a/tests/test_agent_instructions.py
+++ b/tests/test_agent_instructions.py
@@ -14,20 +14,20 @@ def _statuses(results: list[dict]) -> dict[str, str]:
     return {r["file"]: r["status"] for r in results}
 
 
-def test_creates_agents_md_but_not_claude_md(tmp_path: Path):
-    """AGENTS.md is created; CLAUDE.md belongs to the user and is not."""
+def test_creates_both_agents_md_and_claude_md(tmp_path: Path):
+    """On a fresh directory both AGENTS.md and CLAUDE.md are created with the
+    block, so the guidance reaches Claude Code, which reads only CLAUDE.md."""
     results = ensure_agent_instructions(tmp_path)
     statuses = _statuses(results)
 
     assert statuses["AGENTS.md"] == "created"
-    assert statuses["CLAUDE.md"] == "skipped"
-    assert (tmp_path / "AGENTS.md").exists()
-    assert not (tmp_path / "CLAUDE.md").exists()
+    assert statuses["CLAUDE.md"] == "created"
 
-    text = (tmp_path / "AGENTS.md").read_text()
-    assert "redcon_rank" in text
-    assert "<!-- redcon:begin -->" in text
-    assert "<!-- redcon:end -->" in text
+    for name in ("AGENTS.md", "CLAUDE.md"):
+        text = (tmp_path / name).read_text()
+        assert "redcon_rank" in text
+        assert "<!-- redcon:begin -->" in text
+        assert "<!-- redcon:end -->" in text
 
 
 def test_appends_to_existing_files_preserving_content(tmp_path: Path):


### PR DESCRIPTION
1.16 package, PR A of three. Fixes a delivery bug the night-2 evaluation surfaced.

## The bug
Headless Claude Code (`claude -p`) reads CLAUDE.md but not AGENTS.md (verified directly). The installer wrote only AGENTS.md and appended to CLAUDE.md only when that file already existed. So for a user with no CLAUDE.md, redcon's shipped guidance never reached Claude Code at all - which is why the config-file arm in night 2 saw almost no adoption until the block was placed in CLAUDE.md.

## The fix
`ensure_agent_instructions` now creates CLAUDE.md with the marker-delimited block when it is missing, keeping AGENTS.md for the other clients that read it. The block is idempotent and easy to remove.

## Test
`test_creates_both_agents_md_and_claude_md`: on a fresh directory with no CLAUDE.md, after install the redcon block is present in both AGENTS.md and CLAUDE.md. Full suite green (1221 passed).

Note: this is the only delivery-channel change in 1.16. Full-map auto-injection is deliberately out of scope - P120 measured it as harm in a multi-turn loop.