### PR TITLE
Scale the default pack budget by repository size

### DIFF
--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -77,6 +77,26 @@ default pipeline. Same task, same tree, same day as the table above:
   else. Run one pack on your own repository; that number is the only one
   that matters for you.
 
+## Default budget scales with repository size
+
+When you do not pass `--max-tokens` and set no `[budget].max_tokens` in the config,
+the default budget grows step-wise with the scanned repository size, because 30k
+under-covers very large repositories:
+
+| scanned repo tokens | default budget |
+| --- | --- |
+| <= 200k | 30,000 (unchanged) |
+| 200k - 1M | 45,000 |
+| 1M - 3M | 75,000 |
+| > 3M | 120,000 |
+
+Only the top step is directly measured: the coverage sweep in the evaluation below
+found a 120k pack recovers ~90% of the changed files on a 5-7M-token repository. The
+middle steps interpolate between the measured ends; they are not four separate
+measurements. An explicit `--max-tokens` always wins, and if it is small for a
+large repository redcon prints a one-line coverage warning to stderr. Small
+repositories are unaffected.
+
 ## Agentic evaluation
 
 For a pre-registered, two-layer study on real commits - what the pack contains

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -97,6 +97,10 @@ measurements. An explicit `--max-tokens` always wins, and if it is small for a
 large repository redcon prints a one-line coverage warning to stderr. Small
 repositories are unaffected.
 
+Note: setting `[budget].max_tokens` to exactly the built-in default (30,000) is
+indistinguishable from leaving it unset, so it is still subject to auto-scaling. To
+pin 30k on a large repository, configure a different value or pass `--max-tokens`.
+
 ## Agentic evaluation
 
 For a pre-registered, two-layer study on real commits - what the pack contains

--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -707,13 +707,45 @@ def cmd_pack(args: argparse.Namespace) -> int:
     if validation_error is not None:
         return validation_error
 
+    # Resolve the token budget by repository size. With no explicit --max-tokens
+    # the default grows step-wise with the scanned repo (small repos unchanged);
+    # an explicit budget that is small for the repo's size earns a stderr warning.
+    # A scan failure must never break pack, so fall back to the given value.
+    effective_max_tokens = args.max_tokens
+    try:
+        from redcon.config import load_config
+        from redcon.core.budget import (
+            coverage_warning,
+            default_budget_for_repo_tokens,
+            estimate_repo_tokens,
+        )
+        from redcon.schemas.models import DEFAULT_MAX_TOKENS
+
+        budget_config = load_config(
+            Path(args.repo), config_path=Path(args.config) if args.config else None
+        )
+        repo_tokens = estimate_repo_tokens(Path(args.repo), budget_config)
+        if args.max_tokens is not None:
+            # Explicit budget wins; warn only if it is small for a large repo.
+            warning = coverage_warning(repo_tokens, args.max_tokens)
+            if warning:
+                print(warning, file=sys.stderr)
+        elif budget_config.budget.max_tokens != DEFAULT_MAX_TOKENS:
+            # The repo configured its own default; honour it (pass None through).
+            effective_max_tokens = None
+        else:
+            # No budget set anywhere: scale the built-in default by repo size.
+            effective_max_tokens = default_budget_for_repo_tokens(repo_tokens)
+    except Exception:  # noqa: BLE001 - budget scaling is best-effort, never fatal
+        effective_max_tokens = args.max_tokens
+
     t0 = time.time()
     engine = RedconEngine(config_path=args.config)
     data = engine.pack(
         task=args.task,
         repo=args.repo,
         workspace=args.workspace,
-        max_tokens=args.max_tokens,
+        max_tokens=effective_max_tokens,
         top_files=args.top_files,
         delta_from=args.delta,
         compression_profile=getattr(args, "compression_profile", None),

--- a/redcon/core/budget.py
+++ b/redcon/core/budget.py
@@ -1,0 +1,83 @@
+"""Scale the default pack budget by repository size.
+
+The default budget (30k) under-covers very large repositories: the agentic
+coverage sweep measured pack file-hits rising from 0.36 at 12k to 0.90 at 120k on
+a 5-7M-token repo. So when the user does not pass an explicit budget, the default
+grows step-wise with the scanned repository size, and an explicit budget that is
+small for the repository's size earns a warning.
+
+Only the top step (repositories above ~3M tokens use 120k, which the sweep
+measured at ~0.90 coverage) is directly measured. The middle steps interpolate
+between the measured ends; they are not four separate measurements. Small
+repositories (<= 200k tokens) are unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from redcon.schemas.models import DEFAULT_MAX_TOKENS
+
+if TYPE_CHECKING:
+    from redcon.config import RedconConfig
+
+# (repository-token ceiling, default budget). Ascending; the last row is the
+# floor for anything larger.
+_BUDGET_STEPS: tuple[tuple[int, int], ...] = (
+    (200_000, DEFAULT_MAX_TOKENS),  # small repos: unchanged
+    (1_000_000, 45_000),
+    (3_000_000, 75_000),
+)
+_LARGE_REPO_BUDGET = 120_000
+
+
+def default_budget_for_repo_tokens(repo_tokens: int) -> int:
+    """The default pack budget for a repository of *repo_tokens* tokens."""
+    for ceiling, budget in _BUDGET_STEPS:
+        if repo_tokens <= ceiling:
+            return budget
+    return _LARGE_REPO_BUDGET
+
+
+def coverage_warning(repo_tokens: int, budget: int) -> str | None:
+    """A warning if *budget* is below the recommended default for the repo size.
+
+    Only fires for repositories large enough that the default grows above the
+    baseline (> 200k tokens); a small budget on a small repo is the user's call
+    and never warns.
+    """
+    recommended = default_budget_for_repo_tokens(repo_tokens)
+    if recommended <= DEFAULT_MAX_TOKENS or budget >= recommended:
+        return None
+    return (
+        f"redcon: budget {budget:,} tokens may under-cover this repository "
+        f"(~{repo_tokens:,} tokens); ~{recommended:,} is recommended for its size. "
+        "Coverage rises with budget on large repositories."
+    )
+
+
+def estimate_repo_tokens(repo: Path, config: RedconConfig | None = None) -> int:
+    """A cheap estimate of the repository's total tokens, from the scan index.
+
+    Uses cached file sizes (bytes / 4), so it is fast on a warm index and does not
+    read file contents. This is the same basis used to size the sweep repos, so
+    it stays consistent with the thresholds above.
+    """
+    from redcon.scanners.incremental import refresh_scan_index  # noqa: PLC0415
+
+    kwargs: dict = {}
+    if config is not None:
+        scan = config.scan
+        kwargs = {
+            "max_file_size_bytes": scan.max_file_size_bytes,
+            "preview_chars": scan.preview_chars,
+            "include_globs": scan.include_globs,
+            "ignore_globs": scan.ignore_globs,
+            "ignore_dirs": scan.ignore_dirs,
+            "binary_extensions": scan.binary_extensions,
+            "max_file_count": scan.max_file_count,
+            "exclude_secrets": scan.exclude_secrets,
+        }
+    result = refresh_scan_index(Path(repo), **kwargs)
+    return sum(record.size_bytes for record in result.records) // 4

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,0 +1,51 @@
+"""Tests for the repo-size-scaled default budget."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from redcon.core.budget import (
+    coverage_warning,
+    default_budget_for_repo_tokens,
+    estimate_repo_tokens,
+)
+from redcon.schemas.models import DEFAULT_MAX_TOKENS
+
+
+def test_small_repos_keep_the_default_budget():
+    # Repositories at or below 200k tokens are unchanged.
+    assert default_budget_for_repo_tokens(0) == DEFAULT_MAX_TOKENS
+    assert default_budget_for_repo_tokens(50_000) == DEFAULT_MAX_TOKENS
+    assert default_budget_for_repo_tokens(200_000) == DEFAULT_MAX_TOKENS
+
+
+def test_budget_grows_stepwise_with_repo_size():
+    assert default_budget_for_repo_tokens(500_000) == 45_000
+    assert default_budget_for_repo_tokens(2_000_000) == 75_000
+    assert default_budget_for_repo_tokens(6_000_000) == 120_000
+    # Monotonic non-decreasing across the range.
+    sizes = [0, 200_000, 200_001, 1_000_000, 1_000_001, 3_000_000, 3_000_001, 10_000_000]
+    budgets = [default_budget_for_repo_tokens(s) for s in sizes]
+    assert budgets == sorted(budgets)
+
+
+def test_warning_only_when_budget_is_below_the_recommendation():
+    # A default-sized budget on a large repo is under the recommendation.
+    warning = coverage_warning(6_000_000, DEFAULT_MAX_TOKENS)
+    assert warning is not None
+    assert "under-cover" in warning
+    assert "120,000" in warning
+    # At or above the recommendation there is no warning.
+    assert coverage_warning(6_000_000, 120_000) is None
+    # Small repos never warn - even a tiny budget is the user's call.
+    assert coverage_warning(50_000, DEFAULT_MAX_TOKENS) is None
+    assert coverage_warning(50_000, 5_000) is None
+
+
+def test_estimate_repo_tokens_counts_from_the_scan(tmp_path: Path):
+    (tmp_path / "a.py").write_text("x = 1\n" * 100, encoding="utf-8")
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "b.py").write_text("y = 2\n" * 100, encoding="utf-8")
+    tokens = estimate_repo_tokens(tmp_path)
+    # Two ~600-byte files, so roughly (1200 bytes / 4) = ~300 tokens; allow slack.
+    assert 100 <= tokens <= 1000


### PR DESCRIPTION
1.16 package, PR C of three. Scales the default pack budget by repository size.

## Why
The coverage sweep measured pack file-hits rising 0.36 -> 0.90 as budget went 12k -> 120k on a 5-7M-token repo, so the 30k default under-covers very large repositories.

## What
`redcon/core/budget.py`: when no budget is set anywhere, the default grows step-wise with the scanned repo size. Precedence unchanged: explicit `--max-tokens` > configured `[budget].max_tokens` > repo-size default.

| scanned repo tokens | default budget |
| --- | --- |
| <= 200k | 30,000 (unchanged) |
| 200k - 1M | 45,000 |
| 1M - 3M | 75,000 |
| > 3M | 120,000 |

An explicit budget that is small for a large repo prints a one-line coverage warning to **stderr only** - the run.json schema is unchanged. Small repos are entirely unaffected and never warn.

## Honesty note (also in docs)
Only the top step is measured (120k -> ~0.90 coverage on 5-7M repos). The middle steps interpolate between the measured ends; they are not four separate measurements.

## Tests + docs
`tests/test_budget.py` covers the thresholds, the monotonic curve, the warning gating (large repos only), and the scan-based repo-token estimate. Docs note in methodology.md. Full suite green (1226 passed).

Note for the release: default budget rises for repos > 200k tokens, so packs (and prompt_cache_key) change one-time after upgrade on medium/large repos; users with a pinned budget are unaffected. That note goes in the 1.16.0 CHANGELOG.