### PR TITLE
Release 1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.0] - 2026-08-09
+
+### Changed
+
+- Scale the default pack budget by repository size. When no budget is set, the
+  default grows step-wise with the scanned repository (200k-1M: 45k, 1M-3M: 75k,
+  >3M: 120k); small repositories are unchanged. **The default pack budget now
+  rises for repositories over ~200k tokens, so packs and their `prompt_cache_key`
+  change once after upgrading on medium and large repositories. Users who pin a
+  budget with `--max-tokens` or `[budget].max_tokens` are unaffected.** An
+  explicit budget that is small for a large repository prints a coverage warning
+  to stderr.
+- Slim the MCP tool descriptions (about 36% fewer tokens) with a snapshot test
+  that caps their size, since they sit in the agent's cached context every
+  session.
+
+### Fixed
+
+- Write the redcon instruction block to `CLAUDE.md` when it is missing, not only
+  when it already exists. Headless Claude Code reads `CLAUDE.md` but not
+  `AGENTS.md`, so the shipped guidance previously never reached it.
+
+### Added
+
+- A pre-registered, two-layer agentic evaluation writeup in
+  `docs/research/agentic-eval.md`.
+
 ## [1.15.0] - 2026-08-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redcon"
-version = "1.15.0"
+version = "1.16.0"
 description = "Deterministic context budgeting for coding-agent workflows"
 readme = "README.md"
 keywords = [

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/natiixnt/redcon",
     "source": "github"
   },
-  "version": "1.15.0",
+  "version": "1.16.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "redcon",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Release 1.16.0. Bumps `pyproject.toml` and `server.json`, cuts the CHANGELOG. Wheel builds and passes `twine check`; full suite green (1226 passed).

## In this release
- **Budget scales by repo size** (#251): default grows step-wise on large repos; small repos unchanged; stderr warning for a small explicit budget on a large repo.
- **Slim MCP tool descriptions** (#250): ~36% fewer tokens, size-capped.
- **CLAUDE.md delivery fix** (#249): the instruction block reaches headless Claude Code, which reads CLAUDE.md not AGENTS.md.
- **Agentic-evaluation writeup** (#248): docs.

## Upgrade note (in the CHANGELOG)
The default pack budget rises for repositories over ~200k tokens, so packs and their `prompt_cache_key` change once after upgrading on medium and large repositories. Users who pin a budget with `--max-tokens` or `[budget].max_tokens` are unaffected.

No full-map auto-injection (P120 measured it as harm in a loop).

After merge: tag `v1.16.0` to trigger the release workflow; server.json bump is included for the MCP registry publish.