### PR TITLE
Add adaptive render mode (flag, default unchanged)

### DIFF
--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -749,6 +749,7 @@ def cmd_pack(args: argparse.Namespace) -> int:
         top_files=args.top_files,
         delta_from=args.delta,
         compression_profile=getattr(args, "compression_profile", None),
+        render_mode=getattr(args, "render_mode", None),
         changed_files=getattr(args, "changed", None),
     )
 
@@ -3177,6 +3178,16 @@ def _register_packing_commands(sub: argparse._SubParsersAction) -> None:
         help=(
             "Compression profile: 'max' packs tighter representations. "
             "Overrides [compression] profile."
+        ),
+    )
+    pack.add_argument(
+        "--render-mode",
+        choices=["compressed", "adaptive"],
+        default=None,
+        help=(
+            "Per-file delivery form. 'compressed' (default) always compresses to "
+            "fit the budget; 'adaptive' includes a file whole when it fits and "
+            "compresses only on overflow. Overrides [render] mode."
         ),
     )
     pack.add_argument(

--- a/redcon/compressors/context_compressor.py
+++ b/redcon/compressors/context_compressor.py
@@ -627,7 +627,21 @@ def compress_ranked_files(
             )
         )
 
-    if cfg.progressive_packer_enabled:
+    if cfg.render_mode == "adaptive":
+        result = _compress_adaptive(
+            prepared=prepared,
+            max_tokens=max_tokens,
+            cfg=cfg,
+            cache=cache,
+            seen_imports=seen_imports,
+            token_estimator=token_estimator,
+            files_skipped=files_skipped,
+            total_raw=total_raw,
+            duplicate_reads_prevented=duplicate_reads_prevented,
+            ranked_files=ranked_files,
+            summarizer=summarizer,
+        )
+    elif cfg.progressive_packer_enabled:
         result = _compress_progressive(
             prepared=prepared,
             max_tokens=max_tokens,
@@ -697,6 +711,103 @@ def _compress_greedy(
         total_compressed += entry.compressed_tokens
         compressed_files.append(entry)
         files_included.append(ft.path)
+
+    risk = _build_risk_estimate(
+        cfg,
+        files_skipped,
+        ranked_files,
+        total_compressed,
+        total_raw,
+        max_tokens=max_tokens,
+        files_included_count=len(files_included),
+    )
+    cache_snapshot = cache.snapshot()
+    return CompressionResult(
+        compressed_files=compressed_files,
+        files_included=files_included,
+        files_skipped=files_skipped,
+        estimated_input_tokens=total_compressed,
+        estimated_saved_tokens=max(0, total_raw - total_compressed),
+        duplicate_reads_prevented=duplicate_reads_prevented,
+        cache=cache_snapshot,
+        cache_hits=cache_snapshot.hits,
+        quality_risk_estimate=risk,
+        summarizer=summarizer.snapshot(),
+        degraded_files=[],
+        degradation_savings=0,
+    )
+
+
+def _compress_adaptive(
+    prepared: list[FileTiers],
+    max_tokens: int,
+    cfg: CompressionSettings,
+    cache: SummaryCacheBackend,
+    seen_imports: set[str],
+    token_estimator: Callable[[str], int],
+    files_skipped: list[str],
+    total_raw: int,
+    duplicate_reads_prevented: int,
+    ranked_files: list[RankedFile],
+    summarizer: SummarizationService,
+) -> CompressionResult:
+    """Adaptive strategy: include each file whole when it fits the remaining
+    budget, otherwise fall back to its compressed tier, otherwise skip.
+
+    Walks files in ranking order with the same token estimator used everywhere
+    else, so on a repo that fits the budget this degenerates to all-whole with
+    zero compression. Each entry records its delivery form (whole vs compressed)
+    so a pack is auditable. Deterministic: same order, same estimator, no
+    randomness. The whole representation is built directly from the raw text and
+    is not gated by the full-file threshold.
+    """
+    from redcon.compressors.representations import Tier
+
+    compressed_files: list[CompressedFile] = []
+    files_included: list[str] = []
+    total_compressed = 0
+
+    for ft in prepared:
+        whole_tier = Tier(
+            strategy="full",
+            text=f"# Full: {ft.path}\n{ft.full_text}",
+            tokens=token_estimator(ft.full_text),
+            chunk_strategy="full-file",
+            chunk_reason="adaptive: whole file fits remaining budget",
+            selected_ranges=(
+                [
+                    {
+                        "start_line": 1,
+                        "end_line": ft.line_count,
+                        "kind": "full",
+                        "reason": "adaptive whole file",
+                    }
+                ]
+                if ft.line_count > 0
+                else []
+            ),
+        )
+        whole = _finalize_entry(
+            ft.ranked.file, whole_tier, ft.raw_tokens, seen_imports, cache, token_estimator
+        )
+        if total_compressed + whole.compressed_tokens <= max_tokens:
+            whole.delivery = "whole"
+            total_compressed += whole.compressed_tokens
+            compressed_files.append(whole)
+            files_included.append(ft.path)
+            continue
+        # Overflow: fall back to the most-detailed compressed tier if it fits.
+        if ft.tiers:
+            entry = _finalize_entry(
+                ft.ranked.file, ft.tiers[0], ft.raw_tokens, seen_imports, cache, token_estimator
+            )
+            if total_compressed + entry.compressed_tokens <= max_tokens:
+                entry.delivery = "compressed"
+                total_compressed += entry.compressed_tokens
+                compressed_files.append(entry)
+                files_included.append(ft.path)
+                continue
+        files_skipped.append(ft.path)
 
     risk = _build_risk_estimate(
         cfg,

--- a/redcon/config.py
+++ b/redcon/config.py
@@ -163,6 +163,11 @@ class CompressionSettings:
     max_degradation_rounds: int = 1
     risk_skip_weight: float = 0.55
     risk_compression_weight: float = 0.45
+    # Delivery form for each ranked file. "compressed" (default, unchanged) always
+    # compresses to fit the budget; "adaptive" includes a file whole when it fits
+    # the remaining budget and only compresses on overflow. Set via [render] mode
+    # or the --render-mode CLI flag. See redcon/compressors/context_compressor.py.
+    render_mode: str = "compressed"
 
 
 @dataclass(slots=True)
@@ -371,6 +376,11 @@ class RedconConfig:
             warnings.append(
                 f"[compression].full_file_threshold_tokens must be >= 0, "
                 f"got {self.compression.full_file_threshold_tokens}"
+            )
+        if self.compression.render_mode not in ("compressed", "adaptive"):
+            warnings.append(
+                f"[render].mode must be 'compressed' or 'adaptive', "
+                f"got {self.compression.render_mode!r}"
             )
 
         # Role multipliers
@@ -598,6 +608,8 @@ def _apply_compression_overrides(settings: CompressionSettings, data: Mapping[st
         settings.adaptive_line_budget_max_factor = float(data["adaptive_line_budget_max_factor"])
     if "progressive_packer_enabled" in data:
         settings.progressive_packer_enabled = bool(data["progressive_packer_enabled"])
+    if "render_mode" in data:
+        settings.render_mode = str(data["render_mode"]).strip().lower()
     if "max_degradation_rounds" in data:
         settings.max_degradation_rounds = int(data["max_degradation_rounds"])
     if "risk_skip_weight" in data:
@@ -738,6 +750,7 @@ _KNOWN_TOP_LEVEL_KEYS = frozenset(
         "pack",
         "output",
         "model_profile",
+        "render",
         "repos",
         "name",
     }
@@ -915,6 +928,12 @@ def _apply_overrides(config: RedconConfig, data: Mapping[str, Any]) -> RedconCon
             },
         )
         _apply_compression_overrides(config.compression, compression_data)
+
+    # [render] mode is a friendly surface for the packer's per-file delivery form;
+    # it maps onto compression.render_mode, which the compressor already receives.
+    render_data = data.get("render")
+    if isinstance(render_data, Mapping) and "mode" in render_data:
+        config.compression.render_mode = str(render_data["mode"]).strip().lower()
 
     if isinstance(token_data, Mapping) and not (
         isinstance(plugin_data, Mapping) and "token_estimator" in plugin_data

--- a/redcon/core/pipeline.py
+++ b/redcon/core/pipeline.py
@@ -387,6 +387,7 @@ def run_pack(
     plugins: ResolvedPlugins | None = None,
     record_history: bool = True,
     compression_profile: str | None = None,
+    render_mode: str | None = None,
     changed_files: list[str] | None = None,
 ) -> RunReport:
     """Run pack command pipeline and return typed run report."""
@@ -411,6 +412,10 @@ def run_pack(
         )
         if profile_note:
             logger.warning(profile_note)
+    # Render mode override (CLI/SDK wins over config). Set after profile
+    # resolution so a resolved profile does not reset it.
+    if render_mode is not None:
+        prepared_cfg.compression.render_mode = str(render_mode).strip().lower()
     telemetry = _build_telemetry_session(
         repo=target_repo,
         config=prepared_cfg,

--- a/redcon/engine.py
+++ b/redcon/engine.py
@@ -322,6 +322,7 @@ class RedconEngine:
         config_path: str | Path | None = None,
         timeout: int = 120,
         compression_profile: str | None = None,
+        render_mode: str | None = None,
         changed_files: list[str] | None = None,
     ) -> dict[str, Any]:
         """Build compressed context under token and file budgets.
@@ -363,6 +364,7 @@ class RedconEngine:
                     telemetry_sink=self._telemetry_sink,
                     workspace=workspace_definition,
                     compression_profile=compression_profile,
+                    render_mode=render_mode,
                     changed_files=changed_files,
                 )
                 result = as_json_dict(report)
@@ -377,6 +379,7 @@ class RedconEngine:
                     config=cfg,
                     telemetry_sink=self._telemetry_sink,
                     compression_profile=compression_profile,
+                    render_mode=render_mode,
                     changed_files=changed_files,
                 )
                 result = as_json_dict(report)

--- a/redcon/schemas/models.py
+++ b/redcon/schemas/models.py
@@ -70,6 +70,9 @@ class CompressedFile:
     cache_status: str = ""
     relative_path: str = ""
     repo_label: str = ""
+    # How this file was delivered into the pack: "compressed" (the default packer)
+    # or "whole" (adaptive rendering included the file verbatim because it fit).
+    delivery: str = "compressed"
 
 
 @dataclass(slots=True)

--- a/redcon/stages/workflow.py
+++ b/redcon/stages/workflow.py
@@ -97,6 +97,7 @@ def _serialize_compressed_file(item: CompressedFile) -> dict:
         "chunk_strategy": item.chunk_strategy,
         "chunk_reason": item.chunk_reason,
         "selected_ranges": item.selected_ranges,
+        "delivery": item.delivery,
     }
     if item.symbols:
         data["symbols"] = item.symbols

--- a/tests/test_adaptive_rendering.py
+++ b/tests/test_adaptive_rendering.py
@@ -1,0 +1,127 @@
+"""Tests for adaptive render mode ([render] mode = "adaptive").
+
+Adaptive rendering walks ranked files and includes each one whole when it fits
+the remaining budget, falling back to the compressed entry on overflow and
+skipping only when neither fits. These tests pin the guarantees from the design:
+the budget is never exceeded, the walk is deterministic, a repo that fits the
+budget degenerates to all-whole, overflow produces a whole+compressed mix, and
+the default mode is unchanged (compressed).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from redcon.config import CompressionSettings, RedconConfig, load_config
+from redcon.core import pipeline
+from redcon.stages.workflow import as_json_dict
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+
+def _repo(tmp_path: Path, files: dict[str, str]) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    for rel, content in files.items():
+        path = repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    _git(repo, "add", "-A")
+    _git(repo, "-c", "user.email=t@e", "-c", "user.name=t", "commit", "-qm", "init")
+    return repo
+
+
+def _pack(repo: Path, task: str, max_tokens: int, mode: str | None = None) -> dict:
+    compression = CompressionSettings() if mode is None else CompressionSettings(render_mode=mode)
+    config = RedconConfig(compression=compression)
+    return as_json_dict(
+        pipeline.run_pack(task, repo, max_tokens=max_tokens, config=config, record_history=False)
+    )
+
+
+_SMALL_FILES = {
+    "auth.py": 'def login_retry(user):\n    """login retry"""\n    return retry(user)\n',
+    "db.py": "def connect():\n    return 1\n",
+}
+
+
+def test_default_mode_is_compressed(tmp_path: Path):
+    # No render_mode set: every entry is delivered compressed, unchanged behaviour.
+    assert CompressionSettings().render_mode == "compressed"
+    repo = _repo(tmp_path, _SMALL_FILES)
+    data = _pack(repo, "login retry", max_tokens=5000)
+    assert data["compressed_context"], "expected at least one included file"
+    assert all(e["delivery"] == "compressed" for e in data["compressed_context"])
+
+
+def test_small_repo_degenerates_to_all_whole(tmp_path: Path):
+    # A repo that fits the budget is delivered entirely as whole files.
+    repo = _repo(tmp_path, _SMALL_FILES)
+    data = _pack(repo, "login retry", max_tokens=5000, mode="adaptive")
+    assert data["compressed_context"]
+    assert all(e["delivery"] == "whole" for e in data["compressed_context"])
+    assert all(e["text"].startswith("# Full:") for e in data["compressed_context"])
+    # Zero compression: nothing saved because everything is whole.
+    assert data["budget"]["estimated_saved_tokens"] == 0
+
+
+def _overflow_repo(tmp_path: Path) -> Path:
+    big = "\n".join(
+        f"def helper_{i}(retry_login):\n    # retry login helper {i}\n    return {i}\n"
+        for i in range(200)
+    )
+    return _repo(
+        tmp_path,
+        {
+            "auth.py": 'def login_retry(user):\n    """login retry"""\n    return retry(user)\n',
+            "big.py": big,
+        },
+    )
+
+
+def test_budget_never_exceeded_on_overflow(tmp_path: Path):
+    repo = _overflow_repo(tmp_path)
+    for budget in (400, 800, 1500):
+        data = _pack(repo, "login retry helper", max_tokens=budget, mode="adaptive")
+        assert data["budget"]["estimated_input_tokens"] <= budget
+
+
+def test_mixed_whole_and_compressed_on_overflow(tmp_path: Path):
+    # A large ranked-first file must compress while a small file stays whole.
+    repo = _overflow_repo(tmp_path)
+    data = _pack(repo, "login retry helper", max_tokens=400, mode="adaptive")
+    deliveries = {e["path"].split("/")[-1]: e["delivery"] for e in data["compressed_context"]}
+    assert deliveries.get("big.py") == "compressed"
+    assert deliveries.get("auth.py") == "whole"
+
+
+def test_adaptive_is_deterministic(tmp_path: Path):
+    repo = _overflow_repo(tmp_path)
+    first = _pack(repo, "login retry helper", max_tokens=600, mode="adaptive")["compressed_context"]
+    second = _pack(repo, "login retry helper", max_tokens=600, mode="adaptive")[
+        "compressed_context"
+    ]
+    assert [(e["path"], e["delivery"], e["text"]) for e in first] == [
+        (e["path"], e["delivery"], e["text"]) for e in second
+    ]
+
+
+def test_render_section_and_compression_key_parse(tmp_path: Path):
+    # [render] mode and [compression] render_mode both reach the setting.
+    cfg_render = tmp_path / "a.toml"
+    cfg_render.write_text('[render]\nmode = "adaptive"\n')
+    assert load_config(tmp_path, config_path=cfg_render).compression.render_mode == "adaptive"
+
+    cfg_comp = tmp_path / "b.toml"
+    cfg_comp.write_text('[compression]\nrender_mode = "adaptive"\n')
+    assert load_config(tmp_path, config_path=cfg_comp).compression.render_mode == "adaptive"
+
+
+def test_invalid_render_mode_warns():
+    cfg = RedconConfig(compression=CompressionSettings(render_mode="nonsense"))
+    warnings = cfg.validate()
+    assert any("mode" in w and "adaptive" in w for w in warnings)


### PR DESCRIPTION
Product change behind a flag, default unchanged. Adds an adaptive render mode that delivers files whole when they fit the budget and compresses only on overflow. This is the change Experiment 3 measures.

## Surface
- `[render] mode` (also `[compression] render_mode`, and `--render-mode`), values `compressed` (current default, unchanged) and `adaptive`. No default change in this PR.

## Semantics (pinned)
Walk files in ranking order with the same token estimator used everywhere else:
- whole file fits remaining budget -> include verbatim, path-headed (`# Full: <path>`);
- else the compressed entry fits -> include compressed;
- else skip.

On a repo that fits the budget this degenerates to all-whole, zero compression. The tail behaves exactly like today's compression.

## Auditability and determinism
- Each pack entry records its delivery form: `delivery` = `whole` or `compressed`, serialized into `compressed_context`.
- Deterministic: same ranking order, same estimator, no randomness.

## Implementation
`_compress_adaptive` in `redcon/compressors/context_compressor.py`, dispatched from `compress_ranked_files` when `render_mode == "adaptive"`. Everything it needs (whole text, whole-file token count, compressed tier) is already materialized per file, so there is no new file I/O. Config field on `CompressionSettings` with a `[render]` section surface; CLI flag threaded through `engine.pack` and `run_pack` (set after profile resolution so it is not clobbered); `delivery` field added to `CompressedFile` and its serializer.

## Tests (`tests/test_adaptive_rendering.py`)
Budget never exceeded, deterministic across two runs, small-repo degeneration to all-whole, mixed whole+compressed on overflow, default remains compressed, config parse (both surfaces) and invalid-mode validation. Full suite: 1247 passed (live-server tests excluded; the one pre-existing live-gateway failure is unrelated).