### PR TITLE
Correct push-arm precision: exclude redcon .redcon build artifacts

### DIFF
--- a/benchmarks/agentic/agent_arm.py
+++ b/benchmarks/agentic/agent_arm.py
@@ -46,6 +46,7 @@ import argparse
 import contextlib
 import json
 import os
+import shutil
 import subprocess
 import time
 from collections.abc import Iterator
@@ -395,8 +396,30 @@ def _redcon_calls(counts: dict[str, int]) -> int:
     return sum(v for name, v in counts.items() if str(name).startswith("mcp__redcon__"))
 
 
+def _clean_redcon_artifacts(worktree: Path) -> None:
+    """Delete redcon's own cache artifacts a pack build wrote into the worktree.
+
+    When a push arm builds a pack inside the worktree, redcon writes ``.redcon/``
+    and ``.redcon_cache.json*``. Removing them before the agent starts keeps the
+    measured worktree clean so they cannot appear as the agent's edits.
+    """
+    for name in (".redcon", ".redcon_cache.json", ".redcon_cache.json.lock"):
+        target = worktree / name
+        with contextlib.suppress(FileNotFoundError):
+            if target.is_dir():
+                shutil.rmtree(target, ignore_errors=True)
+            else:
+                target.unlink()
+
+
 def _files_edited(worktree: Path) -> list[str]:
-    """Repo-relative paths the agent created or modified in the worktree."""
+    """Repo-relative paths the agent created or modified in the worktree.
+
+    redcon's own cache artifacts (``.redcon/``, ``.redcon_cache.json`` and its
+    lock) are excluded by definition: when an arm builds or the agent calls a
+    pack, redcon writes them, so they are not agent edits and must never count
+    toward recall or precision.
+    """
     out = _git(worktree, "status", "--porcelain")
     edited = []
     for line in out.splitlines():
@@ -405,6 +428,8 @@ def _files_edited(worktree: Path) -> list[str]:
         path = line[3:].strip()
         if " -> " in path:  # rename: take the destination
             path = path.split(" -> ", 1)[1]
+        if path.startswith(".redcon"):
+            continue
         edited.append(path)
     return sorted(edited)
 
@@ -495,6 +520,10 @@ def run_one(
         base["ranking_file_hits"] = (
             round(len(changed & set(ranked)) / len(changed), 6) if changed else 0.0
         )
+    # A pack built above writes redcon artifacts into the worktree; remove them so
+    # they cannot land in the agent's git-status edits (belt-and-suspenders with the
+    # .redcon exclusion in _files_edited).
+    _clean_redcon_artifacts(worktree)
     started = time.monotonic()
     try:
         proc = subprocess.run(

--- a/benchmarks/agentic/results/agent-heavy/NIGHT2.md
+++ b/benchmarks/agentic/results/agent-heavy/NIGHT2.md
@@ -50,10 +50,14 @@ Zero adoption. Arm A called a redcon tool 0 times across all 36 runs, on repos o
 several million tokens. "Available but unprompted" is pure schema overhead with no
 use, and A comes out slightly behind B.
 
+Precision below is the corrected editing-runs value (see the correction note under
+"All arms, precise"); A and B carry no `.redcon` artifacts, so only the convention
+shifts (0.82 to 0.897, 0.80 to 0.872).
+
 | arm | cost/run | turns | recall | precision | capped | redcon calls |
 |---|---|---|---|---|---|---|
-| A (redcon) | $0.82 | 23.2 | 0.62 | 0.82 | 16/36 | 0 |
-| B (baseline) | $0.78 | 19.8 | 0.69 | 0.80 | 10/36 | 0 |
+| A (redcon) | $0.82 | 23.2 | 0.62 | 0.897 | 16/36 | 0 |
+| B (baseline) | $0.78 | 19.8 | 0.69 | 0.872 | 10/36 | 0 |
 
 The night-1 audit (the agent greps by hand instead of ranking) is confirmed at
 full scale. This makes pass 2 the decisive test: whether one guidance line moves
@@ -178,13 +182,26 @@ in arm P was therefore an incomplete map by construction.
 
 ### All arms, precise (n=36 each)
 
+Correction note (dated 2026-08-11): the precision column below is corrected. The
+original figures were wrong for two reasons. (1) The pack build ran redcon inside
+the worktree, so `.redcon/`, `.redcon_cache.json` and its lock landed in
+`files_edited` for the arms that build or call a pack (P 36/36, P120 24/24, Agc
+4/36 - exactly the adopting runs; B/A/Ag have none), deflating their precision.
+(2) The original column averaged precision over all 36 runs, counting a
+non-editing run as 0; the corrected column excludes `.redcon*` paths and averages
+over runs that edited at least one real file (that is why even the artifact-free
+arms shift, e.g. B 0.799 = 0.872 x 33/36). Corrected precision (editing runs in
+parens): **B 0.872 (33), A 0.897 (33), Ag 0.862 (34), Agc 0.846 (29), P 0.916
+(33), P120 0.829 (23).** The table shows the corrected values; recompute from
+`records.jsonl` with `.redcon*` excluded.
+
 | arm | cost/run | turns | recall | precision | capped | adopted |
 |---|---|---|---|---|---|---|
-| B baseline | $0.78 | 19.8 | 0.688 | 0.799 | 10 | 0/36 |
-| A redcon | $0.82 | 23.2 | 0.618 | 0.822 | 16 | 0/36 |
-| Ag guided | $0.91 | 25.7 | 0.617 | 0.814 | 19 | 0/36 |
-| Agc config | $0.69 | 20.8 | 0.588 | 0.676 | 12 | 4/36 |
-| P preinject | $1.84 | 22.2 | 0.634 | 0.412 | 15 | 0/36 |
+| B baseline | $0.78 | 19.8 | 0.688 | 0.872 | 10 | 0/36 |
+| A redcon | $0.82 | 23.2 | 0.618 | 0.897 | 16 | 0/36 |
+| Ag guided | $0.91 | 25.7 | 0.617 | 0.862 | 19 | 0/36 |
+| Agc config | $0.69 | 20.8 | 0.588 | 0.846 | 12 | 4/36 |
+| P preinject | $1.84 | 22.2 | 0.634 | 0.916 | 15 | 0/36 |
 
 Per-stratum recall (precise, n=12/cell):
 
@@ -246,11 +263,13 @@ built its own map** - context has value at the start of a run, not mid-run.
 
 ### P: pack value once adoption is removed
 
-P did not beat B: cost 2.4x, recall 0.634 vs 0.688, and **precision collapsed to
-0.412** (vs 0.799). Mechanism, from the transcripts: the agent anchors on the
-injected map and edits files it lists that are not targets - e.g. django/36be97b9
-rep0 edited 8 files, 5 of them non-targets, one taken straight from the pack
-(`tests/staticfiles_tests/.../ignored.css`). Averaged 3.3 superfluous edits/run.
+P did not beat B: cost 2.4x and recall 0.634 vs 0.688. Precision, corrected for
+the `.redcon` artifact, is **0.916** (not the 0.412 first reported) - **intact,
+slightly above B's 0.872.** The earlier "3.3 superfluous edits/run" and the
+"anchors on the map and edits non-targets" mechanism were an artifact of the pack
+build writing `.redcon/` and `.redcon_cache.json*` into the worktree, counted as
+edits; with those excluded the agent edits few non-target real files. P's loss is
+cost and recall, not precision.
 
 P's recall tracks the pack's coverage almost exactly (0.634 vs pack-file-hits
 0.627): the agent trusts the map, so an incomplete map caps recall below what free
@@ -264,10 +283,11 @@ tests it at scale (24 runs at ~0.9 coverage) and **refutes it**.
 ### P120: a near-complete pack still does not pay
 
 P120 pre-injects a 120k pack (pack-file-hits 0.896, near-complete). It did not beat
-baseline: recall 0.575 vs B 0.688, precision 0.39, cost **$2.72 (3.5x)**, and a
-**33% turn-cap rate** (8/24 hit the 30-turn limit vs 10/36 for B). Even excluding
-the capped runs, the completed P120 runs only *tie* baseline on recall (0.672 vs
-0.688) at 3.4x cost and half the precision (0.45 vs 0.80).
+baseline: recall 0.575 vs B 0.688, cost **$2.72 (3.5x)**, and a **33% turn-cap
+rate** (8/24 hit the 30-turn limit vs 10/36 for B). Precision, corrected for the
+`.redcon` artifact, is **0.829** (not the 0.39 first reported) - intact, near B's
+0.872, not "half". Even excluding the capped runs, the completed P120 runs only
+*tie* baseline on recall (0.672 vs 0.688) at 3.4x cost.
 
 So more coverage did not help - it hurt: the larger map inflates cost (re-read
 every turn) and makes the agent wade through more files, capping out and spreading
@@ -283,8 +303,9 @@ The pull evidence still holds that context helps most early not late: Ag spent i
 extra turns searching, and Agc's `redcon_rank` helped only when it came in the
 first few turns. But the stronger claim - that pushing the map up front pays -
 does **not** survive P120. A targeted early lookup can help; dumping the whole map
-in front of a multi-turn agent does not, at 30k (incomplete, precision harm) or at
-120k (complete, but the agent caps out wading through it). The value of "at start"
+in front of a multi-turn agent does not, at 30k (incomplete, recall capped by the
+map) or at 120k (complete, but the agent caps out wading through it). The value of
+"at start"
 is a small, targeted result, not a large map re-read every turn.
 
 ## Bottom line
@@ -295,16 +316,18 @@ On large repositories, in headless autonomous mode with sonnet, redcon delivered
 1. **Pull fails on delivery.** The agent will not reach for redcon on its own:
    0/36 unprompted, 0/36 with a prompt line, 4/36 via the CLAUDE.md rule.
 2. **Push fails in the loop, regardless of coverage.** Pre-injecting the map does
-   not beat baseline at 30k (0.64 coverage, precision 0.41) or at 120k (0.90
-   coverage, recall ties B at 3.4x cost, half the precision, 33% cap-outs). More
-   coverage did not turn push positive; it made the map harder to use.
+   not beat baseline at 30k (0.64 coverage, recall 0.634 vs 0.688 at 2.4x cost) or
+   at 120k (0.90 coverage, recall ties B at 3.4x cost, 33% cap-outs). Precision is
+   intact once the `.redcon` build artifact is excluded (P 0.916, P120 0.829 vs B
+   0.872 - see the correction note); push fails on cost and recall, not precision.
+   More coverage did not turn push positive; it made the map harder to use.
 
 What is *not* refuted: the pack's file-finding itself is good (the sweep reaches
 0.90 recall at 120k - a budget, not a ranking, limit), and the layer-1 results
 (97.8% file recall, contexts 63-93% smaller) stand for small and medium
 repositories. The gap is between a good pack and a better end-task outcome once an
 autonomous multi-turn agent is in the loop: the agent does as well or better
-exploring freely, and a handed-over map hurts precision and inflates cost. The one
+exploring freely, and a handed-over map lowers recall and inflates cost. The one
 delivery mode these runs do **not** cover is single- or few-turn, non-interactive
 flows (CI checks, review bots, one-shot API calls), where the map is not re-read
 many times; that remains the only open place push might pay, and it is the honest

--- a/docs/research/agentic-eval.md
+++ b/docs/research/agentic-eval.md
@@ -18,8 +18,8 @@ redcon and grepped by hand. On large repos (night 2, django and sympy, 228 agent
 runs) redcon delivered **no measured end-task improvement through any channel
 tested**: the agent will not reach for it (0-11% adoption across three delivery
 channels), and pre-injecting the pack does not beat baseline in a multi-turn loop
-at any coverage (a 0.90-coverage 120k map ties recall at 3.4x cost and half the
-precision). A deterministic sweep shows the coverage ceiling is a **budget limit,
+at any coverage (a 0.90-coverage 120k map ties recall at 3.4x cost, with a 33%
+turn-cap rate; precision is intact once redcon's own build artifact is excluded). A deterministic sweep shows the coverage ceiling is a **budget limit,
 not a ranking limit** (pack file-hits climb 0.36 to 0.90 from 12k to 120k). The
 layer-1 selection quality stands; the open gap is delivery, and it is specific to
 autonomous multi-turn agents on multi-million-token repos.
@@ -84,14 +84,20 @@ changed files. The failure is behavioural (adoption), not ranking.
 a one-line prompt hint, **Agc** plus the rule in CLAUDE.md, **P** pre-inject a 30k
 pack, **P120** pre-inject a 120k pack.
 
+Precision is the corrected value (2026-08-11): the pack build wrote redcon's own
+`.redcon*` cache artifacts into the worktree, which inflated the edited-file set
+for the pack-building arms (P, P120, and the 4 adopting Agc runs) and deflated
+their precision; excluding `.redcon*` and averaging over runs that edited a real
+file gives the numbers below. Push fails on cost and recall, not precision.
+
 | arm | cost/run | recall | precision | adopted |
 |---|---|---|---|---|
-| B baseline | $0.78 | 0.688 | 0.799 | 0/36 |
-| A redcon | $0.82 | 0.618 | 0.822 | 0/36 |
-| Ag guided | $0.91 | 0.617 | 0.814 | 0/36 |
-| Agc config | $0.69 | 0.588 | 0.676 | 4/36 |
-| P (30k) | $1.84 | 0.634 | 0.412 | 0/36 |
-| P120 (120k) | $2.72 | 0.575 | 0.390 | 0/24 |
+| B baseline | $0.78 | 0.688 | 0.872 | 0/36 |
+| A redcon | $0.82 | 0.618 | 0.897 | 0/36 |
+| Ag guided | $0.91 | 0.617 | 0.862 | 0/36 |
+| Agc config | $0.69 | 0.588 | 0.846 | 4/36 |
+| P (30k) | $1.84 | 0.634 | 0.916 | 0/36 |
+| P120 (120k) | $2.72 | 0.575 | 0.829 | 0/24 |
 
 - **Pull fails on delivery.** Adoption is 0/36 unprompted, 0/36 with a prompt
   line, and 4/36 via the CLAUDE.md rule - the only channel with any uptake. (The
@@ -99,11 +105,13 @@ pack, **P120** pre-inject a 120k pack.
   CLAUDE.md is read - a shipped-guidance delivery bug.) The guided arm was the
   single worst: unheard guidance sent the agent searching more, not ranking.
 - **Push fails in the loop, at any coverage.** Pre-injection does not beat
-  baseline at 30k (0.64 coverage; the agent anchors on the incomplete map,
-  precision 0.41) or at 120k (0.90 coverage; recall ties B excluding cap-outs, at
-  3.4x cost, half the precision, and a 33% turn-cap rate). More coverage made the
-  map harder to use, not more valuable. The pre-registered context-window caveat
-  did not trigger: failures were turn-caps, not truncation.
+  baseline at 30k (0.64 coverage; recall 0.634 vs 0.688 at 2.4x cost) or at 120k
+  (0.90 coverage; recall ties B excluding cap-outs, at 3.4x cost and a 33%
+  turn-cap rate). Precision is intact once the `.redcon` build artifact is
+  excluded (P 0.916, P120 0.829 vs B 0.872); push fails on cost and recall, not
+  precision. The incomplete 30k map lowers recall (the agent trusts it), not
+  precision. The pre-registered context-window caveat did not trigger: failures
+  were turn-caps, not truncation.
 
 The injected map's cost scales with turns (the 30k/120k prefix is re-read every
 turn), so any value push might carry is confined to short, non-interactive flows -

--- a/docs/research/exp1-one-shot.md
+++ b/docs/research/exp1-one-shot.md
@@ -111,9 +111,11 @@ x 2 repeats, 24 = 12 tasks x 2 repeats per arm/corpus). All numbers below
 recompute from `benchmarks/agentic/results/oneshot-full/records.jsonl`, committed
 with this PR; the full model responses are archived at
 `~/redcon-exp-backups/exp1-oneshot-transcripts.tar.gz` (64K, 96 files). Total
-list-price cost: $99.72. `empty_result` = 0 across all 96 cells (the tool-less
-`--tools ""` config leaves the model nothing to do but answer), so every parse
-failure is a genuine non-diff response, not a spent-on-a-tool-attempt turn.
+list-price cost: $99.72. `empty_result` = 1 of 96 cells (one small-corpus redcon
+cell, `56c7b8d`, returned an empty response; it is a parse failure scored zero per
+the convention below, so metrics are unaffected). The tool-less `--tools ""`
+config leaves the model nothing to do but answer, so parse failures are genuine
+non-diff responses, not spent-on-a-tool-attempt turns.
 
 ### Metric definitions used below
 

--- a/docs/research/exp2-p-lite.md
+++ b/docs/research/exp2-p-lite.md
@@ -7,8 +7,10 @@ Natalia confirms a usage window.**
 
 Night 2 injected the full pack (arm P at 30k, P120 at 120k) and both lost to
 baseline in a multi-turn loop: the large map is re-read every turn (2.4-3.5x
-cost), the agent anchors on it (precision collapses to ~0.41), and at 120k a
-third of runs cap out. Yet two signals point the other way: Agc's `redcon_rank`
+cost), recall does not improve, and at 120k a third of runs cap out. (Precision
+was originally reported as collapsing to ~0.41; that was a `.redcon` artifact in
+`files_edited` - see the correction note under Results. Precision is intact.) Yet
+two signals point the other way: Agc's `redcon_rank`
 helped when it came early, and context has value at the start of a run. P-lite
 tests the minimal version of that: give the agent only the **ranking list**, not
 the content, and let it read the files itself.
@@ -81,31 +83,48 @@ precise). All numbers recompute from
 full stream-json transcripts are archived at
 `~/redcon-exp-backups/exp2-plite-transcripts.tar.gz` (1.3M).
 
+Correction note (dated 2026-08-11): the precision figures first reported here
+(P-lite 0.465, baseline 0.881) were a harness artifact and are wrong. The pack
+build ran redcon inside the worktree, so `.redcon/`, `.redcon_cache.json` and its
+lock landed in `files_edited` for every P-lite run (24/24) while baseline had none
+(0/36), deflating P-lite precision. Recomputed with `.redcon*` paths excluded on
+both arms, the numbers below are correct and **H3 is held, not refuted.**
+
 | metric | baseline B | P-lite | pre-registered hypothesis |
 |---|---|---|---|
 | cost | $0.776 | $0.664 | H1 (cost ~= baseline): **held** (slightly cheaper) |
 | turns | 19.8 | 17.8 | - |
 | recall (file_hits) | 0.688 | 0.556 | H2 (recall > baseline): **refuted** |
-| precision (post-hoc) | 0.881 | 0.465 | H3 (no precision collapse): **refuted** |
+| precision (`.redcon` excluded) | 0.872 (33 runs) | 0.943 (18 runs) | H3 (no precision collapse): **held** |
 | cap-out | 11/36 (31%) | 8/24 (33%) | - |
 | ranking coverage of GT | - | 0.270 | - |
 
-**Verdict: a clean negative on 2 of 3 pre-registered hypotheses.** P-lite matches
-baseline on cost but does not beat it on recall and collapses precision.
+**Verdict: negative on H2, but H3 holds.** P-lite matches baseline on cost, does
+not beat it on recall, and does **not** collapse precision - its precision (0.943)
+is in fact slightly above baseline (0.872).
 
-**Mechanism.** The injected top-10 ranking covered only 27% of the ground-truth
-files (`ranking_file_hits` = 0.270), so it pointed the agent at a mostly-wrong set
-and anchored edits there - an anchoring effect consistent with the night-2 full-map
-push arms (P at 30k and P120 at 120k), which also collapsed precision. The lightest
-possible in-loop delivery of redcon's ranking does not pay; push delivery is closed
-for interactive use at any weight.
+**Mechanism (corrected).** The ranking did **not** anchor edits onto wrong files:
+precision is intact. What it did was **narrow exploration** - P-lite took fewer
+turns (17.8 vs 19.8) and reached fewer ground-truth files (recall 0.556 vs 0.688).
+Pointed at a top-10 list that covered only 27% of the ground-truth files
+(`ranking_file_hits` = 0.270), the agent searched less and stopped short, rather
+than editing the wrong things. Push delivery stays closed for interactive use, but
+on **cost and recall** grounds, not precision: P costs 2.4x at recall 0.634, P120
+3.4x with a 33% cap-out rate, and P-lite trades recall for a shorter loop with no
+offsetting benefit.
 
 **Metric definitions.** recall = `file_hits` (fraction of ground-truth files the
 agent edited); precision = |files_edited and changed_files| / |files_edited|,
 computed post-hoc over runs that edited at least one file; cap-out = runs whose
-`terminal_reason` is not `completed`.
+`terminal_reason` is not `completed`. **`files_edited` excludes any path starting
+with `.redcon`** (redcon's own cache artifacts, written by the pack build, are not
+agent edits). The run filter is harness-error only (runs with an `error` key are
+dropped; CLI `is_error` runs are kept, matching the night-2 baseline slice).
 
 **Caveats.** P-lite n = 24 vs baseline n = 36 (2 vs 3 repeats). Precision is
-averaged over runs that edited at least one file: 16 of 24 P-lite runs, 25 of 36
-baseline runs. Baseline B is reused from night 2 with no version drift (both under
-CLI 2.1.220, model claude-sonnet-5), so no fresh baseline controls were required.
+averaged over runs that edited at least one non-artifact file: 18 of 24 P-lite runs,
+33 of 36 baseline runs. (An earlier draft reported 16 P-lite editing runs; that
+count came from an erroneous extra `is_error` filter that dropped 8 runs - the
+correct filter keeps all 24, of which 18 edited a real file.) Baseline B is reused
+from night 2 with no version drift (both under CLI 2.1.220, model claude-sonnet-5),
+so no fresh baseline controls were required.

--- a/tests/test_agent_arm.py
+++ b/tests/test_agent_arm.py
@@ -183,6 +183,40 @@ def test_files_edited_reports_modified_added_and_renamed(tmp_path: Path) -> None
     assert "renamed.py" in edited  # the destination side of the rename
 
 
+def test_files_edited_excludes_redcon_artifacts(tmp_path: Path) -> None:
+    # redcon's own cache artifacts must never count as agent edits.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(repo), "-c", "user.email=t@e", "-c", "user.name=t", *args],
+            check=True,
+            capture_output=True,
+        )
+
+    git("init", "-q")
+    (repo / "seed.py").write_text("x = 1\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-qm", "init")
+
+    (repo / "real.py").write_text("y = 2\n", encoding="utf-8")  # a genuine agent edit
+    (repo / ".redcon").mkdir()
+    (repo / ".redcon" / "runs.json").write_text("{}", encoding="utf-8")
+    (repo / ".redcon_cache.json").write_text("{}", encoding="utf-8")
+    (repo / ".redcon_cache.json.lock").write_text("", encoding="utf-8")
+
+    edited = agent_arm._files_edited(repo)
+    assert "real.py" in edited
+    assert not any(p.startswith(".redcon") for p in edited)
+
+    # And the cleanup helper removes them from the worktree entirely.
+    agent_arm._clean_redcon_artifacts(repo)
+    assert not (repo / ".redcon").exists()
+    assert not (repo / ".redcon_cache.json").exists()
+    assert not (repo / ".redcon_cache.json.lock").exists()
+
+
 def test_file_hits_is_recall_of_changed_files() -> None:
     assert agent_arm._file_hits(["a.py", "b.py"], ["a.py", "c.py"]) == 0.5
     assert agent_arm._file_hits(["a.py"], ["a.py"]) == 1.0


### PR DESCRIPTION
Correction: the push-arm precision numbers were a harness artifact. The pack build ran redcon inside the worktree, so `.redcon/`, `.redcon_cache.json` and its lock landed in `files_edited` for every pack-building arm (P 36/36, P120 24/24, P-lite 24/24, Agc 4/36 - exactly the adopting runs), while baseline had none, deflating their precision.

## Recomputed numbers (`.redcon*` excluded on both arms, averaged over runs that edited a real file)
- Exp 2 (P-lite vs baseline): P-lite precision **0.943 (18 editing runs)** vs baseline **0.872 (33)**. **H3 (no precision collapse) is HELD, not refuted.** H2 (recall) refuted stands (0.556 vs 0.688). Cost 0.664 vs 0.776, turns 17.8 vs 19.8.
- Night 2: P precision **0.916** (was 0.412), P120 **0.829** (was 0.39), and for reference A 0.897, Ag 0.862, Agc 0.846, B 0.872. Recall/cost unchanged.
- The baseline precise slice reproduces recall 0.688, $0.776, 19.8 turns exactly.

## What changed vs what stands
- Push stays closed for interactive use, but on **cost and recall**, not precision (P 2.4x at recall 0.634; P120 3.4x with 33% cap-outs; P-lite recall 0.556 with no offsetting benefit).
- Mechanism rewritten: the ranking did **not** anchor edits onto wrong files (precision intact); it **narrowed exploration** (17.8 vs 19.8 turns) and lowered recall.
- 18-vs-16 editing-run resolution: the earlier 16 came from an erroneous extra `is_error` filter that dropped 8 runs; the correct filter keeps all 24, of which 18 edited a real file.

## Files
- `docs/research/exp2-p-lite.md`: H3 verdict to held, corrected precision table, rewritten mechanism, metric definition stating the `.redcon` exclusion and the editing-run filter, 18-vs-16 resolution.
- `benchmarks/agentic/results/agent-heavy/NIGHT2.md`: corrected precision columns and prose, dated correction note.
- `docs/research/agentic-eval.md`: P row and precision mentions.
- `docs/research/exp1-one-shot.md`: `empty_result` 0 to 1 (one redcon cell, unparsed, scored zero per convention; metrics unaffected).

## Harness fix (cannot recur)
`_files_edited` excludes `.redcon*` paths by definition; `_clean_redcon_artifacts` removes a pack build's artifacts from the worktree before the agent starts. Documented in the metric definitions and docstrings; test added. Full suite 1241 passed (live-server tests excluded).

## Exp 1 verification
All other numbers reproduce exactly from records (corpus split 24/24/24/24, conditional overlap, total cost $99.72). Only `empty_result` changed.