### PR TITLE
Flip default render mode to adaptive (1.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Default pack render mode is now **adaptive**: each ranked file is included
+  whole when it fits the remaining budget and compressed only on overflow (the
+  previous behaviour, always compressing, is still available with
+  `--render-mode compressed` or `[render] mode = "compressed"`). This is driven
+  by measurement: at equal budget, adaptive-rendered redcon beats both a naive
+  whole-file keyword retrieval and the old compressed pack on one-shot edit
+  fidelity (file-overlap 0.432 vs 0.319 vs 0.196 pooled; all three pre-registered
+  hypotheses hold - see `docs/research/exp3-adaptive-rendering.md`). **Pack
+  content changes on upgrade, so packs and their `prompt_cache_key` change once
+  and prompt-cache-style caches repopulate; the change is deterministic and one
+  time (same class of note as the 1.16 default-budget change). Pin the old
+  behaviour with `--render-mode compressed` if you need byte-identical packs.**
+
 ## [1.16.0] - 2026-08-09
 
 ### Changed

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -106,6 +106,13 @@ reported quality risk (measured on this repository). It can also be set
 persistently with `[compression] profile = "max"` in `redcon.toml`. `run.json`
 always records which profile actually ran (`compression_profile`).
 
+`--render-mode adaptive|compressed` chooses the per-file delivery form.
+`adaptive` (the default since 1.17.0) includes a file whole when it fits the
+remaining budget and compresses only on overflow; `compressed` always compresses
+to fit (the pre-1.17.0 form). It overrides `[render] mode` in `redcon.toml`. See
+[Configuration](configuration.md) and the measurement in
+[docs/research/exp3-adaptive-rendering.md](research/exp3-adaptive-rendering.md).
+
 Every pack prints a `Cache key`: a stable 16-hex fingerprint of the packed
 content, reproduced exactly when the tree and task are unchanged. Edits that
 do not alter what gets packed keep the key (and any provider prompt cache

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,7 @@ Precedence:
 - `[score]`
 - `[model]`
 - `[compression]`
+- `[render]`
 - `[summarization]`
 - `[tokens]`
 - `[plugins]`
@@ -50,6 +51,9 @@ critical_path_keywords = ["auth", "permissions", "billing"]
 summary_preview_lines = 10
 # profile = "max"  # tighter tier thresholds, ~20% fewer input tokens
 
+[render]
+mode = "adaptive"
+
 [summarization]
 backend = "deterministic"
 adapter = ""
@@ -80,6 +84,30 @@ file_path = ".redcon/telemetry.jsonl"
 Telemetry remains disabled by default and sends no network traffic.
 
 Plugin selection and explicit registration are documented in [Plugins](plugins.md).
+
+## Render mode
+
+`[render] mode` chooses how each ranked file is delivered into the pack. Both
+values keep the same ranking and honour the same token budget; they differ only
+in per-file form:
+
+- `adaptive` (default): include a file whole when it fits the remaining budget,
+  and fall back to a compressed (symbol-extracted) representation only on
+  overflow. On a repository that fits the budget this degenerates to whole files
+  with no compression.
+- `compressed`: always compress each file to fit, the pre-1.17.0 behaviour.
+
+```toml
+[render]
+mode = "adaptive"
+```
+
+Adaptive became the default in 1.17.0, based on the measurement in
+[docs/research/exp3-adaptive-rendering.md](research/exp3-adaptive-rendering.md)
+(at equal budget it improves one-shot edit fidelity over both a naive whole-file
+retrieval and the old compressed pack). The `--render-mode` CLI flag overrides
+this setting per run. Pin `mode = "compressed"` (or `--render-mode compressed`)
+for the pre-1.17.0 pack form.
 
 ## Model Profiles
 

--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -3185,9 +3185,9 @@ def _register_packing_commands(sub: argparse._SubParsersAction) -> None:
         choices=["compressed", "adaptive"],
         default=None,
         help=(
-            "Per-file delivery form. 'compressed' (default) always compresses to "
-            "fit the budget; 'adaptive' includes a file whole when it fits and "
-            "compresses only on overflow. Overrides [render] mode."
+            "Per-file delivery form. 'adaptive' (default) includes a file whole "
+            "when it fits the budget and compresses only on overflow; 'compressed' "
+            "always compresses to fit. Overrides [render] mode."
         ),
     )
     pack.add_argument(

--- a/redcon/config.py
+++ b/redcon/config.py
@@ -163,11 +163,12 @@ class CompressionSettings:
     max_degradation_rounds: int = 1
     risk_skip_weight: float = 0.55
     risk_compression_weight: float = 0.45
-    # Delivery form for each ranked file. "compressed" (default, unchanged) always
-    # compresses to fit the budget; "adaptive" includes a file whole when it fits
-    # the remaining budget and only compresses on overflow. Set via [render] mode
-    # or the --render-mode CLI flag. See redcon/compressors/context_compressor.py.
-    render_mode: str = "compressed"
+    # Delivery form for each ranked file. "adaptive" (default) includes a file
+    # whole when it fits the remaining budget and only compresses on overflow;
+    # "compressed" always compresses to fit. Set via [render] mode or the
+    # --render-mode CLI flag. See redcon/compressors/context_compressor.py.
+    # Adaptive became the default in 1.17.0 (see docs/research/exp3-adaptive-rendering.md).
+    render_mode: str = "adaptive"
 
 
 @dataclass(slots=True)

--- a/tests/test_adaptive_rendering.py
+++ b/tests/test_adaptive_rendering.py
@@ -49,12 +49,20 @@ _SMALL_FILES = {
 }
 
 
-def test_default_mode_is_compressed(tmp_path: Path):
-    # No render_mode set: every entry is delivered compressed, unchanged behaviour.
-    assert CompressionSettings().render_mode == "compressed"
+def test_default_mode_is_adaptive(tmp_path: Path):
+    # Default flipped to adaptive (Exp 3, next release): a repo that fits the budget
+    # is delivered whole with no render_mode set.
+    assert CompressionSettings().render_mode == "adaptive"
     repo = _repo(tmp_path, _SMALL_FILES)
     data = _pack(repo, "login retry", max_tokens=5000)
     assert data["compressed_context"], "expected at least one included file"
+    assert all(e["delivery"] == "whole" for e in data["compressed_context"])
+
+
+def test_compressed_mode_still_available(tmp_path: Path):
+    # The old behaviour is still selectable explicitly.
+    repo = _repo(tmp_path, _SMALL_FILES)
+    data = _pack(repo, "login retry", max_tokens=5000, mode="compressed")
     assert all(e["delivery"] == "compressed" for e in data["compressed_context"])
 
 

--- a/tests/test_pack_pipeline.py
+++ b/tests/test_pack_pipeline.py
@@ -136,6 +136,7 @@ def test_fragment_cache_reuses_reference_on_second_run(tmp_path: Path) -> None:
         tmp_path / "redcon.toml",
         """
 [compression]
+render_mode = "compressed"
 full_file_threshold_tokens = 1000
 snippet_score_threshold = 999
 """.strip(),
@@ -172,6 +173,7 @@ def test_fragment_cache_reuses_reference_across_repeated_tasks(tmp_path: Path) -
         tmp_path / "redcon.toml",
         """
 [compression]
+render_mode = "compressed"
 full_file_threshold_tokens = 1000
 snippet_score_threshold = 999
 """.strip(),
@@ -201,6 +203,7 @@ def test_fragment_cache_reports_token_savings(tmp_path: Path) -> None:
         tmp_path / "redcon.toml",
         """
 [compression]
+render_mode = "compressed"
 full_file_threshold_tokens = 1000
 snippet_score_threshold = 999
 """.strip(),
@@ -234,6 +237,7 @@ def test_warm_cache_produces_self_contained_prompt(tmp_path: Path) -> None:
         tmp_path / "redcon.toml",
         """
 [compression]
+render_mode = "compressed"
 full_file_threshold_tokens = 1
 snippet_score_threshold = 0
 """.strip(),
@@ -307,6 +311,7 @@ def test_python_language_aware_chunk_selection(tmp_path: Path) -> None:
         tmp_path / "redcon.toml",
         """
 [compression]
+render_mode = "compressed"
 full_file_threshold_tokens = 1
 snippet_score_threshold = 0
 symbol_extraction_enabled = false
@@ -351,6 +356,7 @@ def test_typescript_language_aware_chunk_selection(tmp_path: Path) -> None:
         tmp_path / "redcon.toml",
         """
 [compression]
+render_mode = "compressed"
 full_file_threshold_tokens = 1
 snippet_score_threshold = 0
 symbol_extraction_enabled = false
@@ -393,6 +399,7 @@ def test_unknown_extension_falls_back_to_keyword_window(tmp_path: Path) -> None:
         tmp_path / "redcon.toml",
         """
 [compression]
+render_mode = "compressed"
 full_file_threshold_tokens = 1
 snippet_score_threshold = 0
 symbol_extraction_enabled = false
@@ -423,6 +430,7 @@ def test_smart_slicing_uses_import_relationships_and_skips_unrelated_code(tmp_pa
         tmp_path / "redcon.toml",
         """
 [compression]
+render_mode = "compressed"
 full_file_threshold_tokens = 1
 snippet_score_threshold = 0
 symbol_extraction_enabled = false
@@ -490,6 +498,7 @@ def test_run_pack_can_emit_delta_context_package(tmp_path: Path) -> None:
         tmp_path / "redcon.toml",
         """
 [compression]
+render_mode = "compressed"
 full_file_threshold_tokens = 1
 snippet_score_threshold = 0
 snippet_total_line_limit = 40
@@ -588,7 +597,9 @@ recommended_compression_strategy = "aggressive"
     )
     _write(tmp_path / "src" / "notes.py", ("value = 'x' * 80\n" * 120))
 
-    data = as_json_dict(run_pack("rename widget", repo=tmp_path, max_tokens=None))
+    data = as_json_dict(
+        run_pack("rename widget", repo=tmp_path, max_tokens=None, render_mode="compressed")
+    )
 
     assert data["compressed_context"][0]["strategy"] == "summary"
     assert data["model_profile"]["selected_profile"] == "local-llm"
@@ -622,6 +633,7 @@ def test_progressive_packer_degrades_before_dropping(tmp_path: Path) -> None:
         tmp_path / "redcon.toml",
         """
 [compression]
+render_mode = "compressed"
 full_file_threshold_tokens = 5000
 snippet_score_threshold = 0
 progressive_packer_enabled = true
@@ -665,6 +677,7 @@ def test_progressive_packer_triggers_degradation_with_metrics(tmp_path: Path) ->
         tmp_path / "redcon.toml",
         """
 [compression]
+render_mode = "compressed"
 full_file_threshold_tokens = 50000
 snippet_score_threshold = 0
 progressive_packer_enabled = true
@@ -747,6 +760,7 @@ def test_greedy_fallback_when_progressive_disabled(tmp_path: Path) -> None:
         tmp_path / "redcon.toml",
         """
 [compression]
+render_mode = "compressed"
 progressive_packer_enabled = false
 """.strip(),
     )
@@ -778,6 +792,7 @@ def test_compressed_tokens_never_exceeds_original_tokens(tmp_path: Path) -> None
         tmp_path / "redcon.toml",
         """
 [compression]
+render_mode = "compressed"
 full_file_threshold_tokens = 1
 snippet_score_threshold = 0
 symbol_extraction_enabled = true

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -61,7 +61,15 @@ def _make_run_data(entries: list[dict]) -> dict:
 
 def test_profiler_attributes_full_strategy_to_full_stage() -> None:
     data = _make_run_data(
-        [_make_compressed_entry("a.py", strategy="full", chunk_strategy="full-file", original_tokens=100, compressed_tokens=105)]
+        [
+            _make_compressed_entry(
+                "a.py",
+                strategy="full",
+                chunk_strategy="full-file",
+                original_tokens=100,
+                compressed_tokens=105,
+            )
+        ]
     )
     profile = build_savings_profile(data)
     assert profile.per_file[0].stage == STAGE_FULL
@@ -70,7 +78,15 @@ def test_profiler_attributes_full_strategy_to_full_stage() -> None:
 
 def test_profiler_attributes_symbol_strategy_to_symbol_stage() -> None:
     data = _make_run_data(
-        [_make_compressed_entry("b.py", strategy="symbol", chunk_strategy="symbol-extract-python", original_tokens=400, compressed_tokens=120)]
+        [
+            _make_compressed_entry(
+                "b.py",
+                strategy="symbol",
+                chunk_strategy="symbol-extract-python",
+                original_tokens=400,
+                compressed_tokens=120,
+            )
+        ]
     )
     profile = build_savings_profile(data)
     assert profile.per_file[0].stage == STAGE_SYMBOL_EXTRACTION
@@ -79,7 +95,15 @@ def test_profiler_attributes_symbol_strategy_to_symbol_stage() -> None:
 
 def test_profiler_attributes_slice_strategy_to_slicing_stage() -> None:
     data = _make_run_data(
-        [_make_compressed_entry("c.py", strategy="slice", chunk_strategy="lang-python", original_tokens=300, compressed_tokens=80)]
+        [
+            _make_compressed_entry(
+                "c.py",
+                strategy="slice",
+                chunk_strategy="lang-python",
+                original_tokens=300,
+                compressed_tokens=80,
+            )
+        ]
     )
     profile = build_savings_profile(data)
     assert profile.per_file[0].stage == STAGE_SLICING
@@ -88,7 +112,15 @@ def test_profiler_attributes_slice_strategy_to_slicing_stage() -> None:
 
 def test_profiler_attributes_summary_strategy_to_compression_stage() -> None:
     data = _make_run_data(
-        [_make_compressed_entry("d.py", strategy="summary", chunk_strategy="summary-preview", original_tokens=700, compressed_tokens=60)]
+        [
+            _make_compressed_entry(
+                "d.py",
+                strategy="summary",
+                chunk_strategy="summary-preview",
+                original_tokens=700,
+                compressed_tokens=60,
+            )
+        ]
     )
     profile = build_savings_profile(data)
     assert profile.per_file[0].stage == STAGE_COMPRESSION
@@ -97,7 +129,16 @@ def test_profiler_attributes_summary_strategy_to_compression_stage() -> None:
 
 def test_profiler_attributes_cache_reuse_regardless_of_strategy() -> None:
     data = _make_run_data(
-        [_make_compressed_entry("e.py", strategy="slice", chunk_strategy="lang-go", original_tokens=200, compressed_tokens=40, cache_status="reused")]
+        [
+            _make_compressed_entry(
+                "e.py",
+                strategy="slice",
+                chunk_strategy="lang-go",
+                original_tokens=200,
+                compressed_tokens=40,
+                cache_status="reused",
+            )
+        ]
     )
     profile = build_savings_profile(data)
     assert profile.per_file[0].stage == STAGE_CACHE_REUSE
@@ -106,8 +147,17 @@ def test_profiler_attributes_cache_reuse_regardless_of_strategy() -> None:
 
 def test_profiler_attributes_snippet_strategy_to_snippet_stage() -> None:
     from redcon.core.profiler import STAGE_SNIPPET
+
     data = _make_run_data(
-        [_make_compressed_entry("f.py", strategy="snippet", chunk_strategy="snippet-keyword", original_tokens=250, compressed_tokens=90)]
+        [
+            _make_compressed_entry(
+                "f.py",
+                strategy="snippet",
+                chunk_strategy="snippet-keyword",
+                original_tokens=250,
+                compressed_tokens=90,
+            )
+        ]
     )
     profile = build_savings_profile(data)
     assert profile.per_file[0].stage == STAGE_SNIPPET
@@ -121,9 +171,27 @@ def test_profiler_attributes_snippet_strategy_to_snippet_stage() -> None:
 
 def test_profiler_totals_match_sum_of_per_file_values() -> None:
     entries = [
-        _make_compressed_entry("a.py", strategy="full", chunk_strategy="full-file", original_tokens=100, compressed_tokens=105),
-        _make_compressed_entry("b.py", strategy="symbol", chunk_strategy="symbol-extract-python", original_tokens=400, compressed_tokens=120),
-        _make_compressed_entry("c.py", strategy="summary", chunk_strategy="summary-preview", original_tokens=700, compressed_tokens=60),
+        _make_compressed_entry(
+            "a.py",
+            strategy="full",
+            chunk_strategy="full-file",
+            original_tokens=100,
+            compressed_tokens=105,
+        ),
+        _make_compressed_entry(
+            "b.py",
+            strategy="symbol",
+            chunk_strategy="symbol-extract-python",
+            original_tokens=400,
+            compressed_tokens=120,
+        ),
+        _make_compressed_entry(
+            "c.py",
+            strategy="summary",
+            chunk_strategy="summary-preview",
+            original_tokens=700,
+            compressed_tokens=60,
+        ),
     ]
     data = _make_run_data(entries)
     profile = build_savings_profile(data)
@@ -136,9 +204,27 @@ def test_profiler_totals_match_sum_of_per_file_values() -> None:
 
 def test_profiler_by_stage_sums_correctly() -> None:
     entries = [
-        _make_compressed_entry("a.py", strategy="symbol", chunk_strategy="symbol-extract-python", original_tokens=300, compressed_tokens=100),
-        _make_compressed_entry("b.ts", strategy="symbol", chunk_strategy="symbol-extract-typescript", original_tokens=200, compressed_tokens=80),
-        _make_compressed_entry("c.py", strategy="summary", chunk_strategy="summary-preview", original_tokens=600, compressed_tokens=50),
+        _make_compressed_entry(
+            "a.py",
+            strategy="symbol",
+            chunk_strategy="symbol-extract-python",
+            original_tokens=300,
+            compressed_tokens=100,
+        ),
+        _make_compressed_entry(
+            "b.ts",
+            strategy="symbol",
+            chunk_strategy="symbol-extract-typescript",
+            original_tokens=200,
+            compressed_tokens=80,
+        ),
+        _make_compressed_entry(
+            "c.py",
+            strategy="summary",
+            chunk_strategy="summary-preview",
+            original_tokens=600,
+            compressed_tokens=50,
+        ),
     ]
     data = _make_run_data(entries)
     profile = build_savings_profile(data)
@@ -164,7 +250,15 @@ def test_profiler_savings_pct_is_zero_when_no_files() -> None:
 def test_profiler_negative_savings_clamped_to_zero() -> None:
     # Compressed > original is a valid edge case when overhead is added
     data = _make_run_data(
-        [_make_compressed_entry("a.py", strategy="full", chunk_strategy="full-file", original_tokens=10, compressed_tokens=15)]
+        [
+            _make_compressed_entry(
+                "a.py",
+                strategy="full",
+                chunk_strategy="full-file",
+                original_tokens=10,
+                compressed_tokens=15,
+            )
+        ]
     )
     profile = build_savings_profile(data)
     assert profile.per_file[0].tokens_saved == 0
@@ -186,6 +280,7 @@ def test_profiler_delta_savings_tracked_from_delta_budget() -> None:
     }
     profile = build_savings_profile(data)
     from redcon.core.profiler import STAGE_DELTA
+
     assert profile.by_stage[STAGE_DELTA].tokens_saved == 850
 
 
@@ -196,13 +291,16 @@ def test_profiler_delta_savings_tracked_from_delta_budget() -> None:
 
 def test_profile_from_real_pack_run_shows_savings(tmp_path: Path) -> None:
     # Large file forces compression/summary strategy; small one stays full
-    _write(tmp_path / "src" / "router.py", "\n".join(
-        [f"def route_{i}(req): return '{i}'" for i in range(100)]
-    ))
+    _write(
+        tmp_path / "src" / "router.py",
+        "\n".join([f"def route_{i}(req): return '{i}'" for i in range(100)]),
+    )
     _write(tmp_path / "src" / "auth.py", "def login(u, p):\n    return True\n")
 
     engine = RedconEngine()
-    run = engine.pack(task="add auth to router", repo=tmp_path, max_tokens=800)
+    run = engine.pack(
+        task="add auth to router", repo=tmp_path, max_tokens=800, render_mode="compressed"
+    )
 
     profile = engine.profile(run)
 
@@ -219,9 +317,10 @@ def test_profile_from_real_pack_run_shows_savings(tmp_path: Path) -> None:
 
 
 def test_profile_token_savings_decrease_vs_full_file(tmp_path: Path) -> None:
-    _write(tmp_path / "src" / "big.py", "\n".join(
-        [f"def helper_{i}(): return {i}" for i in range(120)]
-    ))
+    _write(
+        tmp_path / "src" / "big.py",
+        "\n".join([f"def helper_{i}(): return {i}" for i in range(120)]),
+    )
 
     engine = RedconEngine()
     run = engine.pack(task="refactor helpers", repo=tmp_path, max_tokens=500)
@@ -232,14 +331,13 @@ def test_profile_token_savings_decrease_vs_full_file(tmp_path: Path) -> None:
 
 
 def test_profile_from_json_file(tmp_path: Path) -> None:
-    _write(tmp_path / "src" / "service.py", "\n".join(
-        [f"def op_{i}(): pass" for i in range(80)]
-    ))
+    _write(tmp_path / "src" / "service.py", "\n".join([f"def op_{i}(): pass" for i in range(80)]))
     engine = RedconEngine()
     run = engine.pack(task="optimize service", repo=tmp_path, max_tokens=400)
 
     run_json_path = tmp_path / "run.json"
     import json as _json
+
     run_json_path.write_text(_json.dumps(run, default=str), encoding="utf-8")
 
     profile = engine.profile(run_json_path)
@@ -255,13 +353,26 @@ def test_profile_from_json_file(tmp_path: Path) -> None:
 
 def test_render_profile_markdown_contains_required_sections() -> None:
     entries = [
-        _make_compressed_entry("src/big.py", strategy="summary", chunk_strategy="summary-preview", original_tokens=500, compressed_tokens=40),
-        _make_compressed_entry("src/small.py", strategy="full", chunk_strategy="full-file", original_tokens=50, compressed_tokens=55),
+        _make_compressed_entry(
+            "src/big.py",
+            strategy="summary",
+            chunk_strategy="summary-preview",
+            original_tokens=500,
+            compressed_tokens=40,
+        ),
+        _make_compressed_entry(
+            "src/small.py",
+            strategy="full",
+            chunk_strategy="full-file",
+            original_tokens=50,
+            compressed_tokens=55,
+        ),
     ]
     data = _make_run_data(entries)
     profile_data = build_savings_profile(data, run_json="run.json")
 
     from dataclasses import asdict
+
     md = render_profile_markdown(asdict(profile_data))
 
     assert "# Redcon Token Savings Profile" in md
@@ -279,21 +390,24 @@ def test_render_profile_markdown_contains_required_sections() -> None:
 
 
 def test_cli_profile_writes_json_and_markdown(tmp_path: Path) -> None:
-    _write(tmp_path / "src" / "router.py", "\n".join(
-        [f"def route_{i}(req): return '{i}'" for i in range(80)]
-    ))
+    _write(
+        tmp_path / "src" / "router.py",
+        "\n".join([f"def route_{i}(req): return '{i}'" for i in range(80)]),
+    )
     engine = RedconEngine()
     run = engine.pack(task="add auth to router", repo=tmp_path, max_tokens=600)
 
     run_json_path = tmp_path / "run.json"
     run_json_path.write_text(json.dumps(run, default=str), encoding="utf-8")
 
-    import sys
     from redcon.cli import build_parser
 
     parser = build_parser()
-    args = parser.parse_args(["profile", str(run_json_path), "--out-prefix", str(tmp_path / "profile")])
+    args = parser.parse_args(
+        ["profile", str(run_json_path), "--out-prefix", str(tmp_path / "profile")]
+    )
     import os
+
     old_cwd = os.getcwd()
     os.chdir(tmp_path)
     try:

--- a/tests/test_symbol_extraction.py
+++ b/tests/test_symbol_extraction.py
@@ -195,6 +195,7 @@ def helper() -> None:
 
     cfg = RedconConfig(
         compression=CompressionSettings(
+            render_mode="compressed",
             full_file_threshold_tokens=1,
             snippet_score_threshold=0,
             snippet_total_line_limit=40,
@@ -245,6 +246,7 @@ def helper() -> None:
 
     cfg = RedconConfig(
         compression=CompressionSettings(
+            render_mode="compressed",
             full_file_threshold_tokens=1,
             snippet_score_threshold=0,
             snippet_total_line_limit=40,
@@ -284,6 +286,7 @@ class AuthService:
 
     full_cfg = RedconConfig(
         compression=CompressionSettings(
+            render_mode="compressed",
             full_file_threshold_tokens=100_000,
             snippet_score_threshold=0,
             symbol_extraction_enabled=True,
@@ -291,6 +294,7 @@ class AuthService:
     )
     symbol_cfg = RedconConfig(
         compression=CompressionSettings(
+            render_mode="compressed",
             full_file_threshold_tokens=1,
             snippet_score_threshold=0,
             snippet_total_line_limit=24,

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from redcon.core import tokens as token_module
 from redcon.core.benchmark import run_benchmark
 from redcon.core.pipeline import as_json_dict, run_pack
-from redcon.core import tokens as token_module
 from redcon.core.tokens import (
     describe_builtin_token_estimator,
     estimate_tokens,
@@ -66,7 +66,9 @@ model = "gpt-4o-mini"
     assert data["token_estimator"]["fallback_used"] is False
 
 
-def test_benchmark_includes_estimator_samples_and_fallback_status(tmp_path: Path, monkeypatch) -> None:
+def test_benchmark_includes_estimator_samples_and_fallback_status(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.setattr("redcon.core.tokens._load_tiktoken", lambda: None)
     token_module._resolve_builtin_token_estimator.cache_clear()
     try:
@@ -134,7 +136,9 @@ def audit_everything(token: str) -> bool:
 
     full_text = (tmp_path / "src" / "auth.py").read_text(encoding="utf-8")
     full_tokens = estimate_tokens(full_text)
-    data = as_json_dict(run_pack("tighten auth login", repo=tmp_path, max_tokens=200))
+    data = as_json_dict(
+        run_pack("tighten auth login", repo=tmp_path, max_tokens=200, render_mode="compressed")
+    )
     entry = next(item for item in data["compressed_context"] if item["path"] == "src/auth.py")
 
     assert entry["strategy"] == "slice"


### PR DESCRIPTION
Default-change PR: flip `render_mode` default to **adaptive** per the Experiment 3 pre-registered interpretation (all three hypotheses held; see #261). Separate from the results and writeup PRs, as requested.

## Change
- `CompressionSettings.render_mode` default `compressed` to `adaptive`. Each ranked file is delivered whole when it fits the budget, compressed only on overflow. The old behaviour is still selectable with `--render-mode compressed` or `[render] mode = "compressed"`.

## Tests
- Flip `test_default_mode_is_compressed` to `test_default_mode_is_adaptive`; add `test_compressed_mode_still_available`.
- Pin `render_mode="compressed"` in the compression-focused tests (symbol extraction, language-aware chunk selection, slice/summary strategies, token savings, profiler savings) - they verify the compressor, not the default, so they should select compressed explicitly. Full suite: 1249 passed (live-server tests excluded).

## Docs
- Update `--render-mode` help and the `render_mode` config field docs (adaptive is now default).
- CHANGELOG entry under Unreleased, citing the measurement (file-overlap 0.432 vs 0.319 vs 0.196 pooled) with a one-time pack-change note: packs and their `prompt_cache_key` change once on upgrade and prompt-cache-style caches repopulate (same class of note as the 1.16 default-budget change); pin `--render-mode compressed` for byte-identical packs.

Version bump and dated CHANGELOG are left for the 1.17.0 release, after review of all three PRs.