### PR TITLE
Release 1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.0] - 2026-08-13
+
 ### Changed
 
 - Default pack render mode is now **adaptive**: each ranked file is included

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redcon"
-version = "1.16.0"
+version = "1.17.0"
 description = "Deterministic context budgeting for coding-agent workflows"
 readme = "README.md"
 keywords = [

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/natiixnt/redcon",
     "source": "github"
   },
-  "version": "1.16.0",
+  "version": "1.17.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "redcon",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Release 1.17.0. All three Exp 3 PRs (#261 results, #262 writeup, #263 default-change) are merged; this cuts the release.

## Changes
- Bump `version` to 1.17.0 in `pyproject.toml`.
- Move CHANGELOG `[Unreleased]` into `[1.17.0] - 2026-08-13`.
- Bump `server.json` to 1.17.0 (MCP Registry entry).

## Headline
Default pack render mode is now **adaptive** (whole files when they fit the budget, compressed on overflow), based on Experiment 3 (`docs/research/exp3-adaptive-rendering.md`): at equal budget it beats both naive keyword retrieval and the old compressed pack on one-shot edit fidelity. One-time pack-change note is in the CHANGELOG; pin `--render-mode compressed` for the pre-1.17.0 form.

## After merge (release steps)
Tag `v1.17.0` and push (release.yml builds and publishes the wheel to PyPI and creates the GitHub Release; the tag must match the pyproject version). Wheel verification from a neutral cwd as noted.