### PR TITLE
Make adaptive size-aware: tier the largest repositories (1.18.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Adaptive rendering is now **size-aware**: on the largest repositories (the top
+  budget band, estimated repository tokens over the last budget step, the
+  120k-budget regime), adaptive delivers only the top-ranked files whole and
+  compresses the tail, instead of spending the whole budget on a few whole files.
+  Smaller and mid-sized repositories are unchanged. Driven by Experiment 4 (see
+  `docs/research/exp4-tiered-rendering.md`): on the held-out heavy tasks this
+  recovers ground-truth coverage (0.756 vs plain adaptive's 0.363) and lifts the
+  parse rate (0.92 vs 0.62), raising heavy one-shot file-overlap above plain
+  adaptive - **the trade is a lower heavy line-overlap (fewer whole files) and no
+  change on small repositories**. The gate is internal to adaptive with no config
+  surface; `--render-mode compressed` still bypasses it. **Packs change on the
+  largest repositories, so their `prompt_cache_key` changes once on upgrade;
+  smaller repositories are byte-identical. Pin `--render-mode compressed` for the
+  pre-1.17.0 pack form.**
+
 ## [1.17.0] - 2026-08-13
 
 ### Changed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,7 +94,7 @@ in per-file form:
 - `adaptive` (default): include a file whole when it fits the remaining budget,
   and fall back to a compressed (symbol-extracted) representation only on
   overflow. On a repository that fits the budget this degenerates to whole files
-  with no compression.
+  with no compression. Adaptive is **size-aware** (see below).
 - `compressed`: always compress each file to fit, the pre-1.17.0 behaviour.
 
 ```toml
@@ -108,6 +108,17 @@ Adaptive became the default in 1.17.0, based on the measurement in
 retrieval and the old compressed pack). The `--render-mode` CLI flag overrides
 this setting per run. Pin `mode = "compressed"` (or `--render-mode compressed`)
 for the pre-1.17.0 pack form.
+
+**Size-aware adaptive (since 1.18.0).** On the largest repositories - the same top
+band that receives the 120k default budget (estimated repository tokens over the
+last budget step) - adaptive delivers only the top-ranked files whole and
+compresses the tail, instead of spending the whole budget on a few whole files.
+This recovers ground-truth coverage that plain adaptive gives up under a 120k
+budget on multi-million-token repositories, at a small heavy-corpus line-overlap
+cost (see [docs/research/exp4-tiered-rendering.md](research/exp4-tiered-rendering.md)).
+Smaller and mid-sized repositories keep plain adaptive. This is internal to
+adaptive with no config surface; `--render-mode compressed` still bypasses it
+entirely.
 
 ## Model Profiles
 

--- a/redcon/core/budget.py
+++ b/redcon/core/budget.py
@@ -40,6 +40,22 @@ def default_budget_for_repo_tokens(repo_tokens: int) -> int:
     return _LARGE_REPO_BUDGET
 
 
+# Adaptive-v2 size gate (Experiment 4). On the largest repositories - the same
+# top band that gets the 120k budget, repositories over the last budget-step
+# ceiling - adaptive delivers the top-ranked files whole and compresses the tail
+# (tiered ``topk:10``) to recover ground-truth coverage that plain adaptive gives
+# up under a 120k budget. Smaller repositories keep plain adaptive. The gate is
+# internal to adaptive: no config or CLI surface, and ``--render-mode compressed``
+# still bypasses it. See docs/research/exp4-tiered-rendering.md.
+TOP_BAND_REPO_TOKENS = _BUDGET_STEPS[-1][0]
+ADAPTIVE_TOP_BAND_POLICY = "topk:10"
+
+
+def repo_in_adaptive_top_band(repo_tokens: int) -> bool:
+    """Whether a repository of *repo_tokens* tokens is in the adaptive-v2 top band."""
+    return repo_tokens > TOP_BAND_REPO_TOKENS
+
+
 def coverage_warning(repo_tokens: int, budget: int) -> str | None:
     """A warning if *budget* is below the recommended default for the repo size.
 

--- a/redcon/core/pipeline.py
+++ b/redcon/core/pipeline.py
@@ -13,6 +13,7 @@ from redcon.compressors.summarizers import normalize_summarizer_report
 from redcon.config import RedconConfig, WorkspaceDefinition, load_config
 from redcon.core.agent_planning import build_agent_workflow_plan
 from redcon.core.agent_simulation import simulate_agent_workflow
+from redcon.core.budget import ADAPTIVE_TOP_BAND_POLICY, repo_in_adaptive_top_band
 from redcon.core.delta import build_delta_report, effective_pack_metrics, resolve_previous_run_label
 from redcon.core.diffing import diff_run_artifacts
 from redcon.core.heatmap import build_heatmap_report, heatmap_as_dict
@@ -442,6 +443,17 @@ def run_pack(
         scan_summary = scan_result.summary
         scanned_repos = []
     telemetry.emit("scan_completed", scanned_files=len(files), scanned_repos=len(scanned_repos))
+    # Size-gated adaptive-v2 (Experiment 4): on the largest repositories, adaptive
+    # delivers the top-ranked files whole and compresses the tail (tiered topk:10)
+    # to recover ground-truth coverage. Internal to adaptive - only when render mode
+    # is adaptive and no explicit tiered policy is set, using the scanned file sizes
+    # (bytes / 4) already in hand, so there is no second scan.
+    if prepared_cfg.compression.render_mode == "adaptive" and not (
+        prepared_cfg.compression.tiered_policy or ""
+    ):
+        repo_tokens = sum(max(0, getattr(record, "size_bytes", 0)) // 4 for record in files)
+        if repo_in_adaptive_top_band(repo_tokens):
+            prepared_cfg.compression.tiered_policy = ADAPTIVE_TOP_BAND_POLICY
     ranked = run_score_stage(
         task,
         files,

--- a/tests/test_adaptive_rendering.py
+++ b/tests/test_adaptive_rendering.py
@@ -191,3 +191,59 @@ def test_tiered_unknown_policy_raises(tmp_path: Path):
     repo = _overflow_repo(tmp_path)
     with pytest.raises(ValueError, match="tiered_policy"):
         _pack_tiered(repo, "login retry helper", 600, "bogus:1")
+
+
+# --- Experiment 4 size-gated adaptive-v2 ---
+
+
+def test_repo_in_adaptive_top_band_boundary():
+    from redcon.core.budget import TOP_BAND_REPO_TOKENS, repo_in_adaptive_top_band
+
+    assert repo_in_adaptive_top_band(TOP_BAND_REPO_TOKENS) is False  # at ceiling: not top band
+    assert repo_in_adaptive_top_band(TOP_BAND_REPO_TOKENS + 1) is True
+    assert repo_in_adaptive_top_band(100_000) is False
+
+
+def _large_repo(tmp_path: Path) -> Path:
+    # Many small ranked-relevant files plus filler under the scan size limit, so the
+    # repo crosses the top-band token threshold (> 3M tokens = > 12 MB bytes).
+    files = {
+        f"src/login_{i}.py": f"def login_retry_{i}(user):\n    return retry_{i}(user)\n"
+        for i in range(15)
+    }
+    filler_line = "value = 'x' * 40  # filler content padding the repository size\n"
+    filler = filler_line * 25_000  # about 1.5 MB per file, under the 2 MB scan limit
+    for i in range(9):  # about 13.5 MB of filler => over the 3M-token top band
+        files[f"data/filler_{i}.py"] = filler
+    return _repo(tmp_path, files)
+
+
+def test_size_gate_tiers_large_repo_under_adaptive(tmp_path: Path):
+    # On a > 3M-token repo, adaptive gates to topk:10: at most 10 whole entries and a
+    # compressed tail, instead of plain adaptive's greedy whole delivery.
+    repo = _large_repo(tmp_path)
+    data = _pack(repo, "login retry", max_tokens=120_000, mode="adaptive")
+    cc = data["compressed_context"]
+    whole = [e for e in cc if e["delivery"] == "whole"]
+    assert len(whole) <= 10
+    assert any(e["delivery"] == "compressed" for e in cc)
+    assert data["budget"]["estimated_input_tokens"] <= 120_000
+
+
+def test_size_gate_not_fired_on_small_repo(tmp_path: Path):
+    # The same 15 relevant files without the filler stay under the threshold, so
+    # plain adaptive delivers them all whole (more than the topk:10 cap).
+    files = {
+        f"src/login_{i}.py": f"def login_retry_{i}(user):\n    return retry_{i}(user)\n"
+        for i in range(15)
+    }
+    repo = _repo(tmp_path, files)
+    data = _pack(repo, "login retry", max_tokens=120_000, mode="adaptive")
+    whole = [e for e in data["compressed_context"] if e["delivery"] == "whole"]
+    assert len(whole) > 10  # not gated: all relevant files delivered whole
+
+
+def test_size_gate_bypassed_by_compressed_mode(tmp_path: Path):
+    repo = _large_repo(tmp_path)
+    data = _pack(repo, "login retry", max_tokens=120_000, mode="compressed")
+    assert all(e["delivery"] == "compressed" for e in data["compressed_context"])


### PR DESCRIPTION
Default-change PR: make adaptive size-aware, shipping the size-gated adaptive-v2 from Experiment 4 (#266). Separate from the results and writeup PRs.

## Change
On repositories in the top budget band (estimated tokens over the last budget step, the 120k regime), adaptive delivers the top-ranked files whole and compresses the tail (tiered topk:10) instead of spending the whole budget on a few whole files. Smaller and mid-sized repositories are unchanged.

- The gate reuses the budget-step threshold (`TOP_BAND_REPO_TOKENS`), fires only under `render_mode` adaptive with no explicit tiered policy, and computes repo tokens from the scan already in hand (no second scan). `--render-mode compressed` bypasses it entirely.
- No config or CLI surface; it is internal to adaptive.

## Why (Exp 4, held with nuance)
On the held-out heavy tasks the gate recovers ground-truth coverage (0.756 vs plain adaptive's 0.363) and lifts the heavy parse rate (0.92 vs 0.62), raising heavy one-shot file-overlap above plain adaptive (0.235 vs 0.208). Honest trade: heavy line-overlap drops (fewer whole files) and small repositories are unchanged by the gate.

## Tests, docs, changelog
- Tests: `repo_in_adaptive_top_band` boundary, gate fires on a >3M-token repo under adaptive (topk:10 cap + compressed tail), does not fire on a small repo, bypassed by compressed. Full suite 1256 passed (live excluded).
- `docs/configuration.md` render section describes size-aware adaptive.
- CHANGELOG entry under Unreleased citing Exp 4 with the one-time pack-change note (packs change on the largest repos, `prompt_cache_key` changes once; smaller repos byte-identical).

Version bump and dated CHANGELOG left for the 1.18.0 release, after review of the three Exp 4 PRs.