### PR TITLE
Release 1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.0] - 2026-08-14
+
 ### Changed
 
 - Adaptive rendering is now **size-aware**: on the largest repositories (the top

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "redcon"
-version = "1.17.0"
+version = "1.18.0"
 description = "Deterministic context budgeting for coding-agent workflows"
 readme = "README.md"
 keywords = [

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/natiixnt/redcon",
     "source": "github"
   },
-  "version": "1.17.0",
+  "version": "1.18.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "redcon",
-      "version": "1.17.0",
+      "version": "1.18.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Release 1.18.0. Promotes the size-aware adaptive rendering change (Exp 4 trio, #266/#267/#268) to a dated release.

## Changes
- `pyproject.toml`: version 1.17.0 -> 1.18.0
- `CHANGELOG.md`: promote the [Unreleased] size-aware adaptive entry to [1.18.0] dated 2026-08-14
- `server.json`: MCP manifest version 1.17.0 -> 1.18.0 (both fields)

Metadata only, no product-code diff. The package `__version__` derives from installed metadata, so the pyproject bump is the single source of truth.

Full suite: 1265 passed, 1 skipped locally. The one failure, `test_gateway_auth.py::TestGatewayAuthLive::test_trailing_space_token_is_401`, is pre-existing on main and unrelated to this release (it passes in CI; locally it depends on the HTTP client preserving a trailing-space header value). Tracked and fixed on a separate branch.

Holding for your go-ahead before merge and tag v1.18.0.