### PR TITLE
Fix gateway auth: normalize bearer token so both server paths agree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   smaller repositories are byte-identical. Pin `--render-mode compressed` for the
   pre-1.17.0 pack form.**
 
+### Fixed
+
+- The stdlib gateway now normalizes trailing optional whitespace in bearer tokens
+  before comparing them, so both server implementations (FastAPI and the stdlib
+  fallback) authenticate the same token identically.
+
 ## [1.17.0] - 2026-08-13
 
 ### Changed

--- a/redcon/gateway/server.py
+++ b/redcon/gateway/server.py
@@ -41,6 +41,22 @@ def _try_import_fastapi():
         return None, None
 
 
+def _bearer_token(authorization: str | None) -> str | None:
+    """Return the bearer token from an Authorization header, or None if the
+    Bearer scheme is absent.
+
+    Surrounding optional whitespace is stripped so both server implementations
+    authenticate a request identically. FastAPI and uvicorn strip trailing header
+    optional whitespace (OWS) before the app sees the value, while the stdlib
+    fallback does not; normalizing here keeps the two paths from disagreeing on
+    the same token.
+    """
+    header = authorization or ""
+    if not header.startswith("Bearer "):
+        return None
+    return header[len("Bearer ") :].strip()
+
+
 def _build_fastapi_app(config: GatewayConfig, handlers: GatewayHandlers):
     """Build and return a FastAPI application for the gateway."""
     fastapi, uvicorn = _try_import_fastapi()
@@ -67,10 +83,9 @@ def _build_fastapi_app(config: GatewayConfig, handlers: GatewayHandlers):
     async def _verify_api_key(authorization: str | None = Header(default=None)):
         if config.api_key is None:
             return  # auth disabled
-        auth_header = authorization or ""
-        if not auth_header.startswith("Bearer "):
+        token = _bearer_token(authorization)
+        if token is None:
             raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
-        token = auth_header[len("Bearer ") :]
         if not hmac.compare_digest(token, config.api_key):
             raise HTTPException(status_code=401, detail="Invalid API key")
 
@@ -294,10 +309,8 @@ class GatewayServer:
 
                 # Auth check
                 if config.api_key:
-                    auth = self.headers.get("Authorization", "")
-                    if not auth.startswith("Bearer ") or not hmac.compare_digest(
-                        auth[len("Bearer ") :], config.api_key
-                    ):
+                    token = _bearer_token(self.headers.get("Authorization"))
+                    if token is None or not hmac.compare_digest(token, config.api_key):
                         self._send_json({"error": "Invalid API key"}, 401)
                         return
 

--- a/tests/test_gateway_auth.py
+++ b/tests/test_gateway_auth.py
@@ -140,14 +140,28 @@ class TestGatewayAuthLive:
         )
         assert status == 401
 
-    def test_trailing_space_token_is_401(self):
+    def test_extra_char_token_is_401(self):
         # Locks in exact (constant-time) comparison: a one-char near-miss fails.
+        # The extra character is not whitespace, so it is never normalized away
+        # (see test_trailing_whitespace_token_is_normalized for the space case).
+        status, _ = _post(
+            f"{self._base}/prepare-context",
+            {"task": "x"},
+            {"Authorization": f"Bearer {_API_KEY}x"},
+        )
+        assert status == 401
+
+    def test_trailing_whitespace_token_is_normalized(self):
+        # A trailing space is HTTP optional whitespace. The app strips it from the
+        # bearer token before comparing, so `Bearer <key> ` authenticates as
+        # `Bearer <key>`. This normalization is shared by both server paths so they
+        # agree; see test_stdlib_and_fastapi_agree_on_whitespace_token.
         status, _ = _post(
             f"{self._base}/prepare-context",
             {"task": "x"},
             {"Authorization": f"Bearer {_API_KEY} "},
         )
-        assert status == 401
+        assert status == 200
 
     def test_correct_bearer_token_is_200(self):
         status, body = _post(
@@ -176,6 +190,37 @@ class TestGatewayAuthDisabledLive:
             status, body = _post(f"{base}/prepare-context", {"task": "x"})
             assert status == 200
             assert "optimized_context" in body
+
+
+class TestGatewayAuthCrossImplementation:
+    """The stdlib and FastAPI paths must authenticate the same token identically.
+
+    They previously disagreed on a trailing-whitespace token (FastAPI stripped the
+    OWS and accepted, the stdlib handler did not and rejected); the shared token
+    normalization fixed that. These force the stdlib path even when FastAPI is
+    installed, so the agreement is pinned in any environment.
+    """
+
+    def test_stdlib_and_fastapi_agree_on_whitespace_token(self, monkeypatch):
+        from redcon.gateway import server as server_mod
+
+        monkeypatch.setattr(server_mod, "_try_import_fastapi", lambda: (None, None))
+        config = GatewayConfig(
+            host="127.0.0.1", port=_free_port(), api_key=_API_KEY, log_requests=False
+        )
+        with _running_gateway(config) as base:
+            normalized, _ = _post(
+                f"{base}/prepare-context",
+                {"task": "x"},
+                {"Authorization": f"Bearer {_API_KEY} "},
+            )
+            near_miss, _ = _post(
+                f"{base}/prepare-context",
+                {"task": "x"},
+                {"Authorization": f"Bearer {_API_KEY}x"},
+            )
+        assert normalized == 200  # stdlib path now normalizes the trailing OWS too
+        assert near_miss == 401  # a real near-miss is still rejected
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the one pre-existing local test failure flagged on #269/#270. Closes #271.

## Root cause (deeper than a bad test)
`TestGatewayAuthLive::test_trailing_space_token_is_401` sent `Authorization: Bearer <key> ` and expected 401. It PASSED in CI but FAILED locally under the gateway extra. Investigation (raw socket preserving the byte on the wire) showed the two server implementations disagree:
- FastAPI + uvicorn strip trailing header optional whitespace (OWS) before the app sees the value, so the token arrives as the exact key and is accepted (200).
- The stdlib fallback (what CI runs, since [dev] does not pull FastAPI) does not strip, so the token keeps its trailing space and is rejected (401).

So the same request authenticated differently depending on whether an optional dependency was installed. FastAPI cannot be made to preserve the OWS (the framework strips it upstream of the app), so the only consistent fix is to normalize, which also matches HTTP semantics.

## Fix
- `redcon/gateway/server.py`: one shared `_bearer_token()` helper that strips surrounding OWS, used by both the FastAPI and stdlib auth paths, so they can no longer drift.
- Tests: replace the trailing-space case with a non-whitespace near-miss (`Bearer <key>x`, survives transmission, still 401, locking exact comparison); add an explicit normalization assertion (trailing space -> 200); add `TestGatewayAuthCrossImplementation` that forces the stdlib path even when FastAPI is installed, pinning that both paths agree in any environment.

## Verification
- Raw-socket probe: before the fix, stdlib returns 401 and FastAPI 200 for a trailing-space token; extra-char and internal-space near-misses return 401 on both.
- Full suite now fully green: 1268 passed, 1 skipped.

Small product change (auth normalization); not a release blocker.