### PR TITLE
Exp 7 Phase A: task-independent redcon brief + django/sympy briefs + pre-registration

### DIFF
--- a/benchmarks/agentic/gen_exp7_briefs.py
+++ b/benchmarks/agentic/gen_exp7_briefs.py
@@ -1,0 +1,91 @@
+"""Generate task-independent repository briefs for the night-2 heavy corpus.
+
+For every heavy task, check the source repository out at the task's base commit
+and render the brief through the shipped `redcon brief` code path (build_brief),
+writing one Markdown brief per (repo, sha). The brief is task-independent, so the
+same repo at the same commit always yields the same file; this script builds each
+one twice and asserts the two renderings are byte-identical, recording the token
+count. Deterministic and free: no agent spend.
+
+    python benchmarks/agentic/gen_exp7_briefs.py \\
+        --src-root /path/to/clones --out benchmarks/agentic/results/exp7-phaseA
+
+`--src-root` holds full clones named `django/` and `sympy/`; those clones are not
+committed. The generated briefs under `--out` are.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = _HERE.parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from redcon.brief import build_brief  # noqa: E402
+
+_SHA_LEN = 12
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+
+def _checkout(src: Path, sha: str) -> None:
+    # Drop any scan index from a prior SHA so the checkout is clean, then hard
+    # checkout the base commit.
+    redcon_dir = src / ".redcon"
+    if redcon_dir.exists():
+        subprocess.run(["rm", "-rf", str(redcon_dir)], check=True)
+    _git(src, "checkout", "-q", "-f", sha)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--src-root", type=Path, required=True)
+    parser.add_argument("--tasks", type=Path, default=_HERE / "tasks-heavy.jsonl")
+    parser.add_argument("--out", type=Path, default=_HERE / "results" / "exp7-phaseA")
+    args = parser.parse_args()
+
+    tasks = [json.loads(line) for line in args.tasks.read_text().splitlines() if line.strip()]
+    args.out.mkdir(parents=True, exist_ok=True)
+
+    index = []
+    for task in tasks:
+        repo = task["repo"]
+        sha = task["sha"]
+        src = args.src_root / repo
+        if not src.exists():
+            print(f"skip {repo} {sha[:_SHA_LEN]}: {src} missing", file=sys.stderr)
+            continue
+        _checkout(src, sha)
+        first = build_brief(src)
+        second = build_brief(src)
+        assert first.text == second.text, f"non-deterministic brief for {repo} {sha}"
+        name = f"{repo}-{sha[:_SHA_LEN]}.brief.md"
+        (args.out / name).write_text(first.text, encoding="utf-8")
+        index.append(
+            {
+                "repo": repo,
+                "sha": sha[:_SHA_LEN],
+                "brief": name,
+                "tokens": first.tokens,
+                "file_count": first.file_count,
+                "truncated": first.truncated,
+            }
+        )
+        print(f"{name}: {first.tokens} tokens, {first.file_count} files")
+
+    (args.out / "index.json").write_text(json.dumps(index, indent=2) + "\n", encoding="utf-8")
+    if index:
+        toks = [row["tokens"] for row in index]
+        print(f"\n{len(index)} briefs; tokens min {min(toks)} max {max(toks)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/agentic/results/exp7-phaseA/django-21c51c2623a9.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/django-21c51c2623a9.brief.md
@@ -20,13 +20,18 @@ Task-independent map of 5653 scanned files (.py x2904, .po x1274, .txt x713), 11
 - `django/views/` (28 files): decorators/, generic/, templates/, __init__, +5 more
 - `django/` top-level modules: __init__, __main__, shortcuts
 
+## Central modules
+- `django/db/__init__.py` (imported by 778 modules)
+- `django/db/models/__init__.py` (imported by 645 modules)
+- `django/core/exceptions.py` (imported by 359 modules)
+- `django/conf/__init__.py` (imported by 239 modules)
+- `django/db/models/functions/datetime.py` (imported by 238 modules)
+- `django/urls/__init__.py` (imported by 217 modules)
+- `django/db/migrations/__init__.py` (imported by 209 modules)
+- `django/utils/translation/__init__.py` (imported by 195 modules)
+
 ## Entry points
 - `django/__main__.py`
-- `django/contrib/admin/views/main.py`
-- `django/core/asgi.py`
-- `django/core/handlers/asgi.py`
-- `django/core/handlers/wsgi.py`
-- `django/core/wsgi.py`
 
 ## Test layout
 - 2466 files total
@@ -36,6 +41,7 @@ Task-independent map of 5653 scanned files (.py x2904, .po x1274, .txt x713), 11
 - (repository root): 5 files
 - `scripts/`: 3 files
 - `docs/`: 1 file
+- 0 files named `conftest.py`
 
 ## Build and config
 - `pyproject.toml`

--- a/benchmarks/agentic/results/exp7-phaseA/django-21c51c2623a9.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/django-21c51c2623a9.brief.md
@@ -1,0 +1,44 @@
+# Repository brief: django
+
+Task-independent map of 5653 scanned files (.py x2904, .po x1274, .txt x713), 11160 internal import links. Geography only, no per-change file list.
+
+## Module geography
+- `django/apps/` (3 files): __init__, config, registry
+- `django/conf/` (286 files): locale/, app_template/, project_template/, urls/, +2 more
+- `django/contrib/` (1667 files): admin/, gis/, auth/, sessions/, +12 more
+- `django/core/` (106 files): management/, checks/, files/, cache/, +12 more
+- `django/db/` (122 files): backends/, models/, migrations/, __init__, +2 more
+- `django/dispatch/` (2 files): __init__, dispatcher
+- `django/forms/` (101 files): jinja2/, templates/, __init__, boundfield, +7 more
+- `django/http/` (5 files): __init__, cookie, multipartparser, request, +1 more
+- `django/middleware/` (10 files): __init__, cache, clickjacking, common, +6 more
+- `django/tasks/` (9 files): backends/, __init__, base, checks, +2 more
+- `django/template/` (27 files): backends/, loaders/, __init__, autoreload, +13 more
+- `django/templatetags/` (6 files): __init__, cache, i18n, l10n, +2 more
+- `django/urls/` (7 files): __init__, base, conf, converters, +3 more
+- `django/utils/` (47 files): translation/, __init__, _os, archive, +39 more
+- `django/views/` (28 files): decorators/, generic/, templates/, __init__, +5 more
+- `django/` top-level modules: __init__, __main__, shortcuts
+
+## Entry points
+- `django/__main__.py`
+- `django/contrib/admin/views/main.py`
+- `django/core/asgi.py`
+- `django/core/handlers/asgi.py`
+- `django/core/handlers/wsgi.py`
+- `django/core/wsgi.py`
+
+## Test layout
+- 2466 files total
+- `tests/`: 2433 files
+- `django/`: 12 files
+- `js_tests/`: 12 files
+- (repository root): 5 files
+- `scripts/`: 3 files
+- `docs/`: 1 file
+
+## Build and config
+- `pyproject.toml`
+- `tox.ini`
+- `package.json`
+- `.pre-commit-config.yaml`

--- a/benchmarks/agentic/results/exp7-phaseA/django-36be97b99d4d.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/django-36be97b99d4d.brief.md
@@ -20,13 +20,18 @@ Task-independent map of 5635 scanned files (.py x2892, .po x1272, .txt x708), 11
 - `django/views/` (28 files): decorators/, generic/, templates/, __init__, +5 more
 - `django/` top-level modules: __init__, __main__, shortcuts
 
+## Central modules
+- `django/db/__init__.py` (imported by 778 modules)
+- `django/db/models/__init__.py` (imported by 643 modules)
+- `django/core/exceptions.py` (imported by 355 modules)
+- `django/db/models/functions/datetime.py` (imported by 237 modules)
+- `django/conf/__init__.py` (imported by 236 modules)
+- `django/urls/__init__.py` (imported by 217 modules)
+- `django/db/migrations/__init__.py` (imported by 209 modules)
+- `django/utils/translation/__init__.py` (imported by 194 modules)
+
 ## Entry points
 - `django/__main__.py`
-- `django/contrib/admin/views/main.py`
-- `django/core/asgi.py`
-- `django/core/handlers/asgi.py`
-- `django/core/handlers/wsgi.py`
-- `django/core/wsgi.py`
 
 ## Test layout
 - 2457 files total
@@ -36,6 +41,7 @@ Task-independent map of 5635 scanned files (.py x2892, .po x1272, .txt x708), 11
 - (repository root): 5 files
 - `docs/`: 1 file
 - `scripts/`: 1 file
+- 0 files named `conftest.py`
 
 ## Build and config
 - `pyproject.toml`

--- a/benchmarks/agentic/results/exp7-phaseA/django-36be97b99d4d.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/django-36be97b99d4d.brief.md
@@ -1,0 +1,44 @@
+# Repository brief: django
+
+Task-independent map of 5635 scanned files (.py x2892, .po x1272, .txt x708), 11084 internal import links. Geography only, no per-change file list.
+
+## Module geography
+- `django/apps/` (3 files): __init__, config, registry
+- `django/conf/` (286 files): locale/, app_template/, project_template/, urls/, +2 more
+- `django/contrib/` (1667 files): admin/, gis/, auth/, sessions/, +12 more
+- `django/core/` (106 files): management/, checks/, files/, cache/, +12 more
+- `django/db/` (122 files): backends/, models/, migrations/, __init__, +2 more
+- `django/dispatch/` (2 files): __init__, dispatcher
+- `django/forms/` (101 files): jinja2/, templates/, __init__, boundfield, +7 more
+- `django/http/` (5 files): __init__, cookie, multipartparser, request, +1 more
+- `django/middleware/` (10 files): __init__, cache, clickjacking, common, +6 more
+- `django/tasks/` (9 files): backends/, __init__, base, checks, +2 more
+- `django/template/` (27 files): backends/, loaders/, __init__, autoreload, +13 more
+- `django/templatetags/` (6 files): __init__, cache, i18n, l10n, +2 more
+- `django/urls/` (7 files): __init__, base, conf, converters, +3 more
+- `django/utils/` (47 files): translation/, __init__, _os, archive, +39 more
+- `django/views/` (28 files): decorators/, generic/, templates/, __init__, +5 more
+- `django/` top-level modules: __init__, __main__, shortcuts
+
+## Entry points
+- `django/__main__.py`
+- `django/contrib/admin/views/main.py`
+- `django/core/asgi.py`
+- `django/core/handlers/asgi.py`
+- `django/core/handlers/wsgi.py`
+- `django/core/wsgi.py`
+
+## Test layout
+- 2457 files total
+- `tests/`: 2426 files
+- `django/`: 12 files
+- `js_tests/`: 12 files
+- (repository root): 5 files
+- `docs/`: 1 file
+- `scripts/`: 1 file
+
+## Build and config
+- `pyproject.toml`
+- `tox.ini`
+- `package.json`
+- `.pre-commit-config.yaml`

--- a/benchmarks/agentic/results/exp7-phaseA/django-56050acb96ab.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/django-56050acb96ab.brief.md
@@ -1,0 +1,44 @@
+# Repository brief: django
+
+Task-independent map of 5680 scanned files (.py x2924, .po x1274, .txt x717), 11349 internal import links. Geography only, no per-change file list.
+
+## Module geography
+- `django/apps/` (3 files): __init__, config, registry
+- `django/conf/` (286 files): locale/, app_template/, project_template/, urls/, +2 more
+- `django/contrib/` (1668 files): admin/, gis/, auth/, sessions/, +12 more
+- `django/core/` (111 files): management/, checks/, files/, mail/, +12 more
+- `django/db/` (122 files): backends/, models/, migrations/, __init__, +2 more
+- `django/dispatch/` (2 files): __init__, dispatcher
+- `django/forms/` (101 files): jinja2/, templates/, __init__, boundfield, +7 more
+- `django/http/` (5 files): __init__, cookie, multipartparser, request, +1 more
+- `django/middleware/` (10 files): __init__, cache, clickjacking, common, +6 more
+- `django/tasks/` (9 files): backends/, __init__, base, checks, +2 more
+- `django/template/` (27 files): backends/, loaders/, __init__, autoreload, +13 more
+- `django/templatetags/` (6 files): __init__, cache, i18n, l10n, +2 more
+- `django/urls/` (7 files): __init__, base, conf, converters, +3 more
+- `django/utils/` (48 files): translation/, __init__, _os, archive, +40 more
+- `django/views/` (28 files): decorators/, generic/, templates/, __init__, +5 more
+- `django/` top-level modules: __init__, __main__, shortcuts
+
+## Entry points
+- `django/__main__.py`
+- `django/contrib/admin/views/main.py`
+- `django/core/asgi.py`
+- `django/core/handlers/asgi.py`
+- `django/core/handlers/wsgi.py`
+- `django/core/wsgi.py`
+
+## Test layout
+- 2480 files total
+- `tests/`: 2447 files
+- `django/`: 12 files
+- `js_tests/`: 12 files
+- (repository root): 5 files
+- `scripts/`: 3 files
+- `docs/`: 1 file
+
+## Build and config
+- `pyproject.toml`
+- `tox.ini`
+- `package.json`
+- `.pre-commit-config.yaml`

--- a/benchmarks/agentic/results/exp7-phaseA/django-56050acb96ab.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/django-56050acb96ab.brief.md
@@ -20,13 +20,18 @@ Task-independent map of 5680 scanned files (.py x2924, .po x1274, .txt x717), 11
 - `django/views/` (28 files): decorators/, generic/, templates/, __init__, +5 more
 - `django/` top-level modules: __init__, __main__, shortcuts
 
+## Central modules
+- `django/db/__init__.py` (imported by 779 modules)
+- `django/db/models/__init__.py` (imported by 646 modules)
+- `django/core/exceptions.py` (imported by 362 modules)
+- `django/conf/__init__.py` (imported by 249 modules)
+- `django/db/models/functions/datetime.py` (imported by 238 modules)
+- `django/urls/__init__.py` (imported by 222 modules)
+- `django/db/migrations/__init__.py` (imported by 209 modules)
+- `django/utils/translation/__init__.py` (imported by 196 modules)
+
 ## Entry points
 - `django/__main__.py`
-- `django/contrib/admin/views/main.py`
-- `django/core/asgi.py`
-- `django/core/handlers/asgi.py`
-- `django/core/handlers/wsgi.py`
-- `django/core/wsgi.py`
 
 ## Test layout
 - 2480 files total
@@ -36,6 +41,7 @@ Task-independent map of 5680 scanned files (.py x2924, .po x1274, .txt x717), 11
 - (repository root): 5 files
 - `scripts/`: 3 files
 - `docs/`: 1 file
+- 0 files named `conftest.py`
 
 ## Build and config
 - `pyproject.toml`

--- a/benchmarks/agentic/results/exp7-phaseA/django-673fa46d8063.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/django-673fa46d8063.brief.md
@@ -20,13 +20,18 @@ Task-independent map of 5646 scanned files (.py x2900, .po x1273, .txt x711), 11
 - `django/views/` (28 files): decorators/, generic/, templates/, __init__, +5 more
 - `django/` top-level modules: __init__, __main__, shortcuts
 
+## Central modules
+- `django/db/__init__.py` (imported by 778 modules)
+- `django/db/models/__init__.py` (imported by 643 modules)
+- `django/core/exceptions.py` (imported by 356 modules)
+- `django/db/models/functions/datetime.py` (imported by 238 modules)
+- `django/conf/__init__.py` (imported by 237 modules)
+- `django/urls/__init__.py` (imported by 217 modules)
+- `django/db/migrations/__init__.py` (imported by 209 modules)
+- `django/utils/translation/__init__.py` (imported by 194 modules)
+
 ## Entry points
 - `django/__main__.py`
-- `django/contrib/admin/views/main.py`
-- `django/core/asgi.py`
-- `django/core/handlers/asgi.py`
-- `django/core/handlers/wsgi.py`
-- `django/core/wsgi.py`
 
 ## Test layout
 - 2461 files total
@@ -36,6 +41,7 @@ Task-independent map of 5646 scanned files (.py x2900, .po x1273, .txt x711), 11
 - (repository root): 5 files
 - `scripts/`: 3 files
 - `docs/`: 1 file
+- 0 files named `conftest.py`
 
 ## Build and config
 - `pyproject.toml`

--- a/benchmarks/agentic/results/exp7-phaseA/django-673fa46d8063.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/django-673fa46d8063.brief.md
@@ -1,0 +1,44 @@
+# Repository brief: django
+
+Task-independent map of 5646 scanned files (.py x2900, .po x1273, .txt x711), 11102 internal import links. Geography only, no per-change file list.
+
+## Module geography
+- `django/apps/` (3 files): __init__, config, registry
+- `django/conf/` (286 files): locale/, app_template/, project_template/, urls/, +2 more
+- `django/contrib/` (1667 files): admin/, gis/, auth/, sessions/, +12 more
+- `django/core/` (106 files): management/, checks/, files/, cache/, +12 more
+- `django/db/` (122 files): backends/, models/, migrations/, __init__, +2 more
+- `django/dispatch/` (2 files): __init__, dispatcher
+- `django/forms/` (101 files): jinja2/, templates/, __init__, boundfield, +7 more
+- `django/http/` (5 files): __init__, cookie, multipartparser, request, +1 more
+- `django/middleware/` (10 files): __init__, cache, clickjacking, common, +6 more
+- `django/tasks/` (9 files): backends/, __init__, base, checks, +2 more
+- `django/template/` (27 files): backends/, loaders/, __init__, autoreload, +13 more
+- `django/templatetags/` (6 files): __init__, cache, i18n, l10n, +2 more
+- `django/urls/` (7 files): __init__, base, conf, converters, +3 more
+- `django/utils/` (47 files): translation/, __init__, _os, archive, +39 more
+- `django/views/` (28 files): decorators/, generic/, templates/, __init__, +5 more
+- `django/` top-level modules: __init__, __main__, shortcuts
+
+## Entry points
+- `django/__main__.py`
+- `django/contrib/admin/views/main.py`
+- `django/core/asgi.py`
+- `django/core/handlers/asgi.py`
+- `django/core/handlers/wsgi.py`
+- `django/core/wsgi.py`
+
+## Test layout
+- 2461 files total
+- `tests/`: 2428 files
+- `django/`: 12 files
+- `js_tests/`: 12 files
+- (repository root): 5 files
+- `scripts/`: 3 files
+- `docs/`: 1 file
+
+## Build and config
+- `pyproject.toml`
+- `tox.ini`
+- `package.json`
+- `.pre-commit-config.yaml`

--- a/benchmarks/agentic/results/exp7-phaseA/django-e7f539f813bd.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/django-e7f539f813bd.brief.md
@@ -20,13 +20,18 @@ Task-independent map of 5653 scanned files (.py x2904, .po x1274, .txt x713), 11
 - `django/views/` (28 files): decorators/, generic/, templates/, __init__, +5 more
 - `django/` top-level modules: __init__, __main__, shortcuts
 
+## Central modules
+- `django/db/__init__.py` (imported by 778 modules)
+- `django/db/models/__init__.py` (imported by 645 modules)
+- `django/core/exceptions.py` (imported by 359 modules)
+- `django/conf/__init__.py` (imported by 239 modules)
+- `django/db/models/functions/datetime.py` (imported by 238 modules)
+- `django/urls/__init__.py` (imported by 217 modules)
+- `django/db/migrations/__init__.py` (imported by 209 modules)
+- `django/utils/translation/__init__.py` (imported by 195 modules)
+
 ## Entry points
 - `django/__main__.py`
-- `django/contrib/admin/views/main.py`
-- `django/core/asgi.py`
-- `django/core/handlers/asgi.py`
-- `django/core/handlers/wsgi.py`
-- `django/core/wsgi.py`
 
 ## Test layout
 - 2466 files total
@@ -36,6 +41,7 @@ Task-independent map of 5653 scanned files (.py x2904, .po x1274, .txt x713), 11
 - (repository root): 5 files
 - `scripts/`: 3 files
 - `docs/`: 1 file
+- 0 files named `conftest.py`
 
 ## Build and config
 - `pyproject.toml`

--- a/benchmarks/agentic/results/exp7-phaseA/django-e7f539f813bd.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/django-e7f539f813bd.brief.md
@@ -1,0 +1,44 @@
+# Repository brief: django
+
+Task-independent map of 5653 scanned files (.py x2904, .po x1274, .txt x713), 11162 internal import links. Geography only, no per-change file list.
+
+## Module geography
+- `django/apps/` (3 files): __init__, config, registry
+- `django/conf/` (286 files): locale/, app_template/, project_template/, urls/, +2 more
+- `django/contrib/` (1667 files): admin/, gis/, auth/, sessions/, +12 more
+- `django/core/` (106 files): management/, checks/, files/, cache/, +12 more
+- `django/db/` (122 files): backends/, models/, migrations/, __init__, +2 more
+- `django/dispatch/` (2 files): __init__, dispatcher
+- `django/forms/` (101 files): jinja2/, templates/, __init__, boundfield, +7 more
+- `django/http/` (5 files): __init__, cookie, multipartparser, request, +1 more
+- `django/middleware/` (10 files): __init__, cache, clickjacking, common, +6 more
+- `django/tasks/` (9 files): backends/, __init__, base, checks, +2 more
+- `django/template/` (27 files): backends/, loaders/, __init__, autoreload, +13 more
+- `django/templatetags/` (6 files): __init__, cache, i18n, l10n, +2 more
+- `django/urls/` (7 files): __init__, base, conf, converters, +3 more
+- `django/utils/` (47 files): translation/, __init__, _os, archive, +39 more
+- `django/views/` (28 files): decorators/, generic/, templates/, __init__, +5 more
+- `django/` top-level modules: __init__, __main__, shortcuts
+
+## Entry points
+- `django/__main__.py`
+- `django/contrib/admin/views/main.py`
+- `django/core/asgi.py`
+- `django/core/handlers/asgi.py`
+- `django/core/handlers/wsgi.py`
+- `django/core/wsgi.py`
+
+## Test layout
+- 2466 files total
+- `tests/`: 2433 files
+- `django/`: 12 files
+- `js_tests/`: 12 files
+- (repository root): 5 files
+- `scripts/`: 3 files
+- `docs/`: 1 file
+
+## Build and config
+- `pyproject.toml`
+- `tox.ini`
+- `package.json`
+- `.pre-commit-config.yaml`

--- a/benchmarks/agentic/results/exp7-phaseA/django-f2169ef36884.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/django-f2169ef36884.brief.md
@@ -20,13 +20,18 @@ Task-independent map of 5638 scanned files (.py x2894, .po x1273, .txt x708), 11
 - `django/views/` (28 files): decorators/, generic/, templates/, __init__, +5 more
 - `django/` top-level modules: __init__, __main__, shortcuts
 
+## Central modules
+- `django/db/__init__.py` (imported by 778 modules)
+- `django/db/models/__init__.py` (imported by 643 modules)
+- `django/core/exceptions.py` (imported by 355 modules)
+- `django/conf/__init__.py` (imported by 237 modules)
+- `django/db/models/functions/datetime.py` (imported by 237 modules)
+- `django/urls/__init__.py` (imported by 217 modules)
+- `django/db/migrations/__init__.py` (imported by 209 modules)
+- `django/utils/translation/__init__.py` (imported by 194 modules)
+
 ## Entry points
 - `django/__main__.py`
-- `django/contrib/admin/views/main.py`
-- `django/core/asgi.py`
-- `django/core/handlers/asgi.py`
-- `django/core/handlers/wsgi.py`
-- `django/core/wsgi.py`
 
 ## Test layout
 - 2458 files total
@@ -36,6 +41,7 @@ Task-independent map of 5638 scanned files (.py x2894, .po x1273, .txt x708), 11
 - (repository root): 5 files
 - `docs/`: 1 file
 - `scripts/`: 1 file
+- 0 files named `conftest.py`
 
 ## Build and config
 - `pyproject.toml`

--- a/benchmarks/agentic/results/exp7-phaseA/django-f2169ef36884.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/django-f2169ef36884.brief.md
@@ -1,0 +1,44 @@
+# Repository brief: django
+
+Task-independent map of 5638 scanned files (.py x2894, .po x1273, .txt x708), 11092 internal import links. Geography only, no per-change file list.
+
+## Module geography
+- `django/apps/` (3 files): __init__, config, registry
+- `django/conf/` (286 files): locale/, app_template/, project_template/, urls/, +2 more
+- `django/contrib/` (1667 files): admin/, gis/, auth/, sessions/, +12 more
+- `django/core/` (106 files): management/, checks/, files/, cache/, +12 more
+- `django/db/` (122 files): backends/, models/, migrations/, __init__, +2 more
+- `django/dispatch/` (2 files): __init__, dispatcher
+- `django/forms/` (101 files): jinja2/, templates/, __init__, boundfield, +7 more
+- `django/http/` (5 files): __init__, cookie, multipartparser, request, +1 more
+- `django/middleware/` (10 files): __init__, cache, clickjacking, common, +6 more
+- `django/tasks/` (9 files): backends/, __init__, base, checks, +2 more
+- `django/template/` (27 files): backends/, loaders/, __init__, autoreload, +13 more
+- `django/templatetags/` (6 files): __init__, cache, i18n, l10n, +2 more
+- `django/urls/` (7 files): __init__, base, conf, converters, +3 more
+- `django/utils/` (47 files): translation/, __init__, _os, archive, +39 more
+- `django/views/` (28 files): decorators/, generic/, templates/, __init__, +5 more
+- `django/` top-level modules: __init__, __main__, shortcuts
+
+## Entry points
+- `django/__main__.py`
+- `django/contrib/admin/views/main.py`
+- `django/core/asgi.py`
+- `django/core/handlers/asgi.py`
+- `django/core/handlers/wsgi.py`
+- `django/core/wsgi.py`
+
+## Test layout
+- 2458 files total
+- `tests/`: 2427 files
+- `django/`: 12 files
+- `js_tests/`: 12 files
+- (repository root): 5 files
+- `docs/`: 1 file
+- `scripts/`: 1 file
+
+## Build and config
+- `pyproject.toml`
+- `tox.ini`
+- `package.json`
+- `.pre-commit-config.yaml`

--- a/benchmarks/agentic/results/exp7-phaseA/index.json
+++ b/benchmarks/agentic/results/exp7-phaseA/index.json
@@ -1,0 +1,98 @@
+[
+  {
+    "repo": "django",
+    "sha": "36be97b99d4d",
+    "brief": "django-36be97b99d4d.brief.md",
+    "tokens": 463,
+    "file_count": 5635,
+    "truncated": false
+  },
+  {
+    "repo": "django",
+    "sha": "21c51c2623a9",
+    "brief": "django-21c51c2623a9.brief.md",
+    "tokens": 463,
+    "file_count": 5653,
+    "truncated": false
+  },
+  {
+    "repo": "sympy",
+    "sha": "1e925fca57b6",
+    "brief": "sympy-1e925fca57b6.brief.md",
+    "tokens": 647,
+    "file_count": 2049,
+    "truncated": true
+  },
+  {
+    "repo": "sympy",
+    "sha": "af838d955f42",
+    "brief": "sympy-af838d955f42.brief.md",
+    "tokens": 648,
+    "file_count": 2053,
+    "truncated": true
+  },
+  {
+    "repo": "django",
+    "sha": "56050acb96ab",
+    "brief": "django-56050acb96ab.brief.md",
+    "tokens": 463,
+    "file_count": 5680,
+    "truncated": false
+  },
+  {
+    "repo": "django",
+    "sha": "673fa46d8063",
+    "brief": "django-673fa46d8063.brief.md",
+    "tokens": 463,
+    "file_count": 5646,
+    "truncated": false
+  },
+  {
+    "repo": "sympy",
+    "sha": "cbd5424918c3",
+    "brief": "sympy-cbd5424918c3.brief.md",
+    "tokens": 648,
+    "file_count": 2054,
+    "truncated": true
+  },
+  {
+    "repo": "sympy",
+    "sha": "d3f6039f88b2",
+    "brief": "sympy-d3f6039f88b2.brief.md",
+    "tokens": 648,
+    "file_count": 2063,
+    "truncated": true
+  },
+  {
+    "repo": "django",
+    "sha": "e7f539f813bd",
+    "brief": "django-e7f539f813bd.brief.md",
+    "tokens": 463,
+    "file_count": 5653,
+    "truncated": false
+  },
+  {
+    "repo": "django",
+    "sha": "f2169ef36884",
+    "brief": "django-f2169ef36884.brief.md",
+    "tokens": 463,
+    "file_count": 5638,
+    "truncated": false
+  },
+  {
+    "repo": "sympy",
+    "sha": "afb25b0d7db1",
+    "brief": "sympy-afb25b0d7db1.brief.md",
+    "tokens": 648,
+    "file_count": 2052,
+    "truncated": true
+  },
+  {
+    "repo": "sympy",
+    "sha": "f9a6c6dda7c2",
+    "brief": "sympy-f9a6c6dda7c2.brief.md",
+    "tokens": 648,
+    "file_count": 2052,
+    "truncated": true
+  }
+]

--- a/benchmarks/agentic/results/exp7-phaseA/index.json
+++ b/benchmarks/agentic/results/exp7-phaseA/index.json
@@ -3,7 +3,7 @@
     "repo": "django",
     "sha": "36be97b99d4d",
     "brief": "django-36be97b99d4d.brief.md",
-    "tokens": 463,
+    "tokens": 556,
     "file_count": 5635,
     "truncated": false
   },
@@ -11,7 +11,7 @@
     "repo": "django",
     "sha": "21c51c2623a9",
     "brief": "django-21c51c2623a9.brief.md",
-    "tokens": 463,
+    "tokens": 556,
     "file_count": 5653,
     "truncated": false
   },
@@ -19,7 +19,7 @@
     "repo": "sympy",
     "sha": "1e925fca57b6",
     "brief": "sympy-1e925fca57b6.brief.md",
-    "tokens": 647,
+    "tokens": 775,
     "file_count": 2049,
     "truncated": true
   },
@@ -27,7 +27,7 @@
     "repo": "sympy",
     "sha": "af838d955f42",
     "brief": "sympy-af838d955f42.brief.md",
-    "tokens": 648,
+    "tokens": 776,
     "file_count": 2053,
     "truncated": true
   },
@@ -35,7 +35,7 @@
     "repo": "django",
     "sha": "56050acb96ab",
     "brief": "django-56050acb96ab.brief.md",
-    "tokens": 463,
+    "tokens": 556,
     "file_count": 5680,
     "truncated": false
   },
@@ -43,7 +43,7 @@
     "repo": "django",
     "sha": "673fa46d8063",
     "brief": "django-673fa46d8063.brief.md",
-    "tokens": 463,
+    "tokens": 556,
     "file_count": 5646,
     "truncated": false
   },
@@ -51,7 +51,7 @@
     "repo": "sympy",
     "sha": "cbd5424918c3",
     "brief": "sympy-cbd5424918c3.brief.md",
-    "tokens": 648,
+    "tokens": 776,
     "file_count": 2054,
     "truncated": true
   },
@@ -59,7 +59,7 @@
     "repo": "sympy",
     "sha": "d3f6039f88b2",
     "brief": "sympy-d3f6039f88b2.brief.md",
-    "tokens": 648,
+    "tokens": 776,
     "file_count": 2063,
     "truncated": true
   },
@@ -67,7 +67,7 @@
     "repo": "django",
     "sha": "e7f539f813bd",
     "brief": "django-e7f539f813bd.brief.md",
-    "tokens": 463,
+    "tokens": 556,
     "file_count": 5653,
     "truncated": false
   },
@@ -75,7 +75,7 @@
     "repo": "django",
     "sha": "f2169ef36884",
     "brief": "django-f2169ef36884.brief.md",
-    "tokens": 463,
+    "tokens": 556,
     "file_count": 5638,
     "truncated": false
   },
@@ -83,7 +83,7 @@
     "repo": "sympy",
     "sha": "afb25b0d7db1",
     "brief": "sympy-afb25b0d7db1.brief.md",
-    "tokens": 648,
+    "tokens": 776,
     "file_count": 2052,
     "truncated": true
   },
@@ -91,7 +91,7 @@
     "repo": "sympy",
     "sha": "f9a6c6dda7c2",
     "brief": "sympy-f9a6c6dda7c2.brief.md",
-    "tokens": 648,
+    "tokens": 776,
     "file_count": 2052,
     "truncated": true
   }

--- a/benchmarks/agentic/results/exp7-phaseA/sympy-1e925fca57b6.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/sympy-1e925fca57b6.brief.md
@@ -1,0 +1,46 @@
+# Repository brief: sympy
+
+Task-independent map of 2049 scanned files (.py x1589, .rst x304, .svg x50), 14176 internal import links. Geography only, no per-change file list.
+
+## Module geography
+- `sympy/assumptions/` (27 files): handlers/, predicates/, relation/, __init__, +9 more
+- `sympy/codegen/` (17 files): __init__, abstract_nodes, algorithms, approximations, +13 more
+- `sympy/combinatorics/` (24 files): __init__, coset_table, fp_groups, free_groups, +20 more
+- `sympy/core/` (44 files): benchmarks/, __init__, _print_helpers, add, +34 more
+- `sympy/functions/` (32 files): special/, elementary/, combinatorial/, __init__
+- `sympy/geometry/` (11 files): __init__, curve, ellipse, entity, +7 more
+- `sympy/integrals/` (20 files): benchmarks/, __init__, deltafunctions, heurisch, +14 more
+- `sympy/liealgebras/` (13 files): __init__, cartan_matrix, cartan_type, dynkin_diagram, +9 more
+- `sympy/logic/` (12 files): algorithms/, utilities/, __init__, boolalg, +1 more
+- `sympy/matrices/` (48 files): expressions/, benchmarks/, __init__, common, +19 more
+- `sympy/ntheory/` (15 files): __init__, bbp_pi, continued_fraction, digits, +11 more
+- `sympy/parsing/` (33 files): latex/, autolev/, c/, fortran/, +7 more
+- `sympy/physics/` (113 files): quantum/, mechanics/, units/, vector/, +14 more
+- `sympy/plotting/` (35 files): pygletplot/, backends/, intervalmath/, __init__, +7 more
+- `sympy/polys/` (119 files): domains/, matrices/, numberfields/, series/, +46 more
+- `sympy/printing/` (40 files): pretty/, __init__, aesaracode, c, +33 more
+- `sympy/series/` (18 files): benchmarks/, __init__, acceleration, approximants, +12 more
+- `sympy/sets/` (17 files): handlers/, __init__, conditionset, contains, +5 more
+- `sympy/simplify/` (17 files): __init__, _cse_diff, combsimp, cse_main, +13 more
+- `sympy/solvers/` (24 files): ode/, benchmarks/, diophantine/, __init__, +10 more
+- `sympy/stats/` (21 files): __init__, compound_rv, crv, crv_types, +17 more
+- `sympy/tensor/` (26 files): array/, __init__, functions, index_methods, +3 more
+- `sympy/utilities/` (29 files): _compilation/, mathml/, __init__, autowrap, +17 more
+- `sympy/vector/` (15 files): __init__, basisdependent, coordsysrect, deloperator, +11 more
+- ... and 16 more `sympy/` subpackages
+- `sympy/` top-level modules: __init__, abc, conftest, galgebra, release, this
+
+## Entry points
+- no conventional entry-point files detected
+
+## Test layout
+- 732 files total
+- `sympy/`: 716 files
+- `bin/`: 15 files
+- `doc/`: 1 file
+
+## Build and config
+- `pyproject.toml`
+- `setup.py`
+- `requirements-dev.txt`
+- `conftest.py`

--- a/benchmarks/agentic/results/exp7-phaseA/sympy-1e925fca57b6.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/sympy-1e925fca57b6.brief.md
@@ -30,6 +30,16 @@ Task-independent map of 2049 scanned files (.py x1589, .rst x304, .svg x50), 141
 - ... and 16 more `sympy/` subpackages
 - `sympy/` top-level modules: __init__, abc, conftest, galgebra, release, this
 
+## Central modules
+- `sympy/core/symbol.py` (imported by 562 modules)
+- `sympy/core/numbers.py` (imported by 509 modules)
+- `sympy/testing/pytest.py` (imported by 431 modules)
+- `sympy/core/singleton.py` (imported by 412 modules)
+- `sympy/core/__init__.py` (imported by 325 modules)
+- `sympy/core/function.py` (imported by 319 modules)
+- `sympy/functions/elementary/miscellaneous.py` (imported by 311 modules)
+- `sympy/functions/elementary/trigonometric.py` (imported by 274 modules)
+
 ## Entry points
 - no conventional entry-point files detected
 
@@ -38,6 +48,7 @@ Task-independent map of 2049 scanned files (.py x1589, .rst x304, .svg x50), 141
 - `sympy/`: 716 files
 - `bin/`: 15 files
 - `doc/`: 1 file
+- 2 files named `conftest.py`
 
 ## Build and config
 - `pyproject.toml`

--- a/benchmarks/agentic/results/exp7-phaseA/sympy-af838d955f42.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/sympy-af838d955f42.brief.md
@@ -1,0 +1,46 @@
+# Repository brief: sympy
+
+Task-independent map of 2053 scanned files (.py x1590, .rst x305, .svg x50), 14254 internal import links. Geography only, no per-change file list.
+
+## Module geography
+- `sympy/assumptions/` (27 files): handlers/, predicates/, relation/, __init__, +9 more
+- `sympy/codegen/` (17 files): __init__, abstract_nodes, algorithms, approximations, +13 more
+- `sympy/combinatorics/` (24 files): __init__, coset_table, fp_groups, free_groups, +20 more
+- `sympy/core/` (44 files): benchmarks/, __init__, _print_helpers, add, +34 more
+- `sympy/functions/` (32 files): special/, elementary/, combinatorial/, __init__
+- `sympy/geometry/` (11 files): __init__, curve, ellipse, entity, +7 more
+- `sympy/integrals/` (20 files): benchmarks/, __init__, deltafunctions, heurisch, +14 more
+- `sympy/liealgebras/` (13 files): __init__, cartan_matrix, cartan_type, dynkin_diagram, +9 more
+- `sympy/logic/` (12 files): algorithms/, utilities/, __init__, boolalg, +1 more
+- `sympy/matrices/` (48 files): expressions/, benchmarks/, __init__, common, +19 more
+- `sympy/ntheory/` (15 files): __init__, bbp_pi, continued_fraction, digits, +11 more
+- `sympy/parsing/` (33 files): latex/, autolev/, c/, fortran/, +7 more
+- `sympy/physics/` (113 files): quantum/, mechanics/, units/, vector/, +14 more
+- `sympy/plotting/` (35 files): pygletplot/, backends/, intervalmath/, __init__, +7 more
+- `sympy/polys/` (119 files): domains/, matrices/, numberfields/, series/, +46 more
+- `sympy/printing/` (40 files): pretty/, __init__, aesaracode, c, +33 more
+- `sympy/series/` (18 files): benchmarks/, __init__, acceleration, approximants, +12 more
+- `sympy/sets/` (17 files): handlers/, __init__, conditionset, contains, +5 more
+- `sympy/simplify/` (17 files): __init__, _cse_diff, combsimp, cse_main, +13 more
+- `sympy/solvers/` (24 files): ode/, benchmarks/, diophantine/, __init__, +10 more
+- `sympy/stats/` (21 files): __init__, compound_rv, crv, crv_types, +17 more
+- `sympy/tensor/` (26 files): array/, __init__, functions, index_methods, +3 more
+- `sympy/utilities/` (29 files): _compilation/, mathml/, __init__, autowrap, +17 more
+- `sympy/vector/` (15 files): __init__, basisdependent, coordsysrect, deloperator, +11 more
+- ... and 16 more `sympy/` subpackages
+- `sympy/` top-level modules: __init__, abc, conftest, galgebra, py, release, this
+
+## Entry points
+- no conventional entry-point files detected
+
+## Test layout
+- 732 files total
+- `sympy/`: 716 files
+- `bin/`: 15 files
+- `doc/`: 1 file
+
+## Build and config
+- `pyproject.toml`
+- `setup.py`
+- `requirements-dev.txt`
+- `conftest.py`

--- a/benchmarks/agentic/results/exp7-phaseA/sympy-af838d955f42.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/sympy-af838d955f42.brief.md
@@ -30,6 +30,16 @@ Task-independent map of 2053 scanned files (.py x1590, .rst x305, .svg x50), 142
 - ... and 16 more `sympy/` subpackages
 - `sympy/` top-level modules: __init__, abc, conftest, galgebra, py, release, this
 
+## Central modules
+- `sympy/core/symbol.py` (imported by 563 modules)
+- `sympy/core/numbers.py` (imported by 509 modules)
+- `sympy/testing/pytest.py` (imported by 431 modules)
+- `sympy/core/singleton.py` (imported by 413 modules)
+- `sympy/core/__init__.py` (imported by 325 modules)
+- `sympy/core/function.py` (imported by 320 modules)
+- `sympy/functions/elementary/miscellaneous.py` (imported by 311 modules)
+- `sympy/functions/elementary/trigonometric.py` (imported by 274 modules)
+
 ## Entry points
 - no conventional entry-point files detected
 
@@ -38,6 +48,7 @@ Task-independent map of 2053 scanned files (.py x1590, .rst x305, .svg x50), 142
 - `sympy/`: 716 files
 - `bin/`: 15 files
 - `doc/`: 1 file
+- 2 files named `conftest.py`
 
 ## Build and config
 - `pyproject.toml`

--- a/benchmarks/agentic/results/exp7-phaseA/sympy-afb25b0d7db1.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/sympy-afb25b0d7db1.brief.md
@@ -30,6 +30,16 @@ Task-independent map of 2052 scanned files (.py x1590, .rst x305, .svg x50), 142
 - ... and 16 more `sympy/` subpackages
 - `sympy/` top-level modules: __init__, abc, conftest, galgebra, py, release, this
 
+## Central modules
+- `sympy/core/symbol.py` (imported by 563 modules)
+- `sympy/core/numbers.py` (imported by 509 modules)
+- `sympy/testing/pytest.py` (imported by 431 modules)
+- `sympy/core/singleton.py` (imported by 413 modules)
+- `sympy/core/__init__.py` (imported by 325 modules)
+- `sympy/core/function.py` (imported by 320 modules)
+- `sympy/functions/elementary/miscellaneous.py` (imported by 311 modules)
+- `sympy/functions/elementary/trigonometric.py` (imported by 274 modules)
+
 ## Entry points
 - no conventional entry-point files detected
 
@@ -38,6 +48,7 @@ Task-independent map of 2052 scanned files (.py x1590, .rst x305, .svg x50), 142
 - `sympy/`: 716 files
 - `bin/`: 15 files
 - `doc/`: 1 file
+- 2 files named `conftest.py`
 
 ## Build and config
 - `pyproject.toml`

--- a/benchmarks/agentic/results/exp7-phaseA/sympy-afb25b0d7db1.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/sympy-afb25b0d7db1.brief.md
@@ -1,0 +1,46 @@
+# Repository brief: sympy
+
+Task-independent map of 2052 scanned files (.py x1590, .rst x305, .svg x50), 14253 internal import links. Geography only, no per-change file list.
+
+## Module geography
+- `sympy/assumptions/` (27 files): handlers/, predicates/, relation/, __init__, +9 more
+- `sympy/codegen/` (17 files): __init__, abstract_nodes, algorithms, approximations, +13 more
+- `sympy/combinatorics/` (24 files): __init__, coset_table, fp_groups, free_groups, +20 more
+- `sympy/core/` (44 files): benchmarks/, __init__, _print_helpers, add, +34 more
+- `sympy/functions/` (32 files): special/, elementary/, combinatorial/, __init__
+- `sympy/geometry/` (11 files): __init__, curve, ellipse, entity, +7 more
+- `sympy/integrals/` (20 files): benchmarks/, __init__, deltafunctions, heurisch, +14 more
+- `sympy/liealgebras/` (13 files): __init__, cartan_matrix, cartan_type, dynkin_diagram, +9 more
+- `sympy/logic/` (12 files): algorithms/, utilities/, __init__, boolalg, +1 more
+- `sympy/matrices/` (48 files): expressions/, benchmarks/, __init__, common, +19 more
+- `sympy/ntheory/` (15 files): __init__, bbp_pi, continued_fraction, digits, +11 more
+- `sympy/parsing/` (33 files): latex/, autolev/, c/, fortran/, +7 more
+- `sympy/physics/` (113 files): quantum/, mechanics/, units/, vector/, +14 more
+- `sympy/plotting/` (35 files): pygletplot/, backends/, intervalmath/, __init__, +7 more
+- `sympy/polys/` (119 files): domains/, matrices/, numberfields/, series/, +46 more
+- `sympy/printing/` (40 files): pretty/, __init__, aesaracode, c, +33 more
+- `sympy/series/` (18 files): benchmarks/, __init__, acceleration, approximants, +12 more
+- `sympy/sets/` (17 files): handlers/, __init__, conditionset, contains, +5 more
+- `sympy/simplify/` (17 files): __init__, _cse_diff, combsimp, cse_main, +13 more
+- `sympy/solvers/` (24 files): ode/, benchmarks/, diophantine/, __init__, +10 more
+- `sympy/stats/` (21 files): __init__, compound_rv, crv, crv_types, +17 more
+- `sympy/tensor/` (26 files): array/, __init__, functions, index_methods, +3 more
+- `sympy/utilities/` (29 files): _compilation/, mathml/, __init__, autowrap, +17 more
+- `sympy/vector/` (15 files): __init__, basisdependent, coordsysrect, deloperator, +11 more
+- ... and 16 more `sympy/` subpackages
+- `sympy/` top-level modules: __init__, abc, conftest, galgebra, py, release, this
+
+## Entry points
+- no conventional entry-point files detected
+
+## Test layout
+- 732 files total
+- `sympy/`: 716 files
+- `bin/`: 15 files
+- `doc/`: 1 file
+
+## Build and config
+- `pyproject.toml`
+- `setup.py`
+- `requirements-dev.txt`
+- `conftest.py`

--- a/benchmarks/agentic/results/exp7-phaseA/sympy-cbd5424918c3.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/sympy-cbd5424918c3.brief.md
@@ -1,0 +1,46 @@
+# Repository brief: sympy
+
+Task-independent map of 2054 scanned files (.py x1589, .rst x306, .svg x50), 14283 internal import links. Geography only, no per-change file list.
+
+## Module geography
+- `sympy/assumptions/` (27 files): handlers/, predicates/, relation/, __init__, +9 more
+- `sympy/codegen/` (17 files): __init__, abstract_nodes, algorithms, approximations, +13 more
+- `sympy/combinatorics/` (24 files): __init__, coset_table, fp_groups, free_groups, +20 more
+- `sympy/core/` (44 files): benchmarks/, __init__, _print_helpers, add, +34 more
+- `sympy/functions/` (32 files): special/, elementary/, combinatorial/, __init__
+- `sympy/geometry/` (11 files): __init__, curve, ellipse, entity, +7 more
+- `sympy/integrals/` (20 files): benchmarks/, __init__, deltafunctions, heurisch, +14 more
+- `sympy/liealgebras/` (13 files): __init__, cartan_matrix, cartan_type, dynkin_diagram, +9 more
+- `sympy/logic/` (12 files): algorithms/, utilities/, __init__, boolalg, +1 more
+- `sympy/matrices/` (48 files): expressions/, benchmarks/, __init__, common, +19 more
+- `sympy/ntheory/` (15 files): __init__, bbp_pi, continued_fraction, digits, +11 more
+- `sympy/parsing/` (33 files): latex/, autolev/, c/, fortran/, +7 more
+- `sympy/physics/` (113 files): quantum/, mechanics/, units/, vector/, +14 more
+- `sympy/plotting/` (35 files): pygletplot/, backends/, intervalmath/, __init__, +7 more
+- `sympy/polys/` (119 files): domains/, matrices/, numberfields/, series/, +46 more
+- `sympy/printing/` (40 files): pretty/, __init__, aesaracode, c, +33 more
+- `sympy/series/` (18 files): benchmarks/, __init__, acceleration, approximants, +12 more
+- `sympy/sets/` (17 files): handlers/, __init__, conditionset, contains, +5 more
+- `sympy/simplify/` (17 files): __init__, _cse_diff, combsimp, cse_main, +13 more
+- `sympy/solvers/` (24 files): ode/, benchmarks/, diophantine/, __init__, +10 more
+- `sympy/stats/` (21 files): __init__, compound_rv, crv, crv_types, +17 more
+- `sympy/tensor/` (26 files): array/, __init__, functions, index_methods, +3 more
+- `sympy/utilities/` (29 files): _compilation/, mathml/, __init__, autowrap, +17 more
+- `sympy/vector/` (15 files): __init__, basisdependent, coordsysrect, deloperator, +11 more
+- ... and 16 more `sympy/` subpackages
+- `sympy/` top-level modules: __init__, abc, conftest, galgebra, py, release, this
+
+## Entry points
+- no conventional entry-point files detected
+
+## Test layout
+- 732 files total
+- `sympy/`: 716 files
+- `bin/`: 15 files
+- `doc/`: 1 file
+
+## Build and config
+- `pyproject.toml`
+- `setup.py`
+- `requirements-dev.txt`
+- `conftest.py`

--- a/benchmarks/agentic/results/exp7-phaseA/sympy-cbd5424918c3.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/sympy-cbd5424918c3.brief.md
@@ -30,6 +30,16 @@ Task-independent map of 2054 scanned files (.py x1589, .rst x306, .svg x50), 142
 - ... and 16 more `sympy/` subpackages
 - `sympy/` top-level modules: __init__, abc, conftest, galgebra, py, release, this
 
+## Central modules
+- `sympy/core/symbol.py` (imported by 564 modules)
+- `sympy/core/numbers.py` (imported by 509 modules)
+- `sympy/testing/pytest.py` (imported by 432 modules)
+- `sympy/core/singleton.py` (imported by 413 modules)
+- `sympy/core/__init__.py` (imported by 325 modules)
+- `sympy/core/function.py` (imported by 321 modules)
+- `sympy/functions/elementary/miscellaneous.py` (imported by 311 modules)
+- `sympy/functions/elementary/trigonometric.py` (imported by 274 modules)
+
 ## Entry points
 - no conventional entry-point files detected
 
@@ -38,6 +48,7 @@ Task-independent map of 2054 scanned files (.py x1589, .rst x306, .svg x50), 142
 - `sympy/`: 716 files
 - `bin/`: 15 files
 - `doc/`: 1 file
+- 2 files named `conftest.py`
 
 ## Build and config
 - `pyproject.toml`

--- a/benchmarks/agentic/results/exp7-phaseA/sympy-d3f6039f88b2.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/sympy-d3f6039f88b2.brief.md
@@ -1,0 +1,46 @@
+# Repository brief: sympy
+
+Task-independent map of 2063 scanned files (.py x1594, .rst x308, .svg x50), 14321 internal import links. Geography only, no per-change file list.
+
+## Module geography
+- `sympy/assumptions/` (27 files): handlers/, predicates/, relation/, __init__, +9 more
+- `sympy/codegen/` (17 files): __init__, abstract_nodes, algorithms, approximations, +13 more
+- `sympy/combinatorics/` (24 files): __init__, coset_table, fp_groups, free_groups, +20 more
+- `sympy/core/` (44 files): benchmarks/, __init__, _print_helpers, add, +34 more
+- `sympy/functions/` (32 files): special/, elementary/, combinatorial/, __init__
+- `sympy/geometry/` (11 files): __init__, curve, ellipse, entity, +7 more
+- `sympy/integrals/` (20 files): benchmarks/, __init__, deltafunctions, heurisch, +14 more
+- `sympy/liealgebras/` (13 files): __init__, cartan_matrix, cartan_type, dynkin_diagram, +9 more
+- `sympy/logic/` (12 files): algorithms/, utilities/, __init__, boolalg, +1 more
+- `sympy/matrices/` (48 files): expressions/, benchmarks/, __init__, common, +19 more
+- `sympy/ntheory/` (15 files): __init__, bbp_pi, continued_fraction, digits, +11 more
+- `sympy/parsing/` (33 files): latex/, autolev/, c/, fortran/, +7 more
+- `sympy/physics/` (113 files): quantum/, mechanics/, units/, vector/, +14 more
+- `sympy/plotting/` (35 files): pygletplot/, backends/, intervalmath/, __init__, +7 more
+- `sympy/polys/` (122 files): domains/, matrices/, numberfields/, series/, +47 more
+- `sympy/printing/` (40 files): pretty/, __init__, aesaracode, c, +33 more
+- `sympy/series/` (18 files): benchmarks/, __init__, acceleration, approximants, +12 more
+- `sympy/sets/` (17 files): handlers/, __init__, conditionset, contains, +5 more
+- `sympy/simplify/` (17 files): __init__, _cse_diff, combsimp, cse_main, +13 more
+- `sympy/solvers/` (24 files): ode/, benchmarks/, diophantine/, __init__, +10 more
+- `sympy/stats/` (21 files): __init__, compound_rv, crv, crv_types, +17 more
+- `sympy/tensor/` (26 files): array/, __init__, functions, index_methods, +3 more
+- `sympy/utilities/` (29 files): _compilation/, mathml/, __init__, autowrap, +17 more
+- `sympy/vector/` (15 files): __init__, basisdependent, coordsysrect, deloperator, +11 more
+- ... and 16 more `sympy/` subpackages
+- `sympy/` top-level modules: __init__, abc, conftest, galgebra, py, release, this
+
+## Entry points
+- no conventional entry-point files detected
+
+## Test layout
+- 734 files total
+- `sympy/`: 718 files
+- `bin/`: 15 files
+- `doc/`: 1 file
+
+## Build and config
+- `pyproject.toml`
+- `setup.py`
+- `requirements-dev.txt`
+- `conftest.py`

--- a/benchmarks/agentic/results/exp7-phaseA/sympy-d3f6039f88b2.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/sympy-d3f6039f88b2.brief.md
@@ -30,6 +30,16 @@ Task-independent map of 2063 scanned files (.py x1594, .rst x308, .svg x50), 143
 - ... and 16 more `sympy/` subpackages
 - `sympy/` top-level modules: __init__, abc, conftest, galgebra, py, release, this
 
+## Central modules
+- `sympy/core/symbol.py` (imported by 566 modules)
+- `sympy/core/numbers.py` (imported by 509 modules)
+- `sympy/testing/pytest.py` (imported by 434 modules)
+- `sympy/core/singleton.py` (imported by 413 modules)
+- `sympy/core/__init__.py` (imported by 325 modules)
+- `sympy/core/function.py` (imported by 321 modules)
+- `sympy/functions/elementary/miscellaneous.py` (imported by 311 modules)
+- `sympy/functions/elementary/trigonometric.py` (imported by 274 modules)
+
 ## Entry points
 - no conventional entry-point files detected
 
@@ -38,6 +48,7 @@ Task-independent map of 2063 scanned files (.py x1594, .rst x308, .svg x50), 143
 - `sympy/`: 718 files
 - `bin/`: 15 files
 - `doc/`: 1 file
+- 2 files named `conftest.py`
 
 ## Build and config
 - `pyproject.toml`

--- a/benchmarks/agentic/results/exp7-phaseA/sympy-f9a6c6dda7c2.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/sympy-f9a6c6dda7c2.brief.md
@@ -1,0 +1,46 @@
+# Repository brief: sympy
+
+Task-independent map of 2052 scanned files (.py x1590, .rst x305, .svg x50), 14258 internal import links. Geography only, no per-change file list.
+
+## Module geography
+- `sympy/assumptions/` (27 files): handlers/, predicates/, relation/, __init__, +9 more
+- `sympy/codegen/` (17 files): __init__, abstract_nodes, algorithms, approximations, +13 more
+- `sympy/combinatorics/` (24 files): __init__, coset_table, fp_groups, free_groups, +20 more
+- `sympy/core/` (44 files): benchmarks/, __init__, _print_helpers, add, +34 more
+- `sympy/functions/` (32 files): special/, elementary/, combinatorial/, __init__
+- `sympy/geometry/` (11 files): __init__, curve, ellipse, entity, +7 more
+- `sympy/integrals/` (20 files): benchmarks/, __init__, deltafunctions, heurisch, +14 more
+- `sympy/liealgebras/` (13 files): __init__, cartan_matrix, cartan_type, dynkin_diagram, +9 more
+- `sympy/logic/` (12 files): algorithms/, utilities/, __init__, boolalg, +1 more
+- `sympy/matrices/` (48 files): expressions/, benchmarks/, __init__, common, +19 more
+- `sympy/ntheory/` (15 files): __init__, bbp_pi, continued_fraction, digits, +11 more
+- `sympy/parsing/` (33 files): latex/, autolev/, c/, fortran/, +7 more
+- `sympy/physics/` (113 files): quantum/, mechanics/, units/, vector/, +14 more
+- `sympy/plotting/` (35 files): pygletplot/, backends/, intervalmath/, __init__, +7 more
+- `sympy/polys/` (119 files): domains/, matrices/, numberfields/, series/, +46 more
+- `sympy/printing/` (40 files): pretty/, __init__, aesaracode, c, +33 more
+- `sympy/series/` (18 files): benchmarks/, __init__, acceleration, approximants, +12 more
+- `sympy/sets/` (17 files): handlers/, __init__, conditionset, contains, +5 more
+- `sympy/simplify/` (17 files): __init__, _cse_diff, combsimp, cse_main, +13 more
+- `sympy/solvers/` (24 files): ode/, benchmarks/, diophantine/, __init__, +10 more
+- `sympy/stats/` (21 files): __init__, compound_rv, crv, crv_types, +17 more
+- `sympy/tensor/` (26 files): array/, __init__, functions, index_methods, +3 more
+- `sympy/utilities/` (29 files): _compilation/, mathml/, __init__, autowrap, +17 more
+- `sympy/vector/` (15 files): __init__, basisdependent, coordsysrect, deloperator, +11 more
+- ... and 16 more `sympy/` subpackages
+- `sympy/` top-level modules: __init__, abc, conftest, galgebra, py, release, this
+
+## Entry points
+- no conventional entry-point files detected
+
+## Test layout
+- 732 files total
+- `sympy/`: 716 files
+- `bin/`: 15 files
+- `doc/`: 1 file
+
+## Build and config
+- `pyproject.toml`
+- `setup.py`
+- `requirements-dev.txt`
+- `conftest.py`

--- a/benchmarks/agentic/results/exp7-phaseA/sympy-f9a6c6dda7c2.brief.md
+++ b/benchmarks/agentic/results/exp7-phaseA/sympy-f9a6c6dda7c2.brief.md
@@ -30,6 +30,16 @@ Task-independent map of 2052 scanned files (.py x1590, .rst x305, .svg x50), 142
 - ... and 16 more `sympy/` subpackages
 - `sympy/` top-level modules: __init__, abc, conftest, galgebra, py, release, this
 
+## Central modules
+- `sympy/core/symbol.py` (imported by 563 modules)
+- `sympy/core/numbers.py` (imported by 509 modules)
+- `sympy/testing/pytest.py` (imported by 431 modules)
+- `sympy/core/singleton.py` (imported by 413 modules)
+- `sympy/core/__init__.py` (imported by 325 modules)
+- `sympy/core/function.py` (imported by 320 modules)
+- `sympy/functions/elementary/miscellaneous.py` (imported by 311 modules)
+- `sympy/functions/elementary/trigonometric.py` (imported by 274 modules)
+
 ## Entry points
 - no conventional entry-point files detected
 
@@ -38,6 +48,7 @@ Task-independent map of 2052 scanned files (.py x1590, .rst x305, .svg x50), 142
 - `sympy/`: 716 files
 - `bin/`: 15 files
 - `doc/`: 1 file
+- 2 files named `conftest.py`
 
 ## Build and config
 - `pyproject.toml`

--- a/docs/research/exp7-repo-brief.md
+++ b/docs/research/exp7-repo-brief.md
@@ -28,10 +28,13 @@ exploration cost without hurting recall or precision.
 - **Task-independent and deterministic.** It takes no task input and produces no
   per-change file ranking. It is built from scan, role, and import-graph
   aggregates: module geography (subpackages of the dominant package, or top-level
-  directories, one line each with a short child descriptor), production entry
-  points (conventional `__main__.py`/`manage.py`/`cli.py`/`wsgi.py`/... files),
-  test layout (where tests live and how many), and root build and config files.
-  Same tree in, same brief out; a determinism test pins this.
+  directories, one line each with a short child descriptor), central modules (the
+  most-depended-on production files by import-graph incoming degree, a structural
+  property of the repo, not a task ranking), production entry points (conventional
+  `__main__.py`/`manage.py`/`cli.py`/`wsgi.py`/... files at path depth <= 2, so a
+  deeply nested `main.py` is not mistaken for a process entry point), test layout
+  (where tests live, how many, and the `conftest.py` count), and root build and
+  config files. Same tree in, same brief out; a determinism test pins this.
 - **Capped.** The brief is trimmed to a hard token ceiling (default 2000, target
   1-2k) so it is cheap to keep in context; geography is dropped from the tail to
   fit and the result is marked truncated.
@@ -112,22 +115,22 @@ Token counts and determinism, from `benchmarks/agentic/results/exp7-phaseA/index
 
 | repo | base commit | files | brief tokens | packages summarized |
 |---|---|---:|---:|---|
-| django | `36be97b99d4d` | 5635 | 463 | no |
-| django | `21c51c2623a9` | 5653 | 463 | no |
-| django | `56050acb96ab` | 5680 | 463 | no |
-| django | `673fa46d8063` | 5646 | 463 | no |
-| django | `e7f539f813bd` | 5653 | 463 | no |
-| django | `f2169ef36884` | 5638 | 463 | no |
-| sympy | `1e925fca57b6` | 2049 | 647 | yes |
-| sympy | `af838d955f42` | 2053 | 648 | yes |
-| sympy | `cbd5424918c3` | 2054 | 648 | yes |
-| sympy | `d3f6039f88b2` | 2063 | 648 | yes |
-| sympy | `afb25b0d7db1` | 2052 | 648 | yes |
-| sympy | `f9a6c6dda7c2` | 2052 | 648 | yes |
+| django | `36be97b99d4d` | 5635 | 556 | no |
+| django | `21c51c2623a9` | 5653 | 556 | no |
+| django | `56050acb96ab` | 5680 | 556 | no |
+| django | `673fa46d8063` | 5646 | 556 | no |
+| django | `e7f539f813bd` | 5653 | 556 | no |
+| django | `f2169ef36884` | 5638 | 556 | no |
+| sympy | `1e925fca57b6` | 2049 | 775 | yes |
+| sympy | `af838d955f42` | 2053 | 776 | yes |
+| sympy | `cbd5424918c3` | 2054 | 776 | yes |
+| sympy | `d3f6039f88b2` | 2063 | 776 | yes |
+| sympy | `afb25b0d7db1` | 2052 | 776 | yes |
+| sympy | `f9a6c6dda7c2` | 2052 | 776 | yes |
 
 All 12 briefs render byte-identically on a repeat build (the generator asserts
-it). Every brief is far under the 2000-token ceiling: django is 463 tokens across
-all six commits, sympy 647 to 648. The token count is near-constant across a
+it). Every brief is far under the 2000-token ceiling: django is 556 tokens across
+all six commits, sympy 775 to 776. The token count is near-constant across a
 repo's commits, which is the task independence and stability the design intends.
 
 The sympy "packages summarized" column is yes because sympy has more subpackages
@@ -136,9 +139,9 @@ folded into a "... and N more subpackages" line. That is the readability cap on 
 package list, not token-ceiling trimming: no brief here was trimmed to fit the
 token budget. django has fewer than 24 subpackages, so every one is listed.
 
-One known imperfection for review: the django briefs list
-`django/contrib/admin/views/main.py` under entry points because the entry-point
-detector matches the `main.py` basename anywhere in production code. It is a real
-module named `main.py`, not a process entry point. The behaviour is deterministic;
-tightening it (for example, root or package-root mains only) is a follow-up if the
-reviewer wants it.
+The briefs surface each repo's genuine core in the Central modules section (for
+django, `db/__init__.py` imported by 778 modules, `db/models/__init__.py` by 643,
+`core/exceptions.py` by 356; for sympy, its core and utilities packages), and the
+entry-point depth guard keeps out deep `main.py` files (the earlier
+`django/contrib/admin/views/main.py` false positive is gone), so django's only
+entry point is `django/__main__.py`.

--- a/docs/research/exp7-repo-brief.md
+++ b/docs/research/exp7-repo-brief.md
@@ -1,0 +1,144 @@
+# Experiment 7 design: task-independent repository brief
+
+Status: **design and Phase A pre-registered. Phase A (the `redcon brief` command,
+the django and sympy briefs, and this pre-registration) is deterministic and
+free. No agent run (arm BR) until this design is approved and Natalia confirms a
+window.**
+
+## Motivation
+
+Every delivery channel tried so far either failed or is narrow. Pull (the agent
+calls redcon) failed on adoption; push (pre-inject a task-specific pack) failed in
+the loop, and the P-lite variant (inject the ranking list) actively hurt: a
+task-specific ranked file list **anchored** the agent and lowered recall. Adaptive
+rendering (Exp 3) helped only one-shot flows. Tool-result compression (Exp 6)
+closed as a negative ceiling.
+
+The brief tests a different shape of context. Instead of task-specific pointers,
+deliver a small, **task-independent** map of the repository: where modules live,
+the entry points, the test layout, and the build and config conventions. The same
+brief serves every task on the repo, so it cannot anchor a specific change the way
+P-lite's per-task ranking did. The bet is that a cheap, stable orientation lowers
+exploration cost without hurting recall or precision.
+
+## Product artifact
+
+`redcon brief` is a real command, not a bench-only tool.
+
+- **Task-independent and deterministic.** It takes no task input and produces no
+  per-change file ranking. It is built from scan, role, and import-graph
+  aggregates: module geography (subpackages of the dominant package, or top-level
+  directories, one line each with a short child descriptor), production entry
+  points (conventional `__main__.py`/`manage.py`/`cli.py`/`wsgi.py`/... files),
+  test layout (where tests live and how many), and root build and config files.
+  Same tree in, same brief out; a determinism test pins this.
+- **Capped.** The brief is trimmed to a hard token ceiling (default 2000, target
+  1-2k) so it is cheap to keep in context; geography is dropped from the tail to
+  fit and the result is marked truncated.
+- **CI freshness.** `redcon brief --check PATH` regenerates the brief and exits
+  nonzero when `PATH` is stale or missing, so a committed brief can be kept
+  current in CI. `--out PATH` writes it; default prints to stdout; `--json` emits a
+  structured report.
+
+The brief deliberately contains **no ranked file list for any specific change**.
+That is the P-lite trap; geography only.
+
+Implementation: `redcon/brief.py` (`build_brief`), CLI `cmd_brief` in
+`redcon/cli.py`, tests in `tests/test_brief.py`.
+
+## Phase A (this PR): deterministic, no agent spend
+
+1. The command, its determinism/token-cap/task-independence tests, and the
+   `--check` CI mode.
+2. Briefs for django and sympy at the 12 night-2 base commits (6 each), generated
+   through the shipped `build_brief` path by `benchmarks/agentic/gen_exp7_briefs.py`
+   and committed under `benchmarks/agentic/results/exp7-phaseA/`. The generator
+   builds each brief twice and asserts byte-identical output. The clones
+   themselves are not committed; the briefs and generator are.
+3. This pre-registration.
+
+Token counts and determinism for the 12 briefs are in the results table below for
+review of quality, size, and stability across commits.
+
+## Phase B design (pre-registered, not run)
+
+### Arm BR
+
+Arm BR is the night-2 heavy harness, changed in exactly one place: the repository
+brief for the task's base commit is appended to `CLAUDE.md` in the worktree before
+the agent starts. Headless Claude Code reads `CLAUDE.md` but not `AGENTS.md` (the
+1.16 delivery lesson), so the brief actually reaches the model. Everything else is
+held to the night-2 baseline: 12 heavy tasks (django and sympy) x 3 precise
+repeats = **36 runs**, about the night-2 baseline arm cost.
+
+### Baseline
+
+Reuse the night-2 baseline arm (B) if the Claude Code CLI is still 2.1.220 at run
+time. If the CLI has drifted, add **6 fresh B control runs** alongside BR per the
+standing drift rule, so the comparison is against a contemporaneous baseline.
+
+### Hypotheses
+
+- **H1 (cost).** BR cost per run <= baseline. The brief is tiny and re-read
+  cheaply from cache, and a correct orientation should cut exploration turns.
+- **H2 (recall).** BR file recall >= baseline. Task-independent geography must not
+  hurt what the agent finds.
+- **H3 (precision).** BR precision does not collapse. The brief names no task
+  files, so no P-lite-style anchoring is expected.
+
+### Mechanism metrics
+
+Turns, time-to-first-edit, and the redcon-brief token share of total input, to
+show *how* any cost or recall change arises (fewer exploration turns, faster first
+edit) rather than only *that* it does.
+
+### Four-outcome interpretation (pre-registered)
+
+| observation | reading | action |
+|---|---|---|
+| cost down at recall parity, or recall up at cost parity | the brief pays | promote `redcon brief` as a shipped feature with CI freshness (`--check`) |
+| cost up, or recall down | honest null | the feature stays optional, not promoted |
+| precision collapse | the anchoring mechanism reaches even task-independent context | record prominently: geography alone anchors, a strong negative result |
+
+## Gating
+
+Design, briefs, and this pre-registration come to Natalia for review **before any
+run**. Phase B (arm BR) fires only on a confirmed window. No hypotheses or
+interpretations are added after the run.
+
+## Results (Phase A): the 12 briefs
+
+Token counts and determinism, from `benchmarks/agentic/results/exp7-phaseA/index.json`:
+
+| repo | base commit | files | brief tokens | packages summarized |
+|---|---|---:|---:|---|
+| django | `36be97b99d4d` | 5635 | 463 | no |
+| django | `21c51c2623a9` | 5653 | 463 | no |
+| django | `56050acb96ab` | 5680 | 463 | no |
+| django | `673fa46d8063` | 5646 | 463 | no |
+| django | `e7f539f813bd` | 5653 | 463 | no |
+| django | `f2169ef36884` | 5638 | 463 | no |
+| sympy | `1e925fca57b6` | 2049 | 647 | yes |
+| sympy | `af838d955f42` | 2053 | 648 | yes |
+| sympy | `cbd5424918c3` | 2054 | 648 | yes |
+| sympy | `d3f6039f88b2` | 2063 | 648 | yes |
+| sympy | `afb25b0d7db1` | 2052 | 648 | yes |
+| sympy | `f9a6c6dda7c2` | 2052 | 648 | yes |
+
+All 12 briefs render byte-identically on a repeat build (the generator asserts
+it). Every brief is far under the 2000-token ceiling: django is 463 tokens across
+all six commits, sympy 647 to 648. The token count is near-constant across a
+repo's commits, which is the task independence and stability the design intends.
+
+The sympy "packages summarized" column is yes because sympy has more subpackages
+(40) than the geography section lists individually (the 24 largest), with the rest
+folded into a "... and N more subpackages" line. That is the readability cap on the
+package list, not token-ceiling trimming: no brief here was trimmed to fit the
+token budget. django has fewer than 24 subpackages, so every one is listed.
+
+One known imperfection for review: the django briefs list
+`django/contrib/admin/views/main.py` under entry points because the entry-point
+detector matches the `main.py` basename anywhere in production code. It is a real
+module named `main.py`, not a process entry point. The behaviour is deterministic;
+tightening it (for example, root or package-root mains only) is a follow-up if the
+reviewer wants it.

--- a/redcon/brief.py
+++ b/redcon/brief.py
@@ -169,19 +169,25 @@ def _geography_lines(prod_files: list[FileRecord], package: str | None) -> tuple
 
 
 def _entrypoints(files: list[FileRecord]) -> list[str]:
-    # Production entry points only, so example and generated mains do not crowd out
-    # the real ones.
+    # Production entry points only, shallow paths only (depth <= 2). A file named
+    # main.py deep in the tree (e.g. an admin view) is not a process entry point,
+    # so the depth guard keeps that class of false positive out.
     found: list[str] = []
     for record in files:
-        if record.role == "prod" and _posix(record.path).name in _ENTRYPOINT_NAMES:
+        parts = _posix(record.path).parts
+        if record.role == "prod" and len(parts) <= 2 and parts[-1] in _ENTRYPOINT_NAMES:
             found.append(record.path)
     return sorted(set(found))
 
 
 def _test_layout(files: list[FileRecord]) -> list[str]:
+    conftests = sum(1 for f in files if _posix(f.path).name == "conftest.py")
     test_files = [f for f in files if f.role == "test"]
     if not test_files:
-        return ["- no dedicated test files detected"]
+        lines = ["- no dedicated test files detected"]
+        if conftests:
+            lines.append(f"- {_files(conftests)} named `conftest.py`")
+        return lines
     top_dirs: Counter[str] = Counter()
     for record in test_files:
         top_dirs[_top_component(record.path)] += 1
@@ -189,7 +195,21 @@ def _test_layout(files: list[FileRecord]) -> list[str]:
     for top in sorted(top_dirs, key=lambda name: (-top_dirs[name], name))[:6]:
         label = f"`{top}/`" if top and "." not in top else "(repository root)"
         lines.append(f"- {label}: {_files(top_dirs[top])}")
+    lines.append(f"- {_files(conftests)} named `conftest.py`")
     return lines
+
+
+def _central_modules(prod_paths: set[str], graph, limit: int = 8) -> list[tuple[str, int]]:
+    """The most-depended-on production modules: files with the highest import-graph
+    incoming degree. Sorted by degree descending, then path ascending. This is a
+    structural property of the repository, not a task-specific ranking."""
+    ranked = [
+        (path, len(importers))
+        for path, importers in graph.incoming.items()
+        if path in prod_paths and importers
+    ]
+    ranked.sort(key=lambda item: (-item[1], item[0]))
+    return ranked[:limit]
 
 
 def _build_config(files: list[FileRecord]) -> list[str]:
@@ -203,11 +223,16 @@ def _render(
     file_count: int,
     lang_summary: str,
     geography: list[str],
+    central: list[tuple[str, int]],
     entrypoints: list[str],
     test_layout: list[str],
     build_config: list[str],
     import_edges: int,
 ) -> str:
+    central_lines = [
+        f"- `{path}` (imported by {_files(degree).replace('file', 'module')})"
+        for path, degree in central
+    ] or ["- no internal import structure detected"]
     parts = [
         f"# Repository brief: {repo_name}",
         "",
@@ -218,6 +243,9 @@ def _render(
         "",
         "## Module geography",
         *geography,
+        "",
+        "## Central modules",
+        *central_lines,
         "",
         "## Entry points",
         *([f"- `{p}`" for p in entrypoints] or ["- no conventional entry-point files detected"]),
@@ -267,6 +295,7 @@ def build_brief(
     lang_summary = _language_summary(files)
     graph = build_import_graph(files, set(_ENTRYPOINT_NAMES))
     import_edges = sum(len(v) for v in graph.outgoing.values())
+    central = _central_modules({f.path for f in prod_files}, graph)
 
     repo_name = repo_path.resolve().name
 
@@ -276,6 +305,7 @@ def build_brief(
             len(files),
             lang_summary,
             geo,
+            central,
             entrypoints,
             test_layout,
             build_config,

--- a/redcon/brief.py
+++ b/redcon/brief.py
@@ -1,0 +1,299 @@
+# Copyright (c) 2026 Natalia Szczepanik. Licensed under FSL-1.1-MIT (see LICENSE).
+
+"""Deterministic, task-independent repository brief.
+
+A brief is a small map of a repository's shape - module geography, entry points,
+test layout, and build/config conventions - built purely from scan, role, and
+import-graph aggregates. It takes no task input and lists no per-task file
+ranking: the same tree produces the same brief, and one brief serves every task
+on the repo. That task independence is deliberate. Injecting a task-specific
+ranked file list anchored the agent and hurt recall (the P-lite result); a brief
+carries geography only, so it cannot anchor a change.
+
+The output is capped to a small token budget so it is cheap to keep in context.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+from redcon.config import RedconConfig, load_config
+from redcon.core.tokens import estimate_tokens
+from redcon.schemas.models import FileRecord
+from redcon.scorers.import_graph import build_import_graph
+from redcon.stages.workflow import run_scan_stage
+
+# Conventional execution entry-point basenames (not build files, not test infra).
+_ENTRYPOINT_NAMES = (
+    "__main__.py",
+    "main.py",
+    "manage.py",
+    "cli.py",
+    "app.py",
+    "wsgi.py",
+    "asgi.py",
+)
+# Root build and config files, in the order they are reported when present.
+_BUILD_FILES = (
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    "tox.ini",
+    "noxfile.py",
+    "Makefile",
+    "requirements.txt",
+    "requirements-dev.txt",
+    "package.json",
+    "Cargo.toml",
+    "go.mod",
+    ".pre-commit-config.yaml",
+    "conftest.py",
+    "pytest.ini",
+)
+# Cap on how many package lines the geography section lists before summarizing.
+_MAX_GEOGRAPHY_LINES = 24
+# Default token ceiling for the whole brief.
+DEFAULT_MAX_TOKENS = 2000
+
+
+@dataclass(frozen=True)
+class Brief:
+    """A rendered repository brief and its provenance."""
+
+    repo: str
+    text: str
+    tokens: int
+    file_count: int
+    truncated: bool
+
+
+def _posix(path: str) -> PurePosixPath:
+    return PurePosixPath(path.replace("\\", "/"))
+
+
+def _top_component(path: str) -> str:
+    parts = _posix(path).parts
+    return parts[0] if parts else ""
+
+
+def _main_package(prod_files: list[FileRecord]) -> str | None:
+    """The top-level directory holding the most production source, if any.
+
+    Ties break alphabetically so the choice is deterministic.
+    """
+    counts: Counter[str] = Counter()
+    for record in prod_files:
+        top = _top_component(record.path)
+        if top and "." not in top:  # a directory, not a root-level file
+            counts[top] += 1
+    if not counts:
+        return None
+    best = max(sorted(counts), key=lambda name: counts[name])
+    return best
+
+
+def _files(n: int) -> str:
+    return f"{n} file" if n == 1 else f"{n} files"
+
+
+def _package_view(
+    prod_files: list[FileRecord], package: str
+) -> tuple[dict[str, list[tuple[str, ...]]], list[str]]:
+    """Split *package* into subdirectories and direct module files.
+
+    Returns (subdirs, direct_modules): subdirs maps a subdirectory name to the
+    path-parts of the prod files beneath it; direct_modules is the module stems
+    living directly in the package.
+    """
+    subdirs: dict[str, list[tuple[str, ...]]] = defaultdict(list)
+    direct: list[str] = []
+    for record in prod_files:
+        parts = _posix(record.path).parts
+        if len(parts) < 2 or parts[0] != package:
+            continue
+        if len(parts) == 2:
+            direct.append(PurePosixPath(parts[1]).stem)
+        else:
+            subdirs[parts[1]].append(parts)
+    return subdirs, direct
+
+
+def _subdir_descriptor(paths_parts: list[tuple[str, ...]], limit: int = 4) -> str:
+    """Immediate children of a subdirectory: grandchild directories keep a trailing
+    slash, module files show their stem. Most common first, alphabetical in a tie."""
+    counts: Counter[str] = Counter()
+    for parts in paths_parts:
+        # parts == (package, subdir, grandchild, ...)
+        grandchild = parts[2]
+        if len(parts) >= 4:
+            counts[grandchild + "/"] += 1  # grandchild is a directory
+        else:
+            counts[PurePosixPath(grandchild).stem] += 1  # grandchild is a module file
+    names = sorted(counts, key=lambda name: (-counts[name], name))[:limit]
+    extra = len(counts) - len(names)
+    tail = f", +{extra} more" if extra > 0 else ""
+    return ", ".join(names) + tail if names else ""
+
+
+def _geography_lines(prod_files: list[FileRecord], package: str | None) -> tuple[list[str], bool]:
+    lines: list[str] = []
+    truncated = False
+    if package:
+        subdirs, direct = _package_view(prod_files, package)
+        ordered = sorted(subdirs, key=lambda name: (-len(subdirs[name]), name))
+        shown = ordered[:_MAX_GEOGRAPHY_LINES]
+        truncated = len(ordered) > len(shown)
+        for child in sorted(shown):
+            parts_list = subdirs[child]
+            desc = _subdir_descriptor(parts_list)
+            suffix = f": {desc}" if desc else ""
+            lines.append(f"- `{package}/{child}/` ({_files(len(parts_list))}){suffix}")
+        if truncated:
+            lines.append(f"- ... and {len(ordered) - len(shown)} more `{package}/` subpackages")
+        if direct:
+            mods = ", ".join(sorted(set(direct)))
+            lines.append(f"- `{package}/` top-level modules: {mods}")
+    else:
+        # No dominant package: list top-level directories instead.
+        tops: Counter[str] = Counter()
+        for record in prod_files:
+            top = _top_component(record.path)
+            if top and "." not in top:
+                tops[top] += 1
+        ordered = sorted(tops, key=lambda name: (-tops[name], name))[:_MAX_GEOGRAPHY_LINES]
+        for top in sorted(ordered):
+            lines.append(f"- `{top}/` ({_files(tops[top])})")
+    return lines, truncated
+
+
+def _entrypoints(files: list[FileRecord]) -> list[str]:
+    # Production entry points only, so example and generated mains do not crowd out
+    # the real ones.
+    found: list[str] = []
+    for record in files:
+        if record.role == "prod" and _posix(record.path).name in _ENTRYPOINT_NAMES:
+            found.append(record.path)
+    return sorted(set(found))
+
+
+def _test_layout(files: list[FileRecord]) -> list[str]:
+    test_files = [f for f in files if f.role == "test"]
+    if not test_files:
+        return ["- no dedicated test files detected"]
+    top_dirs: Counter[str] = Counter()
+    for record in test_files:
+        top_dirs[_top_component(record.path)] += 1
+    lines = [f"- {_files(len(test_files))} total"]
+    for top in sorted(top_dirs, key=lambda name: (-top_dirs[name], name))[:6]:
+        label = f"`{top}/`" if top and "." not in top else "(repository root)"
+        lines.append(f"- {label}: {_files(top_dirs[top])}")
+    return lines
+
+
+def _build_config(files: list[FileRecord]) -> list[str]:
+    present = {_posix(f.path).name for f in files if len(_posix(f.path).parts) == 1}
+    lines = [f"- `{name}`" for name in _BUILD_FILES if name in present]
+    return lines or ["- no standard build or config files found at the repository root"]
+
+
+def _render(
+    repo_name: str,
+    file_count: int,
+    lang_summary: str,
+    geography: list[str],
+    entrypoints: list[str],
+    test_layout: list[str],
+    build_config: list[str],
+    import_edges: int,
+) -> str:
+    parts = [
+        f"# Repository brief: {repo_name}",
+        "",
+        (
+            f"Task-independent map of {file_count} scanned files ({lang_summary}), "
+            f"{import_edges} internal import links. Geography only, no per-change file list."
+        ),
+        "",
+        "## Module geography",
+        *geography,
+        "",
+        "## Entry points",
+        *([f"- `{p}`" for p in entrypoints] or ["- no conventional entry-point files detected"]),
+        "",
+        "## Test layout",
+        *test_layout,
+        "",
+        "## Build and config",
+        *build_config,
+    ]
+    return "\n".join(parts) + "\n"
+
+
+def _language_summary(files: list[FileRecord], limit: int = 3) -> str:
+    exts: Counter[str] = Counter()
+    for record in files:
+        if record.extension:
+            exts[record.extension] += 1
+    if not exts:
+        return "no recognized source"
+    top = sorted(exts, key=lambda ext: (-exts[ext], ext))[:limit]
+    return ", ".join(f"{ext} x{exts[ext]}" for ext in top)
+
+
+def build_brief(
+    repo: Path | str,
+    config: RedconConfig | None = None,
+    *,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+) -> Brief:
+    """Build a deterministic, task-independent brief for *repo*.
+
+    The same tree and config produce byte-identical output. The brief is trimmed
+    to stay within *max_tokens*; when geography is dropped to fit, the result is
+    marked truncated.
+    """
+    repo_path = Path(repo)
+    cfg = config or load_config(repo_path)
+    files = run_scan_stage(repo_path, cfg)
+
+    prod_files = [f for f in files if f.role == "prod"]
+    package = _main_package(prod_files)
+    geography, geo_truncated = _geography_lines(prod_files, package)
+    entrypoints = _entrypoints(files)
+    test_layout = _test_layout(files)
+    build_config = _build_config(files)
+    lang_summary = _language_summary(files)
+    graph = build_import_graph(files, set(_ENTRYPOINT_NAMES))
+    import_edges = sum(len(v) for v in graph.outgoing.values())
+
+    repo_name = repo_path.resolve().name
+
+    def render(geo: list[str]) -> str:
+        return _render(
+            repo_name,
+            len(files),
+            lang_summary,
+            geo,
+            entrypoints,
+            test_layout,
+            build_config,
+            import_edges,
+        )
+
+    text = render(geography)
+    truncated = geo_truncated
+    # Trim geography from the tail until the brief fits the token ceiling.
+    while estimate_tokens(text) > max_tokens and len(geography) > 1:
+        geography = geography[:-1]
+        truncated = True
+        text = render(geography + [f"- ... geography trimmed to fit {max_tokens} tokens"])
+
+    return Brief(
+        repo=repo_name,
+        text=text,
+        tokens=estimate_tokens(text),
+        file_count=len(files),
+        truncated=truncated,
+    )

--- a/redcon/cli.py
+++ b/redcon/cli.py
@@ -2731,6 +2731,71 @@ def cmd_repo_map(args: argparse.Namespace) -> int:
     return 0
 
 
+_BRIEF_DEFAULT_MAX_TOKENS = 2000
+
+
+def cmd_brief(args: argparse.Namespace) -> int:
+    """Generate a deterministic, task-independent repository brief."""
+    from redcon.brief import build_brief
+
+    try:
+        brief = build_brief(args.repo, max_tokens=max(200, args.max_tokens))
+    except Exception as e:  # noqa: BLE001 - surface any scan/build error as exit 2
+        print(f"Error: brief failed: {e}", file=sys.stderr)
+        return 2
+
+    if args.check is not None:
+        target = Path(args.check)
+        if not target.exists():
+            print(
+                f"redcon brief --check: {target} does not exist; "
+                f"create it with `redcon brief --repo {args.repo} --out {target}`",
+                file=sys.stderr,
+            )
+            return 1
+        if target.read_text(encoding="utf-8") != brief.text:
+            print(
+                f"redcon brief --check: {target} is stale; "
+                f"regenerate with `redcon brief --repo {args.repo} --out {target}`",
+                file=sys.stderr,
+            )
+            return 1
+        if not getattr(args, "quiet", False):
+            print(
+                f"redcon brief --check: {target} is up to date ({brief.tokens} tokens)",
+                file=sys.stderr,
+            )
+        return 0
+
+    if args.json:
+        payload = {
+            "repo": brief.repo,
+            "tokens": brief.tokens,
+            "file_count": brief.file_count,
+            "truncated": brief.truncated,
+            "text": brief.text,
+        }
+        print(_json_mod.dumps(payload, indent=2))
+        return 0
+
+    if args.out:
+        Path(args.out).write_text(brief.text, encoding="utf-8")
+        if not getattr(args, "quiet", False):
+            print(
+                f"redcon brief: wrote {brief.tokens} tokens to {args.out}",
+                file=sys.stderr,
+            )
+    else:
+        if not getattr(args, "quiet", False):
+            trunc = " (truncated)" if brief.truncated else ""
+            print(
+                f"redcon brief: {brief.file_count} files, {brief.tokens} tokens{trunc}",
+                file=sys.stderr,
+            )
+        print(brief.text, end="")
+    return 0
+
+
 def cmd_cmd_quality(args: argparse.Namespace) -> int:
     """Run the M8 quality harness; non-zero exit on any failure (for CI)."""
     from redcon.cmd.quality import run_quality_check
@@ -4150,6 +4215,39 @@ def _register_dev_commands(sub: argparse._SubParsersAction) -> None:
         help="Emit a structured JSON report instead of plain text",
     )
     repo_map_parser.set_defaults(func=cmd_repo_map)
+
+    brief_parser = sub.add_parser(
+        "brief",
+        help=(
+            "Generate a deterministic, task-independent repository brief "
+            "(module geography, entry points, test layout, build conventions)"
+        ),
+    )
+    brief_parser.add_argument(
+        "--repo", default=".", help="Repository path (default: current directory)"
+    )
+    brief_parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=_BRIEF_DEFAULT_MAX_TOKENS,
+        help=f"Token ceiling for the brief (default: {_BRIEF_DEFAULT_MAX_TOKENS})",
+    )
+    brief_parser.add_argument(
+        "--out", default=None, help="Write the brief to this path instead of stdout"
+    )
+    brief_parser.add_argument(
+        "--check",
+        default=None,
+        metavar="PATH",
+        help="Verify the brief at PATH is current; exit nonzero when stale or missing",
+    )
+    brief_parser.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help="Emit a structured JSON report instead of plain text",
+    )
+    brief_parser.set_defaults(func=cmd_brief)
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -38,16 +38,21 @@ _FILES = {
     "myproject/cli.py": "import myproject.core.engine\n",
     "myproject/core/__init__.py": "",
     "myproject/core/engine.py": "def run():\n    return 1\n",
-    "myproject/core/planner.py": "def plan():\n    return 2\n",
+    "myproject/core/planner.py": "import myproject.core.engine\n\n\ndef plan():\n    return 2\n",
     "myproject/db/__init__.py": "",
     "myproject/db/models.py": "class Model:\n    pass\n",
     "myproject/db/backends/sqlite.py": "def connect():\n    return None\n",
+    # A main.py deep in the tree is not a process entry point (depth guard drops it).
+    "myproject/views/admin/main.py": "def changelist():\n    return None\n",
     "tests/test_engine.py": "def test_run():\n    assert True\n",
     "tests/test_models.py": "def test_model():\n    assert True\n",
+    "tests/conftest.py": "import pytest\n",
     "docs/guide.md": "# Guide\n",
     "pyproject.toml": "[project]\nname = 'myproject'\n",
     "Makefile": "test:\n\tpytest\n",
 }
+# Extra subpackages so the geography section is long enough to test trimming.
+_FILES.update({f"myproject/mod{i:02d}/impl.py": "def f():\n    return 1\n" for i in range(15)})
 
 
 def test_brief_is_deterministic(tmp_path: Path):
@@ -62,6 +67,7 @@ def test_brief_has_expected_sections(tmp_path: Path):
     text = build_brief(repo).text
     assert "# Repository brief: myproject" in text
     assert "## Module geography" in text
+    assert "## Central modules" in text
     assert "## Entry points" in text
     assert "## Test layout" in text
     assert "## Build and config" in text
@@ -83,11 +89,38 @@ def test_brief_maps_geography_and_entry_points(tmp_path: Path):
     assert "`Makefile`" in text
 
 
-def test_brief_respects_token_cap(tmp_path: Path):
-    # A tiny ceiling forces geography to be trimmed to fit and marked truncated.
+def test_brief_central_modules_use_import_degree(tmp_path: Path):
+    # engine is imported by cli and planner, so it is the most central module.
     repo = _repo(tmp_path, _FILES)
-    brief = build_brief(repo, max_tokens=120)
-    assert brief.tokens <= 120
+    text = build_brief(repo).text
+    section = text.split("## Central modules", 1)[1].split("##", 1)[0]
+    assert "`myproject/core/engine.py` (imported by 2 modules)" in section
+
+
+def test_brief_entrypoint_depth_guard(tmp_path: Path):
+    # A main.py deep in the tree is not surfaced as an entry point.
+    repo = _repo(tmp_path, _FILES)
+    entry = build_brief(repo).text.split("## Entry points", 1)[1].split("##", 1)[0]
+    assert "myproject/__main__.py" in entry
+    assert "views/admin/main.py" not in entry
+
+
+def test_brief_test_layout_counts_conftest(tmp_path: Path):
+    repo = _repo(tmp_path, _FILES)
+    layout = build_brief(repo).text.split("## Test layout", 1)[1].split("##", 1)[0]
+    assert "1 file named `conftest.py`" in layout
+
+
+def test_brief_respects_token_cap(tmp_path: Path):
+    # A ceiling below the full brief forces geography to be trimmed to fit and
+    # marked truncated. The cap sits above the fixed-section floor so it is
+    # reachable by trimming geography alone.
+    repo = _repo(tmp_path, _FILES)
+    full = build_brief(repo, max_tokens=10000)
+    cap = 250
+    assert cap < full.tokens, "fixture is too small to exercise trimming"
+    brief = build_brief(repo, max_tokens=cap)
+    assert brief.tokens <= cap
     assert brief.truncated
 
 

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -1,0 +1,101 @@
+"""Tests for the task-independent repository brief (`redcon brief`).
+
+The brief is a deterministic map of a repository's shape built from scan, role,
+and import-graph aggregates, with no task input and no per-change file ranking.
+These pin the guarantees the feature depends on: determinism (same tree, same
+brief), the token ceiling, task independence, and that the expected sections and
+geography are present.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from redcon.brief import build_brief
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+
+def _repo(tmp_path: Path, files: dict[str, str]) -> Path:
+    repo = tmp_path / "myproject"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    for rel, content in files.items():
+        path = repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    _git(repo, "add", "-A")
+    _git(repo, "-c", "user.email=t@e", "-c", "user.name=t", "commit", "-qm", "init")
+    return repo
+
+
+_FILES = {
+    "myproject/__init__.py": "",
+    "myproject/__main__.py": "def main():\n    return 0\n",
+    "myproject/cli.py": "import myproject.core.engine\n",
+    "myproject/core/__init__.py": "",
+    "myproject/core/engine.py": "def run():\n    return 1\n",
+    "myproject/core/planner.py": "def plan():\n    return 2\n",
+    "myproject/db/__init__.py": "",
+    "myproject/db/models.py": "class Model:\n    pass\n",
+    "myproject/db/backends/sqlite.py": "def connect():\n    return None\n",
+    "tests/test_engine.py": "def test_run():\n    assert True\n",
+    "tests/test_models.py": "def test_model():\n    assert True\n",
+    "docs/guide.md": "# Guide\n",
+    "pyproject.toml": "[project]\nname = 'myproject'\n",
+    "Makefile": "test:\n\tpytest\n",
+}
+
+
+def test_brief_is_deterministic(tmp_path: Path):
+    repo = _repo(tmp_path, _FILES)
+    first = build_brief(repo).text
+    second = build_brief(repo).text
+    assert first == second
+
+
+def test_brief_has_expected_sections(tmp_path: Path):
+    repo = _repo(tmp_path, _FILES)
+    text = build_brief(repo).text
+    assert "# Repository brief: myproject" in text
+    assert "## Module geography" in text
+    assert "## Entry points" in text
+    assert "## Test layout" in text
+    assert "## Build and config" in text
+
+
+def test_brief_maps_geography_and_entry_points(tmp_path: Path):
+    repo = _repo(tmp_path, _FILES)
+    brief = build_brief(repo)
+    text = brief.text
+    # Subpackages of the dominant package appear as geography, not a ranked list.
+    assert "`myproject/core/`" in text
+    assert "`myproject/db/`" in text
+    # The db descriptor mentions its subdirectory (backends/) and module (models).
+    assert "backends/" in text
+    # Entry points are the conventional production mains.
+    assert "myproject/__main__.py" in text
+    # Build and config surfaces the root files that exist.
+    assert "`pyproject.toml`" in text
+    assert "`Makefile`" in text
+
+
+def test_brief_respects_token_cap(tmp_path: Path):
+    # A tiny ceiling forces geography to be trimmed to fit and marked truncated.
+    repo = _repo(tmp_path, _FILES)
+    brief = build_brief(repo, max_tokens=120)
+    assert brief.tokens <= 120
+    assert brief.truncated
+
+
+def test_brief_names_no_task_or_ground_truth(tmp_path: Path):
+    # Task independence: the brief carries geography only. It must not contain a
+    # per-file ranking header or any task string (there is no task input at all).
+    repo = _repo(tmp_path, _FILES)
+    text = build_brief(repo).text.lower()
+    assert "task" not in text.replace("task-independent", "").replace("no per-change file list", "")
+    assert "score" not in text
+    assert "rank" not in text


### PR DESCRIPTION
Exp 7 Phase A, revised per review. Deterministic, no agent spend. No agent run (arm BR) until the design and regenerated briefs are reviewed and a window is confirmed.

## Review changes applied
a. **Central modules** section: top 8 production files by import-graph incoming degree, sorted (degree desc, path asc), descriptive phrasing. The import graph now informs the brief, not just an edge count. Django surfaces `db/__init__.py` (imported by 778 modules), `db/models/__init__.py` (643), `core/exceptions.py` (356); sympy its core and utilities packages.
b. **Entry-point depth guard** (path depth <= 2): removes the `django/contrib/admin/views/main.py` class of noise. Django's only entry point is now `django/__main__.py`.
c. **conftest.py count** line added to Test layout.

## Regenerated briefs (with the generator)
| repo | tokens (all 6 commits) | files |
|---|---|---|
| django | 556 (constant) | ~5.6k |
| sympy | 775-776 | ~2.0k |

Determinism holds (each built twice, byte-identical); token counts near-constant across a repo's commits; all far under the 2000-token ceiling. Full data in `benchmarks/agentic/results/exp7-phaseA/`.

## Product artifact
`redcon brief`: deterministic, task-independent (geography + central modules + entry points + test layout + build/config; no per-change file ranking), token-capped, `--check` for CI freshness. Implementation `redcon/brief.py` + `cmd_brief`; 8 tests in `tests/test_brief.py` (determinism, sections, central-modules degree, depth guard, conftest count, token cap, task independence).

## Pre-registered Phase B (not run)
Arm BR = base-commit brief appended to CLAUDE.md in the worktree, 12 heavy tasks x 3 precise repeats = 36 runs; baseline reuses night-2 B (or 6 fresh controls on CLI drift); H1 cost / H2 recall / H3 precision; mechanism metrics; four-outcome table. Full design in `docs/research/exp7-repo-brief.md`.

## Notes
- Rebased onto current main (includes the merged gateway fix and 1.18.0 release). Full suite: 1276 passed, 1 skipped, fully green.